### PR TITLE
[codex] Add Zenodo O3 cross sections

### DIFF
--- a/docs/sphinx/source/api/optical.md
+++ b/docs/sphinx/source/api/optical.md
@@ -9,6 +9,8 @@
     :toctree: generated/
 
     sasktran2.optical.O3DBM
+    sasktran2.optical.O3BirkWagner
+    sasktran2.optical.O3Serdyuchenko
     sasktran2.optical.NO2Vandaele
     sasktran2.optical.HITRANUV
     sasktran2.optical.HITRANAbsorber

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,9 @@ classifiers = [
 test = ["pytest"]
 solar = ["astropy>=7"]
 hapi = ["hitran-api"]
+zenodo = ["zenodo-get"]
 dev = ["ruff", "sphinx", "sphinx_book_theme", "myst-nb", "sphinx_design", "sphinx-github-changelog", "sphinxcontrib-bibtex"]
-complete = ["sasktran2[solar,hapi]"]
+complete = ["sasktran2[solar,hapi,zenodo]"]
 
 [tool.pixi.project]
 channels = ["conda-forge"]

--- a/src/sasktran2/database/o3.py
+++ b/src/sasktran2/database/o3.py
@@ -1,0 +1,224 @@
+"""Local builders for Zenodo-hosted ozone absorption cross-section databases.
+
+The public optical properties in :mod:`sasktran2.optical` expect the same compact
+NetCDF layout used by the built-in DBM database: an ``xs`` variable in
+``m^2/molecule`` with ``temperature_k`` and ``wavelength_nm`` coordinates.  The
+Zenodo sources are not distributed in that layout, so these classes are small
+cache managers that download the original files once and convert them into the
+standard SASKTRAN2 absorber database format.
+"""
+
+from __future__ import annotations
+
+import re
+import zipfile
+from pathlib import Path
+
+import numpy as np
+import xarray as xr
+
+from .base import CachedDatabase
+from .zenodo import download_zenodo_record
+
+
+class _ZenodoO3Database(CachedDatabase):
+    """Base class for one-file Zenodo O3 datasets with a derived NetCDF cache.
+
+    ``_raw_filename`` is kept next to ``_processed_filename`` under the user's
+    configured database root.  On first use we download the Zenodo record, locate
+    the expected raw file, and then write the converted NetCDF file.  Later calls
+    only open the converted cache.
+    """
+
+    _record_id: str
+    _raw_filename: str
+    _processed_filename: str
+
+    def __init__(
+        self,
+        db_root: Path | None = None,
+        rel_path: Path | None = Path("cross_sections/o3"),
+    ) -> None:
+        super().__init__(db_root, rel_path=rel_path)
+
+    def path(self, _key: str = "", **kwargs) -> Path:
+        output_file = self._db_root.joinpath(self._processed_filename)
+        if not output_file.exists():
+            raw_file = self._raw_file()
+            self._convert(raw_file, output_file)
+
+        return output_file
+
+    def load_ds(self, key: str = "", **kwargs) -> xr.Dataset:
+        return xr.open_dataset(self.path(key, **kwargs))
+
+    def clear(self):
+        for filename in (self._processed_filename, self._raw_filename):
+            path = self._db_root.joinpath(filename)
+            if path.exists():
+                path.unlink()
+
+    def _raw_file(self) -> Path:
+        raw_file = self._db_root.joinpath(self._raw_filename)
+        if raw_file.exists():
+            return raw_file
+
+        download_zenodo_record(self._record_id, self._db_root)
+
+        if raw_file.exists():
+            return raw_file
+
+        matches = list(self._db_root.rglob(self._raw_filename))
+        if matches:
+            return matches[0]
+
+        msg = (
+            f"Could not find {self._raw_filename} after downloading Zenodo "
+            f"record {self._record_id}"
+        )
+        raise OSError(msg)
+
+    def _convert(self, raw_file: Path, output_file: Path) -> None:
+        raise NotImplementedError
+
+
+class O3BirkWagnerDatabase(_ZenodoO3Database):
+    """
+    Cached Birk and Wagner O3 absorption cross-section database.
+
+    The source archive contains one ASCII table for each measured temperature.
+    Each table has wavelength, absorption cross section, and uncertainty columns.
+    Only the measured cross sections are stored in the SASKTRAN2 cache; the raw
+    uncertainty columns and polynomial coefficient file remain available in the
+    downloaded Zenodo archive if users need them for their own analysis. The
+    wavelength grid is preserved as a vacuum wavelength grid; applying an
+    air-to-vacuum conversion shifts the Huggins-band structure out of alignment
+    with the independently vacuum-labelled Serdyuchenko dataset.
+    """
+
+    _record_id = "1485588"
+    _raw_filename = "O3_UV_region_absorption_cross_section_database_13112018.zip"
+    _processed_filename = "birk_wagner.nc"
+
+    def _convert(self, raw_file: Path, output_file: Path) -> None:
+        # The measured ACS files are named O3_ACS_193K.asc, O3_ACS_213K.asc,
+        # etc.  The archive also contains a polynomial-coefficient file, which
+        # is intentionally ignored here so the optical property matches the
+        # discrete measured-temperature database style used by O3DBM.
+        #
+        # No air-to-vacuum conversion is applied to the wavelength column. In the
+        # 315-345 nm overlap region, the measured structures align with the
+        # Serdyuchenko vacuum wavelength grid as-is and become visibly shifted if
+        # the Birk/Wagner grid is treated as air wavelengths.
+        temperature_re = re.compile(r"O3_ACS_(\d+)K\.asc$")
+        temperatures = []
+        cross_sections = []
+        wavelength_nm = None
+
+        with zipfile.ZipFile(raw_file) as zf:
+            source_files = [
+                name
+                for name in zf.namelist()
+                if temperature_re.search(Path(name).name) is not None
+            ]
+
+            if not source_files:
+                msg = f"No Birk/Wagner O3_ACS temperature files found in {raw_file}"
+                raise OSError(msg)
+
+            for source_file in source_files:
+                match = temperature_re.search(Path(source_file).name)
+                temperatures.append(float(match.group(1)))
+
+                with zf.open(source_file) as f:
+                    data = np.loadtxt(f, skiprows=2)
+
+                if wavelength_nm is None:
+                    wavelength_nm = data[:, 0]
+                elif not np.allclose(wavelength_nm, data[:, 0], rtol=0, atol=1e-8):
+                    msg = "Birk/Wagner O3 files do not share a common wavelength grid"
+                    raise ValueError(msg)
+
+                cross_sections.append(data[:, 1])
+
+        sort_idx = np.argsort(temperatures)
+        temperature_k = np.asarray(temperatures, dtype=float)[sort_idx]
+        xs = np.asarray(cross_sections, dtype=float)[sort_idx] / 1e4
+
+        ds = xr.Dataset(
+            {
+                "xs": (
+                    ["temperature_k", "wavelength_nm"],
+                    xs,
+                    {"units": "m^2 molecule^-1"},
+                )
+            },
+            coords={
+                "temperature_k": temperature_k,
+                "wavelength_nm": wavelength_nm.astype(float),
+            },
+            attrs={
+                "source": "Birk and Wagner O3 UV absorption cross sections",
+                "doi": "10.5281/zenodo.1485588",
+            },
+        )
+
+        ds.to_netcdf(output_file)
+
+
+class O3SerdyuchenkoDatabase(_ZenodoO3Database):
+    """
+    Cached Serdyuchenko-Gorshelev O3 absorption cross-section database.
+
+    The source file is a single wide ASCII table. Column 1 is vacuum wavelength
+    in nm, followed by cross sections for temperatures from 293 K down to 193 K.
+    The converted cache sorts those temperatures into ascending order so the
+    generic absorber database can interpolate consistently.
+    """
+
+    _record_id = "5793207"
+    _raw_filename = "SerdyuchenkoGorshelev5digits_latest.dat"
+    _processed_filename = "serdyuchenko.nc"
+
+    def _convert(self, raw_file: Path, output_file: Path) -> None:
+        # The file header states "NUMBER OF HEADER LINES: 45".  np.loadtxt then
+        # reads a rectangular array with wavelength in column 0 and temperature
+        # cross sections in columns 1:.
+        data = np.loadtxt(raw_file, skiprows=45)
+
+        temperature_k = np.array(
+            [
+                293.0,
+                283.0,
+                273.0,
+                263.0,
+                253.0,
+                243.0,
+                233.0,
+                223.0,
+                213.0,
+                203.0,
+                193.0,
+            ]
+        )
+        sort_idx = np.argsort(temperature_k)
+
+        ds = xr.Dataset(
+            {
+                "xs": (
+                    ["temperature_k", "wavelength_nm"],
+                    data[:, 1:].T[sort_idx] / 1e4,
+                    {"units": "m^2 molecule^-1"},
+                )
+            },
+            coords={
+                "temperature_k": temperature_k[sort_idx],
+                "wavelength_nm": data[:, 0].astype(float),
+            },
+            attrs={
+                "source": "Serdyuchenko-Gorshelev O3 UV/VIS/NIR absorption cross sections",
+                "doi": "10.5281/zenodo.5793207",
+            },
+        )
+
+        ds.to_netcdf(output_file)

--- a/src/sasktran2/database/zenodo.py
+++ b/src/sasktran2/database/zenodo.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import importlib
+import shlex
+from pathlib import Path
+
+
+def download_zenodo_record(record_id: str, output_dir: Path) -> None:
+    """
+    Download a Zenodo record into a local directory using zenodo-get.
+
+    zenodo-get changed its public API between major versions. This helper supports
+    both the old ``zenodo_get(argv)`` entry point and the newer ``download`` helper.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        zenodo_get = importlib.import_module("zenodo_get")
+    except ImportError as e:
+        msg = (
+            "zenodo_get is required to download this database from Zenodo. "
+            "Install the optional dependency with `pip install sasktran2[zenodo]` "
+            "or install `zenodo-get` directly."
+        )
+        raise ImportError(msg) from e
+
+    if hasattr(zenodo_get, "download"):
+        zenodo_get.download(str(record_id), output_dir=output_dir.as_posix())
+    elif hasattr(zenodo_get, "zenodo_get"):
+        zenodo_get.zenodo_get(
+            shlex.split(f'--record {record_id} -o "{output_dir.as_posix()}"')
+        )
+    else:
+        msg = "Installed zenodo_get package does not expose a supported download API"
+        raise ImportError(msg)

--- a/src/sasktran2/optical/__init__.py
+++ b/src/sasktran2/optical/__init__.py
@@ -4,6 +4,7 @@ import numpy as np
 
 import sasktran2 as sk
 from sasktran2.constants import K_BOLTZMANN
+from sasktran2.database.o3 import O3BirkWagnerDatabase, O3SerdyuchenkoDatabase
 from sasktran2.database.web import StandardDatabase
 
 from . import database, refraction  # noqa: F401
@@ -95,6 +96,118 @@ class O3DBM(database.OpticalDatabaseGenericAbsorber):
         else:
             msg = "Could not find DBM file"
             raise OSError(msg)
+
+
+class O3BirkWagner(database.OpticalDatabaseGenericAbsorber):
+    def __init__(self) -> None:
+        """
+        Tabulated high resolution UV cross-sections of O3 measured by Birk and Wagner.
+
+        This database is useful for UV ozone absorption calculations in the
+        Hartley/Huggins region. The raw Zenodo archive contains measured
+        absorption cross sections and uncertainties for six temperatures:
+
+            | 193 K
+            | 213 K
+            | 233 K
+            | 253 K
+            | 273 K
+            | 293 K
+
+        The wavelength grid is common to all six tables and spans approximately
+        243.9 nm to 346.0 nm. The wavelength grid is used directly as a vacuum
+        wavelength grid; an overlap comparison with the independently
+        vacuum-labelled Serdyuchenko dataset shows the Huggins-band structure is
+        aligned as-is and shifted if an air-to-vacuum conversion is applied.
+        Cross sections are provided by the source files in cm^2/molecule and
+        converted internally to m^2/molecule.
+
+        Data Source
+            The data are from the ESA SEOM-IAS ozone UV absorption cross-section
+            database created by M. Birk and G. Wagner at DLR for improved
+            atmospheric spectroscopy in support of Sentinel-5P/TROPOMI. The
+            source archive also contains uncertainty columns and polynomial
+            coefficients; this class uses the measured tabulated cross sections.
+
+        The source files are downloaded from Zenodo record 1485588 when the local
+        NetCDF cache is missing. Downloading requires the optional ``zenodo-get``
+        package, available through the ``sasktran2[zenodo]`` extra.
+
+        References
+        ----------
+        Birk, M. and Wagner, G. "ESA SEOM-IAS - Measurement and ACS database
+        O3 UV region." Zenodo, 2018. doi:10.5281/zenodo.1485588.
+
+        Raises
+        ------
+        ImportError
+            If the data must be downloaded and zenodo-get is not installed
+        OSError
+            If the data could not be downloaded or converted
+        """
+        super().__init__(O3BirkWagnerDatabase().path())
+
+
+class O3Serdyuchenko(database.OpticalDatabaseGenericAbsorber):
+    def __init__(self) -> None:
+        """
+        Tabulated UV/VIS/NIR cross-sections of O3 measured by Serdyuchenko et al.
+
+        This database covers a broader spectral range than O3DBM or
+        O3BirkWagner, extending from 213.33 nm to 1100.00 nm on a 0.01 nm
+        wavelength grid. Cross sections are available at 11 temperatures:
+
+            | 193 K
+            | 203 K
+            | 213 K
+            | 223 K
+            | 233 K
+            | 243 K
+            | 253 K
+            | 263 K
+            | 273 K
+            | 283 K
+            | 293 K
+
+        The measurements combine a Bruker HR 120 Fourier transform spectrometer
+        and an ESA 400 Echelle spectrometer. Cross sections are provided by the
+        source file in cm^2/molecule and converted internally to m^2/molecule.
+
+        Data Source
+            The source file is the Serdyuchenko-Gorshelev UV/VIS/NIR ozone
+            absorption cross-section dataset. The original file stores
+            temperatures in descending order from 293 K to 193 K; SASKTRAN2
+            sorts them into ascending order before interpolation.
+
+        The source file is downloaded from Zenodo record 5793207 when the local
+        NetCDF cache is missing. Downloading requires the optional ``zenodo-get``
+        package, available through the ``sasktran2[zenodo]`` extra.
+
+        References
+        ----------
+        Gorshelev, V., Serdyuchenko, A., Weber, M., Chehade, W., and Burrows,
+        J. P. "High spectral resolution ozone absorption cross-sections -
+        Part 1: Measurements, data analysis and comparison with previous
+        measurements around 293 K." Atmospheric Measurement Techniques 7,
+        609-624, 2014. doi:10.5194/amt-7-609-2014.
+
+        Serdyuchenko, A., Gorshelev, V., Weber, M., Chehade, W., and Burrows,
+        J. P. "High spectral resolution ozone absorption cross-sections -
+        Part 2: Temperature dependence." Atmospheric Measurement Techniques 7,
+        625-636, 2014. doi:10.5194/amt-7-625-2014.
+
+        Serdyuchenko, A., Gorshelev, V., Weber, M., and Burrows, J. P.
+        "Serdyuchenko-Gorshelev UV/VIS/NIR ozone absorption cross-section."
+        Zenodo, 2021. doi:10.5281/zenodo.5793207.
+
+        Raises
+        ------
+        ImportError
+            If the data must be downloaded and zenodo-get is not installed
+        OSError
+            If the data could not be downloaded or converted
+        """
+        super().__init__(O3SerdyuchenkoDatabase().path())
 
 
 class NO2Vandaele(database.OpticalDatabaseGenericAbsorber):

--- a/tests/optical/test_o3_zenodo.py
+++ b/tests/optical/test_o3_zenodo.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import importlib
+import zipfile
+
+import numpy as np
+import pytest
+import sasktran2 as sk
+import xarray as xr
+from sasktran2.database.o3 import O3BirkWagnerDatabase, O3SerdyuchenkoDatabase
+from sasktran2.database.zenodo import download_zenodo_record
+
+
+def test_o3_zenodo_optical_properties_are_exported():
+    assert sk.optical.O3BirkWagner is not None
+    assert sk.optical.O3Serdyuchenko is not None
+
+
+def test_birk_wagner_database_conversion(tmp_path):
+    raw_file = tmp_path.joinpath(
+        "O3_UV_region_absorption_cross_section_database_13112018.zip"
+    )
+
+    with zipfile.ZipFile(raw_file, "w") as zf:
+        for temperature, scale in [(193, 1.0), (293, 2.0)]:
+            zf.writestr(
+                f"ACS/O3_ACS_{temperature}K.asc",
+                "\n".join(
+                    [
+                        f"O3_ACS_{temperature}K.asc",
+                        "wavelength[nm] absorption cross section[cm^2/molecule] uncertainty[cm^2/molecule]",
+                        f"300.0 {scale * 1e-18:.6e} 1e-20",
+                        f"301.0 {scale * 2e-18:.6e} 1e-20",
+                    ]
+                ),
+            )
+
+    db = O3BirkWagnerDatabase(db_root=tmp_path, rel_path=None)
+    output_file = db.path()
+
+    with xr.open_dataset(output_file) as ds:
+        np.testing.assert_allclose(ds["temperature_k"], [193.0, 293.0])
+        np.testing.assert_allclose(ds["wavelength_nm"], [300.0, 301.0])
+        np.testing.assert_allclose(
+            ds["xs"].to_numpy(),
+            [[1e-22, 2e-22], [2e-22, 4e-22]],
+        )
+
+
+def test_serdyuchenko_database_conversion(tmp_path):
+    raw_file = tmp_path.joinpath("SerdyuchenkoGorshelev5digits_latest.dat")
+    header = ["header"] * 45
+    row_0 = "213.33 " + " ".join(f"{value:.1e}" for value in range(1, 12))
+    row_1 = "213.34 " + " ".join(f"{value:.1e}" for value in range(2, 13))
+    raw_file.write_text("\n".join([*header, row_0, row_1]))
+
+    db = O3SerdyuchenkoDatabase(db_root=tmp_path, rel_path=None)
+    output_file = db.path()
+
+    with xr.open_dataset(output_file) as ds:
+        np.testing.assert_allclose(
+            ds["temperature_k"],
+            [
+                193.0,
+                203.0,
+                213.0,
+                223.0,
+                233.0,
+                243.0,
+                253.0,
+                263.0,
+                273.0,
+                283.0,
+                293.0,
+            ],
+        )
+        np.testing.assert_allclose(ds["wavelength_nm"], [213.33, 213.34])
+        np.testing.assert_allclose(ds["xs"].isel(temperature_k=0), [11e-4, 12e-4])
+        np.testing.assert_allclose(ds["xs"].isel(temperature_k=-1), [1e-4, 2e-4])
+
+
+def test_download_zenodo_record_missing_dependency(monkeypatch, tmp_path):
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name, package=None):
+        if name == "zenodo_get":
+            msg = "missing test dependency"
+            raise ImportError(msg)
+        return real_import_module(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    with pytest.raises(ImportError, match="zenodo_get is required"):
+        download_zenodo_record("5793207", tmp_path)


### PR DESCRIPTION
## Summary

Adds two new ozone absorption cross-section optical properties:

- `sk.optical.O3BirkWagner()` for the Birk/Wagner ESA SEOM-IAS UV dataset from Zenodo record 1485588.
- `sk.optical.O3Serdyuchenko()` for the Serdyuchenko-Gorshelev UV/VIS/NIR dataset from Zenodo record 5793207.

The new database helpers download the original Zenodo files with optional `zenodo-get`, convert them into the existing SASKTRAN2 absorber NetCDF layout, and cache the processed files under `cross_sections/o3`. The public docs include spectral ranges, temperature grids, source information, and the Birk/Wagner vacuum-grid overlap check against Serdyuchenko.

## User impact

Users can now select either dataset through the same `OpticalDatabaseGenericAbsorber` path as `O3DBM`. If a dataset is not cached and `zenodo-get` is missing, the error explains how to install the optional `sasktran2[zenodo]` extra.

## Validation

- `pixi run pre-commit`
- `pixi run python -m pytest tests/optical/test_o3.py tests/optical/test_o3_zenodo.py`
- `pixi run docs`
- Compared Birk/Wagner against Serdyuchenko in the 315-345 nm overlap. Treating the Birk/Wagner source grid as vacuum gives much lower normalized RMSE than applying an air-to-vacuum conversion.