### PR TITLE
Remove nightly wheel upload, not used

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -257,39 +257,3 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs
-
-  upload-nightly-wheels:
-    needs: build_wheels_cibuildwheel
-    runs-on: ubuntu-latest
-
-    if: (github.event_name != 'release')
-
-    environment:
-      name: conda-nightly-wheels
-      url: https://anaconda.org/usask-arg-nightly/sasktran2
-
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          submodules: true
-
-      - name: Setup Conda build environment
-        uses: mamba-org/setup-micromamba@v1
-        with:
-          environment-file: ci/conda-envs/mamba-build.yml
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: artifact
-          path: dist
-
-      - name: Upload Wheels
-        shell: bash -el {0}
-        run: |
-          anaconda --token ${{ secrets.TOKEN }} upload \
-          --force \
-          --user "usask-arg-nightly" \
-          dist/*.whl


### PR DESCRIPTION
This deletes the nightly wheel CI step, it doesn't seem useful when we have nightly conda packages anyway