### PR TITLE
Expose LOS refraction deflection angle

### DIFF
--- a/cpp/c_api/output.cpp
+++ b/cpp/c_api/output.cpp
@@ -195,4 +195,25 @@ int sk_output_get_los_optical_depth(OutputC* output, double** od) {
         return -1;
     }
 }
+
+int sk_output_get_los_refraction_deflection_angle(OutputC* output,
+                                                  double** angle) {
+    if (output->impl == nullptr) {
+        return -1; // Error: Output not initialized
+    }
+
+    auto* impl1 = dynamic_cast<sasktran2::OutputC<1>*>(output->impl.get());
+    auto* impl3 = dynamic_cast<sasktran2::OutputC<3>*>(output->impl.get());
+
+    if (impl1) {
+        *angle = impl1->los_refraction_deflection_angle().data();
+        return 0;
+    } else if (impl3) {
+        *angle = impl3->los_refraction_deflection_angle().data();
+        return 0;
+    } else {
+        // Handle error case
+        return -1;
+    }
+}
 }

--- a/cpp/include/c_api/output.h
+++ b/cpp/include/c_api/output.h
@@ -30,6 +30,9 @@ int sk_output_assign_surface_flux_derivative_memory(OutputC* output,
 
 int sk_output_get_los_optical_depth(OutputC* output, double** od);
 
+int sk_output_get_los_refraction_deflection_angle(OutputC* output,
+                                                  double** angle);
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpp/include/sasktran2/output.h
+++ b/cpp/include/sasktran2/output.h
@@ -48,6 +48,7 @@ namespace sasktran2 {
 
         // Diagnostic qunatities
         Eigen::MatrixXd m_los_optical_depth;
+        Eigen::VectorXd m_los_refraction_deflection_angle;
 
         const sasktran2::atmosphere::Atmosphere<NSTOKES>* m_atmosphere;
         const sasktran2::Config* m_config;
@@ -111,6 +112,14 @@ namespace sasktran2 {
         }
 
         Eigen::MatrixXd& los_optical_depth() { return m_los_optical_depth; }
+
+        const Eigen::VectorXd& los_refraction_deflection_angle() const {
+            return m_los_refraction_deflection_angle;
+        }
+
+        Eigen::VectorXd& los_refraction_deflection_angle() {
+            return m_los_refraction_deflection_angle;
+        }
     };
 
     /** An idealized output container where only the line of sight radiances are

--- a/cpp/include/sasktran2/raytracing.h
+++ b/cpp/include/sasktran2/raytracing.h
@@ -90,6 +90,10 @@ namespace sasktran2::raytracing {
                                   refractive effects. Could be negative if the
                                   ray hits the ground. */
 
+        double los_refraction_deflection_angle; /**< Final LOS refraction
+                                                   bending angle in [radians].
+                                                 */
+
         std::vector<std::pair<int, double>> interpolation_index_weights; /**<
             Workspace memory to be used by the raytracer.
          */
@@ -100,6 +104,7 @@ namespace sasktran2::raytracing {
             ground_is_hit = false;
             layers.resize(0);
             tangent_radius = std::numeric_limits<double>::quiet_NaN();
+            los_refraction_deflection_angle = 0.0;
         }
     };
 

--- a/cpp/include/sasktran2/refraction.h
+++ b/cpp/include/sasktran2/refraction.h
@@ -5,8 +5,20 @@
 
 #include <sasktran2/geometry.h>
 #include <sasktran2/viewinggeometry.h>
