### PR TITLE
Update required LAPACK vendor on conda builds

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -52,11 +52,6 @@ requirements:
     - xarray
     - netcdf4
     - scipy
-    - libblas=*=*netlib
-    - libcblas=*=*netlib
-    - liblapack=*=*netlib
-    - liblapacke=*=*netlib
-    - libtmglib=*=*netlib
     - llvm-openmp # [mac]
 
 test:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -52,6 +52,8 @@ requirements:
     - xarray
     - netcdf4
     - scipy
+    - libblas
+    - liblapacke
     - llvm-openmp # [mac]
 
 test:


### PR DESCRIPTION
right now the package seems to be forcing netlib lapack variants, we want to use conda's metapackages instead