### PR TITLE
HAPI Backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 
 [project.optional-dependencies]
 test = ["pytest"]
+hapi = ["hitran-api"]
 
 [tool.scikit-build]
 wheel.expand-macos-universal-tags = true

--- a/src/sasktran2/database/__init__.py
+++ b/src/sasktran2/database/__init__.py
@@ -1,5 +1,5 @@
 # ruff: noqa: F401
 
-from .hitran import HITRANDatabase
+from .hitran import HITRANDatabase, HITRANLineDatabase
 from .mie import MieDatabase
 from .web import StandardDatabase

--- a/src/sasktran2/database/hitran.py
+++ b/src/sasktran2/database/hitran.py
@@ -209,6 +209,8 @@ class HITRANDatabase(CachedDatabase, OpticalDatabaseGenericAbsorber):
         self._reduction_factor = reduction_factor
         self._molecule = molecule
         self._ltol = 1e-9
+        self._wavenumber_wing = 50
+        self._wavenumber_margin = 10
 
         CachedDatabase.__init__(
             self,
@@ -299,18 +301,14 @@ class HITRANDatabase(CachedDatabase, OpticalDatabaseGenericAbsorber):
 
         hapi.db_begin(str(line_db._db_root))
 
-        # TODO: let user modify these options
-        wavenumber_wing = 50
-        wavenumber_margin = 10
-
         hapi.select(
             self._molecule,
             DestinationTableName="spectral_window",
             Conditions=(
                 "between",
                 "nu",
-                self._start_wavenumber - wavenumber_margin,
-                self._end_wavenumber + wavenumber_margin,
+                self._start_wavenumber - self._wavenumber_margin,
+                self._end_wavenumber + self._wavenumber_margin,
             ),
         )
 
@@ -327,7 +325,7 @@ class HITRANDatabase(CachedDatabase, OpticalDatabaseGenericAbsorber):
                     SourceTables="spectral_window",
                     Environment={"T": temp, "p": pres / 101325.0},
                     WavenumberGrid=hires_wavenumber_grid.tolist(),
-                    WavenumberWing=wavenumber_wing,
+                    WavenumberWing=self._wavenumber_wing,
                 )
                 xs[idx, idy] = xs_hapi / 1e4
 

