### PR TITLE
Compile in win32 using bigobj

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,6 +228,10 @@ else()
   endif()
 endif()
 
+if(WIN32)
+  target_compile_options(sasktran2BuildProperties INTERFACE /bigobj)
+endif()
+
 # -------- END LAPACK FINDING -------
 
 message(STATUS "Lapack Configuration Complete")


### PR DESCRIPTION
Add /bigobj to windows compile, usually only necessary in debug?