+#include <cmath>
 
 namespace sasktran2::raytracing::refraction {
+
+    inline bool refractive_index_is_unity(const sasktran2::Geometry1D& geometry,
+                                          double tolerance = 1e-12) {
+        for (int i = 0; i < geometry.refractive_index().size(); ++i) {
+            if (std::abs(geometry.refractive_index()[i] - 1.0) >= tolerance) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 
     /**
      * @brief Calculates the refractive index at a given altitude by

--- a/cpp/lib/output/output.cpp
+++ b/cpp/lib/output/output.cpp
@@ -25,6 +25,12 @@ namespace sasktran2 {
 
         this->resize();
 
+        m_los_refraction_deflection_angle.resize(m_nlos);
+        for (int i = 0; i < m_nlos; ++i) {
+            m_los_refraction_deflection_angle[i] =
+                internal_viewing.traced_rays[i].los_refraction_deflection_angle;
+        }
+
         if constexpr (NSTOKES > 1) {
             m_stokes_C.resize(m_nlos);
             m_stokes_S.resize(m_nlos);

--- a/cpp/lib/raytracing/refraction.cpp
+++ b/cpp/lib/raytracing/refraction.cpp
@@ -31,6 +31,13 @@ namespace sasktran2::raytracing::refraction {
         result.first = 0;
         result.second = 0;
 
+        if (refractive_index_is_unity(geometry)) {
+            result.first = sqrt(r2 * r2 - rt * rt) - sqrt(r1 * r1 - rt * rt);
+            result.second = acos(rt / r2) - acos(rt / r1);
+
+            return result;
+        }
+
         if (std::abs(r1 - r2) < min_cell_length) {
             result.first = sqrt(r2 * r2 - rt * rt) - sqrt(r1 * r1 - rt * rt);
             // Closed form expression for the deflection angle assuming n=nt=1

--- a/cpp/lib/raytracing/spherical_shell.cpp
+++ b/cpp/lib/raytracing/spherical_shell.cpp
@@ -1,6 +1,7 @@
 #include "sasktran2/internal_common.h"
 #include <sasktran2/raytracing.h>
 #include <sasktran2/refraction.h>
+#include <algorithm>
 
 namespace sasktran2::raytracing {
     void SphericalShellRayTracer::trace_ray(
@@ -87,8 +88,6 @@ namespace sasktran2::raytracing {
         // Iterate through all of the rays, starting from the observer
         double total_deflection = 0.0;
         std::vector<std::pair<int, double>> index_weights;
-
-        double costh = result.observer_and_look.cos_viewing();
 
         double rt_refracted = result.tangent_radius;
 
@@ -198,6 +197,48 @@ namespace sasktran2::raytracing {
                 m_geometry.altitude_grid().interpolation_method());
             add_interpolation_weights(layer, m_geometry);
             add_solar_parameters(m_geometry.coordinates().sun_unit(), layer);
+        }
+
+        if (!result.is_straight && !result.layers.empty() &&
+            !refraction::refractive_index_is_unity(m_geometry)) {
+            const auto& final_layer = result.layers.front();
+            const double final_radius = final_layer.exit.radius();
+            const Eigen::Vector3d final_radial =
+                final_layer.exit.position.normalized();
+            const Eigen::Vector3d final_tangent =
+                (-x_basis * sin(total_deflection) +
+                 y_basis * cos(total_deflection))
+                    .normalized();
+
+            const double final_refractive_index =
+                refraction::refractive_index_at_altitude(
+                    m_geometry,
+                    final_radius - m_geometry.coordinates().earth_radius(),
+                    index_weights);
+            const double sin_final_angle = std::clamp(
+                nt * rt_refracted / (final_refractive_index * final_radius),
+                0.0, 1.0);
+            const double cos_final_angle =
+                sqrt(std::max(0.0, 1.0 - sin_final_angle * sin_final_angle));
+
+            const double radial_delta =
+                final_layer.r_exit - final_layer.r_entrance;
+            const double radial_sign =
+                std::abs(radial_delta) > 0
+                    ? (radial_delta > 0 ? 1.0 : -1.0)
+                    : (final_layer.average_look_away.dot(final_radial) >= 0.0
+                           ? 1.0
+                           : -1.0);
+
+            const Eigen::Vector3d final_refracted_look =
+                radial_sign * cos_final_angle * final_radial +
+                sin_final_angle * final_tangent;
+
+            const double look_dot =
+                std::clamp(result.observer_and_look.look_away.dot(
+                               final_refracted_look.normalized()),
+                           -1.0, 1.0);
+            result.los_refraction_deflection_angle = acos(look_dot);
         }
     }
 

--- a/cpp/lib/tests/raytracing/test_spherical_shell.cpp
+++ b/cpp/lib/tests/raytracing/test_spherical_shell.cpp
@@ -2,6 +2,7 @@
 #include <sasktran2/test_helper.h>
 
 #include <sasktran2.h>
+#include <cmath>
 
 TEST_CASE("Spherical Shell Raytracer - Observer Outside limb Viewing",
           "[sasktran2][raytracing]") {
@@ -110,6 +111,54 @@ TEST_CASE(
     }
 
     REQUIRE(min_alt < tangent_altitude);
+}
+
+TEST_CASE("Spherical Shell Raytracer - LOS Refraction Deflection Diagnostic",
+          "[sasktran2][raytracing]") {
+    double dx = 1000;
+    int nx = 66;
+    double x0 = 0;
+    double tangent_altitude = 10000.0;
+
+    Eigen::VectorXd grid_values(nx);
+    for (int i = 0; i < nx; ++i) {
+        grid_values(i) = x0 + i * dx;
+    }
+
+    sasktran2::grids::AltitudeGrid grid = sasktran2::grids::AltitudeGrid(
+        std::move(grid_values), sasktran2::grids::gridspacing::constant,
+        sasktran2::grids::outofbounds::extend,
+        sasktran2::grids::interpolation::linear);
+
+    sasktran2::Coordinates coord(1, 0, 6372000);
+
+    sasktran2::Geometry1D geo(std::move(coord), std::move(grid));
+
+    sasktran2::raytracing::SphericalShellRayTracer raytracer(geo);
+
+    sasktran2::viewinggeometry::TangentAltitude ray_policy(tangent_altitude, 0,
+                                                           600000);
+
+    auto viewing_ray = ray_policy.construct_ray(geo.coordinates());
+
+    sasktran2::raytracing::TracedRay traced_ray;
+    raytracer.trace_ray(viewing_ray, traced_ray, false);
+
+    REQUIRE(std::abs(traced_ray.los_refraction_deflection_angle) < 1e-12);
+
+    raytracer.trace_ray(viewing_ray, traced_ray, true);
+
+    REQUIRE(std::abs(traced_ray.los_refraction_deflection_angle) < 1e-8);
+
+    for (int i = 0; i < geo.refractive_index().size(); ++i) {
+        double altitude = geo.altitude_grid().grid()(i);
+        geo.refractive_index()(i) = 1.0 + 2.8e-4 * std::exp(-altitude / 7000.0);
+    }
+
+    raytracer.trace_ray(viewing_ray, traced_ray, true);
+
+    REQUIRE(std::isfinite(traced_ray.los_refraction_deflection_angle));
+    REQUIRE(traced_ray.los_refraction_deflection_angle > 0.0);
 }
 
 TEST_CASE("Spherical Shell Raytracer - Observer Inside Limb Viewing",

--- a/rust/sasktran2-py-ext/src/output.rs
+++ b/rust/sasktran2-py-ext/src/output.rs
@@ -1,4 +1,4 @@
-use numpy::{PyArray2, PyArray3, PyArray4};
+use numpy::{PyArray1, PyArray2, PyArray3, PyArray4};
 use pyo3::{prelude::*, types::PyDict};
 use sasktran2_rs::bindings::output;
 
@@ -102,5 +102,13 @@ impl PyOutput {
     fn get_los_optical_depth<'py>(this: Bound<'py, Self>) -> PyResult<Bound<'py, PyArray2<f64>>> {
         let array = &this.borrow().output.los_optical_depth();
         Ok(PyArray2::from_array(this.py(), array))
+    }
+
+    #[getter]
+    fn get_los_refraction_deflection_angle<'py>(
+        this: Bound<'py, Self>,
+    ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let array = &this.borrow().output.los_refraction_deflection_angle();
+        Ok(PyArray1::from_array(this.py(), array))
     }
 }

--- a/rust/sasktran2-rs/src/bindings/output.rs
+++ b/rust/sasktran2-rs/src/bindings/output.rs
@@ -191,6 +191,19 @@ impl Output {
 
         output
     }
+
+    pub fn los_refraction_deflection_angle(&self) -> Array1<f64> {
+        let mut internal: *mut f64 = std::ptr::null_mut();
+        let internal_view = unsafe {
+            ffi::sk_output_get_los_refraction_deflection_angle(self.output, &mut internal);
+            ArrayView1::from_shape_ptr(self.num_los, internal)
+        };
+
+        let mut output = Array1::<f64>::zeros(self.num_los);
+        output.assign(&internal_view);
+
+        output
+    }
 }
 
 impl Drop for Output {

--- a/rust/sasktran2-sys/src/bindings.rs
+++ b/rust/sasktran2-sys/src/bindings.rs
@@ -884,6 +884,12 @@ unsafe extern "C" {
         od: *mut *mut f64,
     ) -> ::std::os::raw::c_int;
 }
+unsafe extern "C" {
+    pub fn sk_output_get_los_refraction_deflection_angle(
+        output: *mut OutputC,
+        angle: *mut *mut f64,
+    ) -> ::std::os::raw::c_int;
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Engine {

--- a/src/sasktran2/engine.py
+++ b/src/sasktran2/engine.py
@@ -170,4 +170,11 @@ class Engine:
                 dims=["wavelength", "los"],
             )
 
+        if self._config.los_refraction:
+            out_ds["los_refraction_deflection_angle"] = xr.DataArray(
+                output.los_refraction_deflection_angle,
+                dims=["los"],
+                attrs={"units": "rad"},
+            )
+
         return out_ds

--- a/tests/engine/test_refraction.py
+++ b/tests/engine/test_refraction.py
@@ -298,6 +298,14 @@ def test_refraction_enabling():
 
     radiance = engine.calculate_radiance(atmosphere)
 
+    assert "los_refraction_deflection_angle" in radiance_refracted
+    deflection = radiance_refracted["los_refraction_deflection_angle"]
+    assert deflection.dims == ("los",)
+    assert deflection.attrs["units"] == "rad"
+    assert np.all(np.isfinite(deflection.to_numpy()))
+    assert np.any(deflection.to_numpy() > 0)
+    assert "los_refraction_deflection_angle" not in radiance
+
     # Verify that this should fail
     try:
         np.testing.assert_allclose(


### PR DESCRIPTION
## Summary
- expose `los_refraction_deflection_angle` in Python radiance datasets when LOS refraction is enabled
- store the final directional bending diagnostic on traced rays and pass it through the C++/C/Rust/Python output bridge
- add raytracing and Python coverage for disabled, unity-index, and refracted cases

## Notes
- the diagnostic is LOS-only, wavelength-independent, and reported in radians
- unity refractive-index profiles now take the exact straight-path shortcut so the diagnostic stays physically zero

## Validation
- `pixi run build`
- `pixi run pytest tests/engine/test_refraction.py tests/engine/test_od_output.py`
- `/private/tmp/sasktran2-cpp-tests-los-deflection/lib/tests/sasktran2_tests "Spherical Shell Raytracer*"`
- `pixi run pre-commit`