--- a/src/sasktran2/database/hitran.py
+++ b/src/sasktran2/database/hitran.py
@@ -394,7 +394,7 @@ class HITRANDatabase(CachedDatabase, OpticalDatabaseGenericAbsorber):
                 xs[idx, idy] = xs_hapi / 1e4
 
         ds = xr.Dataset(
-            {"xs": (["pressure", "temperature", "wavelength_nm"], xs)},
+            {"xs": (["pressure", "temperature", "wavenumber_cminv"], xs)},
             coords={
                 "pressure": PRESSURE_GRID,
                 "temperature": TEMP_GRID,

--- a/src/sasktran2/database/hitran.py
+++ b/src/sasktran2/database/hitran.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import numpy as np
 import xarray as xr
 
+from sasktran2 import appconfig
 from sasktran2.optical.database import OpticalDatabaseGenericAbsorber
 from sasktran2.units import wavenumber_cminv_to_wavlength_nm
 
@@ -116,6 +117,47 @@ PRESSURE_GRID = (
 TEMP_GRID = np.arange(190, 311, 10)
 
 
+class HITRANLineDatabase:
+    def __init__(self):
+        CachedDatabase.__init__(
+            self, appconfig.database_root().joinpath("hitran_lines")
+        )
+
+    def path(self, key: str, **kwargs) -> Path:
+        data_file = self._db_root.joinpath(f"{key}.data")
+        header_file = self._db_root.joinpath(f"{key}.header")
+        if not (data_file.exists() and header_file.exists()):
+            # download lines for this molecule
+            self._download_line_db(key)
+
+    def load_ds(self, key: str, **kwargs) -> xr.Dataset:
+        raise NotImplementedError
+
+    def clear(self):
+        raise NotImplementedError
+
+    def _download_line_db(self, molecule):
+        try:
+            import hapi
+        except ImportError as err:
+            msg = "HITRAN API is required to use HAPI, try pip install hitran-api"
+            raise ImportError(msg) from err
+
+        hapi.db_begin(str(self._db_root))
+
+        # Get global isotopologue ids for this molecule
+        mol_index = hapi.ISO_ID_INDEX["mol_name"]
+        iso_ids = []
+        for id in hapi.ISO_ID:
+            if hapi.ISO_ID[id][mol_index] == molecule:
+                iso_ids.append(id)
+
+        # Download files
+        hapi.fetch_by_ids(molecule, iso_ids, 0.0, 1.0e6)
+
+        return
+
+
 class HITRANDatabase(CachedDatabase, OpticalDatabaseGenericAbsorber):
     def __init__(
         self,
@@ -136,7 +178,7 @@ class HITRANDatabase(CachedDatabase, OpticalDatabaseGenericAbsorber):
             The root directory to store the database, by default None
         backend : str, optional
             The backend to use, by default "sasktran_legacy" which requires the module `sasktran` to be installed. Currently supported
-            options are ["sasktran_legacy"]. Default is "sasktran_legacy"
+            options are ["sasktran_legacy", "hapi"]. Default is "sasktran_legacy"
         kwargs
             Additional arguments to pass to the particle size distribution, these should match the psize_distribution.args() method
         """
@@ -169,7 +211,9 @@ class HITRANDatabase(CachedDatabase, OpticalDatabaseGenericAbsorber):
         self._ltol = 1e-9
 
         CachedDatabase.__init__(
-            self, db_root=db_root, rel_path=Path("hitran").joinpath(self._molecule)
+            self,
+            db_root=db_root,
+            rel_path=Path("hitran").joinpath(self._molecule, self._backend),
         )
 
         self._data_file = self._db_root.joinpath(f"{identifier}.nc")
@@ -179,6 +223,8 @@ class HITRANDatabase(CachedDatabase, OpticalDatabaseGenericAbsorber):
     def generate(self):
         if self._backend == "sasktran_legacy":
             self._generate_sasktran_legacy()
+        elif self._backend == "hapi":
+            self._generate_hapi()
         else:
             msg = f"Invalid backend {self._backend}"
             raise ValueError(msg)
@@ -229,6 +275,61 @@ class HITRANDatabase(CachedDatabase, OpticalDatabaseGenericAbsorber):
                     .total
                     / 1e4
                 )
+
+        ds = xr.Dataset(
+            {"xs": (["pressure", "temperature", "wavelength_nm"], xs)},
+            coords={
+                "pressure": PRESSURE_GRID,
+                "temperature": TEMP_GRID,
+                "wavenumber_cminv": hires_wavenumber_grid,
+            },
+        )
+
+        ds.to_netcdf(self._data_file)
+
+    def _generate_hapi(self):
+        line_db = HITRANLineDatabase()
+        line_db.path(self._molecule)
+
+        try:
+            import hapi
+        except ImportError as err:
+            msg = "HITRAN API is required to use HAPI, try pip install hitran-api"
+            raise ImportError(msg) from err
+
+        hapi.db_begin(str(line_db._db_root))
+
+        # TODO: let user modify these options
+        wavenumber_wing = 50
+        wavenumber_margin = 10
+
+        hapi.select(
+            self._molecule,
+            DestinationTableName="spectral_window",
+            Conditions=(
+                "between",
+                "nu",
+                self._start_wavenumber - wavenumber_margin,
+                self._end_wavenumber + wavenumber_margin,
+            ),
+        )
+
+        hires_wavenumber_grid = np.arange(
+            self._start_wavenumber, self._end_wavenumber, self._wavenumber_resolution
+        )
+
+        xs = np.zeros((len(PRESSURE_GRID), len(TEMP_GRID), len(hires_wavenumber_grid)))
+
+        for idx, pres in enumerate(PRESSURE_GRID):
+            for idy, temp in enumerate(TEMP_GRID):
+                # TODO: add option to use other broadening functions
+                _, xs_hapi = hapi.absorptionCoefficient_Voigt(
+                    SourceTables="spectral_window",
+                    Environment={"T": temp, "p": pres / 101325.0},
+                    WavenumberGrid=hires_wavenumber_grid.tolist(),
+                    WavenumberWing=wavenumber_wing,
+                )
+                xs[idx, idy] = xs_hapi / 1e4
 
         ds = xr.Dataset(
             {"xs": (["pressure", "temperature", "wavelength_nm"], xs)},


### PR DESCRIPTION
Adds the HITRAN API (HAPI) as a backend for HITRAN cross section calculation. This requires the `hitran-api` python package which is added as an optional dependency. HITRAN line files are downloaded for each molecule as needed and saved in a folder called `hitran_lines` in the root database folder.