### PR TITLE
Add wigner-d function to Python interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,6 +284,7 @@ if(BUILD_PYTHON)
     src/engine.cpp
     src/mie.cpp
     src/output.cpp
+    src/math.cpp
     WITH_SOABI)
 
   target_link_libraries(_core PRIVATE pybind11::headers)

--- a/docs/sphinx/source/api/util.rst
+++ b/docs/sphinx/source/api/util.rst
@@ -7,3 +7,8 @@ Interpolation
 -------------
 
 .. automodule:: sasktran2.util.interpolation
+
+Wigner Functions
+----------------
+
+.. autoclass:: sasktran2.util.WignerD

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@ void init_viewing_geometry(py::module_&);
 void init_output(py::module_&);
 void init_engine(py::module_&);
 void init_mie(py::module_&);
+void init_math(py::module_&);
 
 PYBIND11_MODULE(_core, m) {
     init_config(m);
@@ -23,5 +24,6 @@ PYBIND11_MODULE(_core, m) {
     init_viewing_geometry(m);
     init_output(m);
     init_engine(m);
+    init_math(m);
     init_mie(m);
 }

--- a/src/math.cpp
+++ b/src/math.cpp
@@ -1,0 +1,59 @@
+#include "sasktran2/math/wigner.h"
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/eigen.h>
+#include <sasktran2.h>
+
+namespace py = pybind11;
+using namespace pybind11::literals;
+
+void init_math(py::module_& m) {
+    py::class_<sasktran2::math::WignerDCalculator>(m, "WignerD")
+        .def(py::init<int, int>(), R"(
+            Performs calculations of the Wigner (small) d function, :math:`d^l_{m, n}(\theta)`.
+
+            First, this class is constructed for a given `m` and `n`, and then :py:meth:`d` is called
+            for a given `l`.
+
+            The Wigner functions are closely related to the associated Legendre polynomials,
+            .. math::
+
+                d^l_{m, 0}(\theta) = \sqrt{\frac{(l-m)!}{(l+m)!}} P^m_l(\cos \theta)
+
+            and the regular Legendre polynomials,
+            .. math::
+
+                d^l_{0, 0}(\theta) = P_l(\cos \theta)
+
+            Parameters
+            ----------
+            m: int
+                The parameter `m` in :math:`d^l_{m, n}`
+
+            n: int
+                The parameter `n` in :math:`d^l_{m, n}`
+
+    )",
+             "m"_a, "n"_a)
+        .def("d", py::vectorize(&sasktran2::math::WignerDCalculator::d), R"(
+            Calculates :math:`d^l_{m, n}(\theta)` for a given `l`, and `m`, `n` provided in the constructor.
+            Note that only one of `theta`, `l` can be array-like, one must be scalar.
+
+            Parameters
+            ----------
+            theta: numpy.ndarray[numpy.float64]
+                Angles (in radians) to calculate the function at
+
+            l: numpy.ndarray[numpy.int32]
+                The parameter `n` in :math:`d^l_{m, n}`
+
+            Returns
+            -------
+            np.array
+                The calculated Wigner function, either scalar or the same size as `theta` or `l`, whichever is array-like.
+
+        )",
+             "theta"_a, "l"_a)
+
+        ;
+}

--- a/src/sasktran2/util/__init__.py
+++ b/src/sasktran2/util/__init__.py
@@ -1,3 +1,4 @@
 # ruff: noqa: F401
 
+from .._core import WignerD
 from . import interpolation

--- a/tests/util/test_wigner.py
+++ b/tests/util/test_wigner.py
@@ -1,0 +1,28 @@
+import numpy as np
+import sasktran2 as sk
+from scipy.special import eval_legendre
+
+
+def test_wigner_construction():
+    _ = sk.util.WignerD(0, 0)
+
+
+def test_wigner_vectorization():
+    wd = sk.util.WignerD(0, 0)
+
+    theta = np.arange(0, np.pi, 0.01)
+
+    _ = wd.d(theta, 10)
+
+
+def test_wigner_against_legendre():
+    wig = sk.util.WignerD(0, 0)
+
+    theta = np.arange(0, np.pi, 0.01)
+
+    for legidx in range(20):
+        true = eval_legendre(legidx, np.cos(theta))
+
+        ours = wig.d(theta, legidx)
+
+        np.testing.assert_array_almost_equal(true, ours)


### PR DESCRIPTION
Adds the Wigner D functions to the Python interface, this basically just exposes the c++ WignerDCalculator class