### PR TITLE
Optimize exact single-scatter derivatives

### DIFF
--- a/cpp/include/sasktran2/solartransmission.h
+++ b/cpp/include/sasktran2/solartransmission.h
@@ -7,6 +7,7 @@
 #include <sasktran2/atmosphere/atmosphere.h>
 #include <sasktran2/config.h>
 #include <sasktran2/dual.h>
+#include <array>
 
 namespace sasktran2::solartransmission {
     /** Generates one row of what is known as the geometry matrix.  The optical
@@ -240,6 +241,15 @@ namespace sasktran2::solartransmission {
                      sasktran2::Dual<double, sasktran2::dualstorage::dense,
                                      NSTOKES>& source) const;
 
+        /** Returns the interpolated phase vector and accumulates its
+         * scattering-property derivatives directly into a target source. */
+        Eigen::Vector<double, NSTOKES> scatter_and_accumulate_derivative(
+            int threadidx, int losidx, int layeridx,
+            const raytracing::GridWeightStencilView& index_weights,
+            bool is_entrance, double source_amplitude, double derivative_scale,
+            sasktran2::Dual<double, sasktran2::dualstorage::dense, NSTOKES>&
+                target) const;
+
       private:
         void initialize_geometry_impl(
             const std::vector<sasktran2::raytracing::TracedRay>& los_rays,
@@ -253,8 +263,8 @@ namespace sasktran2::solartransmission {
                                      NSTOKES>& source) const;
     };
 
-    template <bool USE_ACTIVE_DERIVATIVES, int NSTOKES>
-    inline void scattering_source_impl(
+    template <int NSTOKES>
+    inline void scattering_source(
         const PhaseHandler<NSTOKES>& phase_handler, int threadidx, int losidx,
         int layeridx, int wavelidx,
         const raytracing::GridWeightStencilView& index_weights,
@@ -262,50 +272,14 @@ namespace sasktran2::solartransmission {
         const atmosphere::Atmosphere<NSTOKES>& atmosphere,
         Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator
             solar_trans_iter,
-        bool calculate_derivatives, std::vector<int>& active_derivative_indices,
+        bool calculate_derivatives,
         sasktran2::Dual<double, sasktran2::dualstorage::dense, NSTOKES>&
             source) {
         const auto& storage = atmosphere.storage();
         source.value.setZero();
 
         if (calculate_derivatives) {
-            if constexpr (USE_ACTIVE_DERIVATIVES) {
-                active_derivative_indices.clear();
-                for (auto it = solar_trans_iter; it; ++it) {
-                    active_derivative_indices.push_back(it.index());
-                }
-                for (std::size_t index = 0; index < index_weights.size();
-                     ++index) {
-                    const auto ele = index_weights[index];
-                    if (ele.second == 0.0) {
-                        continue;
-                    }
-                    active_derivative_indices.push_back(ele.first);
-                    active_derivative_indices.push_back(
-                        atmosphere.ssa_deriv_start_index() + ele.first);
-                    for (int derivative_group = 0;
-                         derivative_group <
-                         atmosphere.num_scattering_deriv_groups();
-                         ++derivative_group) {
-                        active_derivative_indices.push_back(
-                            atmosphere.scat_deriv_start_index() +
-                            derivative_group *
-                                atmosphere.storage().total_extinction.rows() +
-                            ele.first);
-                    }
-                }
-                std::sort(active_derivative_indices.begin(),
-                          active_derivative_indices.end());
-                active_derivative_indices.erase(
-                    std::unique(active_derivative_indices.begin(),
-                                active_derivative_indices.end()),
-                    active_derivative_indices.end());
-                for (const int derivative_index : active_derivative_indices) {
-                    source.deriv.col(derivative_index).setZero();
-                }
-            } else {
-                source.deriv.setZero();
-            }
+            source.deriv.setZero();
         }
 
         double ssa = 0;
@@ -387,13 +361,7 @@ namespace sasktran2::solartransmission {
         if (!calculate_derivatives) {
             return;
         }
-        if constexpr (USE_ACTIVE_DERIVATIVES) {
-            for (const int derivative_index : active_derivative_indices) {
-                source.deriv.col(derivative_index) *= source_amplitude;
-            }
-        } else {
-            source.deriv *= source_amplitude;
-        }
+        source.deriv *= source_amplitude;
         // Solar transmission derivative factors
         for (auto it = solar_trans_iter; it; ++it) {
             source.deriv(Eigen::placeholders::all, it.index()) -=
@@ -415,8 +383,11 @@ namespace sasktran2::solartransmission {
         }
     }
 
+    /** Evaluates one exact single-scatter endpoint and accumulates its
+     * derivatives directly into the integrated ray source. This avoids
+     * materializing and then copying a dense endpoint derivative buffer. */
     template <int NSTOKES>
-    inline void scattering_source(
+    inline Eigen::Vector<double, NSTOKES> accumulate_exact_scattering_source(
         const PhaseHandler<NSTOKES>& phase_handler, int threadidx, int losidx,
         int layeridx, int wavelidx,
         const raytracing::GridWeightStencilView& index_weights,
@@ -424,23 +395,50 @@ namespace sasktran2::solartransmission {
         const atmosphere::Atmosphere<NSTOKES>& atmosphere,
         Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator
             solar_trans_iter,
-        bool calculate_derivatives, bool use_active_derivatives,
-        std::vector<int>& active_derivative_indices,
+        double derivative_scale,
         sasktran2::Dual<double, sasktran2::dualstorage::dense, NSTOKES>&
-            source) {
-        if (use_active_derivatives) {
-            scattering_source_impl<true>(
-                phase_handler, threadidx, losidx, layeridx, wavelidx,
-                index_weights, is_entrance, solar_trans, atmosphere,
-                solar_trans_iter, calculate_derivatives,
-                active_derivative_indices, source);
-        } else {
-            scattering_source_impl<false>(
-                phase_handler, threadidx, losidx, layeridx, wavelidx,
-                index_weights, is_entrance, solar_trans, atmosphere,
-                solar_trans_iter, calculate_derivatives,
-                active_derivative_indices, source);
+            target) {
+        const auto& storage = atmosphere.storage();
+        double ssa = 0.0;
+        double extinction = 0.0;
+        for (std::size_t index = 0; index < index_weights.size(); ++index) {
+            const auto weight = index_weights[index];
+            if (weight.second == 0.0) {
+                continue;
+            }
+            ssa += storage.ssa(weight.first, wavelidx) * weight.second;
+            extinction += storage.total_extinction(weight.first, wavelidx) *
+                          weight.second;
         }
+
+        const double unscaled_amplitude = solar_trans / (EIGEN_PI * 4);
+        const double source_amplitude = extinction * ssa * unscaled_amplitude;
+        const Eigen::Vector<double, NSTOKES> phase =
+            phase_handler.scatter_and_accumulate_derivative(
+                threadidx, losidx, layeridx, index_weights, is_entrance,
+                source_amplitude, derivative_scale, target);
+        const Eigen::Vector<double, NSTOKES> endpoint_source =
+            source_amplitude * phase;
+
+        for (auto it = solar_trans_iter; it; ++it) {
+            target.deriv.col(it.index()) -=
+                derivative_scale * it.value() * endpoint_source;
+        }
+
+        for (std::size_t index = 0; index < index_weights.size(); ++index) {
+            const auto weight = index_weights[index];
+            if (weight.second == 0.0) {
+                continue;
+            }
+            target.deriv.col(atmosphere.ssa_deriv_start_index() +
+                             weight.first) += derivative_scale * weight.second *
+                                              extinction * unscaled_amplitude *
+                                              phase;
+            target.deriv.col(weight.first) += derivative_scale * weight.second *
+                                              ssa * unscaled_amplitude * phase;
+        }
+
+        return endpoint_source;
     }
 
     template <typename S, int NSTOKES>
@@ -458,8 +456,14 @@ namespace sasktran2::solartransmission {
 
         PhaseHandler<NSTOKES> m_phase_handler;
 
-        mutable std::vector<std::vector<int>> m_start_active_derivative_indices;
-        mutable std::vector<std::vector<int>> m_end_active_derivative_indices;
+        // [los][layer][solar endpoint][geometry endpoint], where endpoint 0 is
+        // the layer exit and endpoint 1 is the layer entrance.
+        using ActiveDerivativeIndices =
+            std::array<std::array<std::vector<int>, 2>, 2>;
+        std::vector<std::vector<ActiveDerivativeIndices>>
+            m_active_derivative_indices;
+        const std::vector<sasktran2::raytracing::TracedRay>* m_traced_rays =
+            nullptr;
 
         mutable std::vector<
             sasktran2::Dual<double, sasktran2::dualstorage::dense, NSTOKES>>
@@ -475,6 +479,8 @@ namespace sasktran2::solartransmission {
 
         std::vector<bool> m_los_ground_is_hit;
         std::vector<sasktran2::raytracing::LayerGeometry> m_los_end_layers;
+
+        void initialize_active_derivative_indices();
 
         void integrated_source_constant(
             int wavelidx, int losidx, int layeridx, int wavel_threadidx,
@@ -560,6 +566,17 @@ namespace sasktran2::solartransmission {
             return dimension == 1 ||
                    (dimension == 2 && m_geometry_2d != nullptr);
         }
+
+        bool supports_sparse_derivative_tracking() const override {
+            return std::is_same_v<S, SolarTransmissionExact>;
+        }
+
+        void append_end_of_ray_active_derivatives(
+            int losidx, std::vector<int>& derivative_indices) const override;
+
+        void append_interior_active_derivatives(
+            int losidx, int layeridx,
+            std::vector<int>& derivative_indices) const override;
 
         /** Calculates the source term at the end of the ray.  Common examples
          * of this are ground scattering, ground emission, or the solar radiance

--- a/cpp/include/sasktran2/source_integrator.h
+++ b/cpp/include/sasktran2/source_integrator.h
@@ -50,12 +50,16 @@ namespace sasktran2 {
         std::vector<Eigen::MatrixXd>
             m_shell_od; /**< Vector of matrices that stores the optical depth
                            for each layer */
-        const std::vector<sasktran2::raytracing::TracedRay>*
-            m_traced_rays; /**< Reference to the rays we are integrating */
+        const std::vector<sasktran2::raytracing::TracedRay>* m_traced_rays =
+            nullptr; /**< Reference to the rays we are integrating */
 
-        const sasktran2::atmosphere::Atmosphere<NSTOKES>* m_atmosphere;
+        const sasktran2::atmosphere::Atmosphere<NSTOKES>* m_atmosphere =
+            nullptr;
         int m_num_geometry_locations = 0;
         int m_num_geometry_dimensions = 1;
+        bool m_use_sparse_derivative_tracking = false;
+        std::vector<std::vector<std::vector<std::pair<int, int>>>>
+            m_attenuation_active_derivative_ranges;
 
         void integrate_ray(
             sasktran2::Dual<double, sasktran2::dualstorage::dense, NSTOKES>&
@@ -82,6 +86,8 @@ namespace sasktran2 {
         void set_calculate_derivatives(bool enable) {
             m_derivatives_enabled = enable;
             m_calculate_derivatives = enable;
+            m_use_sparse_derivative_tracking = false;
+            m_attenuation_active_derivative_ranges.clear();
         }
 
         /** Initializes the geometry of the source integrator
@@ -99,6 +105,12 @@ namespace sasktran2 {
          */
         void initialize_atmosphere(
             const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmo);
+
+        /** Precomputes the cumulative derivative columns that can be nonzero
+         * before each layer attenuation. This is enabled only when every
+         * active source can report its derivative sparsity exactly. */
+        void initialize_derivative_sparsity(
+            const std::vector<SourceTermInterface<NSTOKES>*>& source_terms);
 
         /** Integrates the source terms and stores the result in radiance
          *

--- a/cpp/include/sasktran2/source_interface.h
+++ b/cpp/include/sasktran2/source_interface.h
@@ -126,4 +126,20 @@ template <int NSTOKES> class SourceTermInterface {
     virtual bool supports_geometry_dimension(int dimension) const {
         return dimension == 1 || !has_interior_source();
     }
+
+    /** Returns true when this source can report every derivative column that
+     * it may modify. The source integrator uses this information to avoid
+     * scaling derivative columns that are still identically zero. */
+    virtual bool supports_sparse_derivative_tracking() const { return false; }
+
+    /** Appends derivative columns that may be modified by the source at the
+     * end of a ray. */
+    virtual void append_end_of_ray_active_derivatives(int,
+                                                      std::vector<int>&) const {
+    }
+
+    /** Appends derivative columns that may be modified by the source within a
+     * layer. */
+    virtual void append_interior_active_derivatives(int, int,
+                                                    std::vector<int>&) const {}
 };

--- a/cpp/lib/engine/engine.cpp
+++ b/cpp/lib/engine/engine.cpp
@@ -477,6 +477,7 @@ void Sasktran2<NSTOKES>::calculate_radiance(
     }
 
     m_source_integrator->initialize_atmosphere(atmosphere);
+    m_source_integrator->initialize_derivative_sparsity(m_los_source_terms);
 
     // Allocate memory, should be moved to thread storage?
     auto& radiance = const_cast<std::vector<

--- a/cpp/lib/phasefunction/phasehandler.cpp
+++ b/cpp/lib/phasefunction/phasehandler.cpp
@@ -322,6 +322,21 @@ namespace sasktran2::solartransmission {
         bool is_entrance,
         sasktran2::Dual<double, sasktran2::dualstorage::dense, NSTOKES>& source)
         const {
+        const double source_amplitude = source.value(0);
+        const auto phase = scatter_and_accumulate_derivative(
+            threadidx, losidx, layeridx, index_weights, is_entrance,
+            source_amplitude, 1.0, source);
+        source.value = source_amplitude * phase;
+    }
+
+    template <int NSTOKES>
+    Eigen::Vector<double, NSTOKES>
+    PhaseHandler<NSTOKES>::scatter_and_accumulate_derivative(
+        int threadidx, int losidx, int layeridx,
+        const raytracing::GridWeightStencilView& index_weights,
+        bool is_entrance, double source_amplitude, double derivative_scale,
+        sasktran2::Dual<double, sasktran2::dualstorage::dense, NSTOKES>& target)
+        const {
         const auto& internal_indices =
             is_entrance ? m_geometry_entrance_to_internal[losidx][layeridx]
                         : m_geometry_exit_to_internal[losidx][layeridx];
@@ -369,13 +384,13 @@ namespace sasktran2::solartransmission {
                     }
                     const int internal_index =
                         internal_indices[derivative_internal_offset++];
-                    source.deriv(0, derivative_start + index_weight.first) +=
-                        source.value(0) *
+                    target.deriv(0, derivative_start + index_weight.first) +=
+                        derivative_scale * source_amplitude *
                         m_d_phase(0, internal_index, d, threadidx) *
                         index_weight.second;
                 }
             }
-            source.value(0) *= phase_result;
+            return Eigen::Vector<double, 1>::Constant(phase_result);
 
         } else if constexpr (NSTOKES == 3) {
             Eigen::Vector3d phase_result = Eigen::Vector3d::Zero();
@@ -430,17 +445,17 @@ namespace sasktran2::solartransmission {
 
                     int deriv_index = m_atmosphere->scat_deriv_start_index() +
                                       d * m_geometry.size() + geometry_index;
-                    source.deriv(0, deriv_index) +=
-                        source.value(0) *
+                    target.deriv(0, deriv_index) +=
+                        derivative_scale * source_amplitude *
                         m_d_phase(0, internal_index, d, threadidx) * weight;
 
-                    source.deriv(1, deriv_index) +=
-                        source.value(0) *
+                    target.deriv(1, deriv_index) +=
+                        derivative_scale * source_amplitude *
                         m_d_phase(1, internal_index, d, threadidx) * weight *
                         (-C2);
 
-                    source.deriv(2, deriv_index) +=
-                        source.value(0) *
+                    target.deriv(2, deriv_index) +=
+                        derivative_scale * source_amplitude *
                         m_d_phase(1, internal_index, d, threadidx) * weight *
                         (-S2);
                 };
@@ -458,8 +473,9 @@ namespace sasktran2::solartransmission {
                 }
             }
 
-            source.value.array() = source.value(0) * phase_result.array();
+            return phase_result;
         } else {
+            return Eigen::Vector<double, NSTOKES>::Zero();
         }
     }
 

--- a/cpp/lib/solar/singlescattersource.cpp
+++ b/cpp/lib/solar/singlescattersource.cpp
@@ -21,6 +21,14 @@ namespace sasktran2::solartransmission {
         m_atmosphere = &atmosphere;
         this->m_phase_handler.initialize_atmosphere(atmosphere);
 
+        if constexpr (std::is_same_v<S, SolarTransmissionExact>) {
+            if (atmosphere.num_deriv() > 0) {
+                initialize_active_derivative_indices();
+            } else {
+                m_active_derivative_indices.clear();
+            }
+        }
+
         // Initialize some local memory storage
         for (int i = 0; i < m_start_source_cache.size(); ++i) {
             m_start_source_cache[i].resize(NSTOKES, atmosphere.num_deriv(),
@@ -40,9 +48,6 @@ namespace sasktran2::solartransmission {
 
         // Set up storage for each thread
         // m_solar_trans.resize(config.num_threads());
-        m_start_active_derivative_indices.resize(config.num_threads());
-        m_end_active_derivative_indices.resize(config.num_threads());
-
         m_solar_trans.resize(config.num_wavelength_threads());
 
         m_start_source_cache.resize(config.num_threads());
@@ -172,10 +177,71 @@ namespace sasktran2::solartransmission {
     }
 
     template <typename S, int NSTOKES>
+    void SingleScatterSource<S, NSTOKES>::append_end_of_ray_active_derivatives(
+        int losidx, std::vector<int>& derivative_indices) const {
+        if constexpr (!std::is_same_v<S, SolarTransmissionExact>) {
+            return;
+        }
+
+        if (!m_los_ground_is_hit.at(losidx)) {
+            return;
+        }
+
+        if (m_config->wf_precision() !=
+            sasktran2::Config::WeightingFunctionPrecision::limited) {
+            const int exit_index = m_index_map[losidx][0];
+            for (Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator
+                     derivative(m_geometry_sparse, exit_index);
+                 derivative; ++derivative) {
+                derivative_indices.push_back(derivative.index());
+            }
+        }
+
+        for (int derivative = 0;
+             derivative < m_atmosphere->surface().num_deriv(); ++derivative) {
+            derivative_indices.push_back(
+                m_atmosphere->surface_deriv_start_index() + derivative);
+        }
+    }
+
+    template <typename S, int NSTOKES>
+    void SingleScatterSource<S, NSTOKES>::append_interior_active_derivatives(
+        int losidx, int layeridx, std::vector<int>& derivative_indices) const {
+        if constexpr (!std::is_same_v<S, SolarTransmissionExact>) {
+            return;
+        }
+
+        const auto& layer_active_derivatives =
+            m_active_derivative_indices[losidx][layeridx];
+        const bool use_lower_interpolation =
+            m_geometry_1d != nullptr &&
+            m_geometry_1d->altitude_grid().interpolation_method() ==
+                grids::interpolation::lower;
+
+        const std::vector<int>* start_active;
+        const std::vector<int>* end_active;
+        if (use_lower_interpolation) {
+            const auto& layer = (*m_traced_rays)[losidx].layers[layeridx];
+            const bool use_entrance_weights = layer.r_exit > layer.r_entrance;
+            start_active = &layer_active_derivatives[1][use_entrance_weights];
+            end_active = &layer_active_derivatives[0][use_entrance_weights];
+        } else {
+            start_active = &layer_active_derivatives[1][1];
+            end_active = &layer_active_derivatives[0][0];
+        }
+
+        derivative_indices.insert(derivative_indices.end(),
+                                  start_active->begin(), start_active->end());
+        derivative_indices.insert(derivative_indices.end(), end_active->begin(),
+                                  end_active->end());
+    }
+
+    template <typename S, int NSTOKES>
     void SingleScatterSource<S, NSTOKES>::initialize_geometry(
         const sasktran2::viewinggeometry::InternalViewingGeometry&
             internal_viewing) {
         ZoneScopedN("Initialize Single Scatter Source Geometry");
+        m_traced_rays = &internal_viewing.traced_rays;
         this->m_solar_transmission.initialize_geometry(
             internal_viewing.traced_rays);
 
@@ -243,6 +309,88 @@ namespace sasktran2::solartransmission {
     }
 
     template <typename S, int NSTOKES>
+    void
+    SingleScatterSource<S, NSTOKES>::initialize_active_derivative_indices() {
+        if (m_traced_rays == nullptr || m_atmosphere == nullptr) {
+            throw std::runtime_error(
+                "Single scatter geometry and atmosphere must be initialized "
+                "before derivative sparsity");
+        }
+
+        m_active_derivative_indices.clear();
+        m_active_derivative_indices.resize(m_traced_rays->size());
+
+        const auto build_indices =
+            [&](int solar_index,
+                const sasktran2::raytracing::GridWeightStencilView&
+                    geometry_weights,
+                std::vector<int>& result) {
+                result.clear();
+                result.reserve(
+                    m_geometry_sparse.innerVector(solar_index).nonZeros() +
+                    geometry_weights.size() *
+                        (2 + m_atmosphere->num_scattering_deriv_groups()));
+
+                for (Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator
+                         it(m_geometry_sparse, solar_index);
+                     it; ++it) {
+                    result.push_back(it.index());
+                }
+
+                for (std::size_t index = 0; index < geometry_weights.size();
+                     ++index) {
+                    const auto weight = geometry_weights[index];
+                    if (weight.second == 0.0) {
+                        continue;
+                    }
+
+                    result.push_back(weight.first);
+                    result.push_back(m_atmosphere->ssa_deriv_start_index() +
+                                     weight.first);
+                    for (int derivative_group = 0;
+                         derivative_group <
+                         m_atmosphere->num_scattering_deriv_groups();
+                         ++derivative_group) {
+                        result.push_back(
+                            m_atmosphere->scat_deriv_start_index() +
+                            derivative_group * m_geometry.size() +
+                            weight.first);
+                    }
+                }
+
+                std::sort(result.begin(), result.end());
+                result.erase(std::unique(result.begin(), result.end()),
+                             result.end());
+            };
+
+        for (std::size_t los_index = 0; los_index < m_traced_rays->size();
+             ++los_index) {
+            const auto& ray = (*m_traced_rays)[los_index];
+            auto& los_indices = m_active_derivative_indices[los_index];
+            los_indices.resize(ray.layers.size());
+
+            for (std::size_t layer_index = 0; layer_index < ray.layers.size();
+                 ++layer_index) {
+                const int exit_solar_index =
+                    m_index_map[los_index][layer_index];
+                const int entrance_solar_index = exit_solar_index + 1;
+                const auto entrance_weights = ray.entrance_weights(layer_index);
+                const auto exit_weights = ray.exit_weights(layer_index);
+                auto& layer_indices = los_indices[layer_index];
+
+                build_indices(exit_solar_index, exit_weights,
+                              layer_indices[0][0]);
+                build_indices(exit_solar_index, entrance_weights,
+                              layer_indices[0][1]);
+                build_indices(entrance_solar_index, exit_weights,
+                              layer_indices[1][0]);
+                build_indices(entrance_solar_index, entrance_weights,
+                              layer_indices[1][1]);
+            }
+        }
+    }
+
+    template <typename S, int NSTOKES>
     void SingleScatterSource<S, NSTOKES>::integrated_source_constant(
         int wavelidx, int losidx, int layeridx, int wavel_threadidx,
         int threadidx, const sasktran2::raytracing::LayerGeometry& layer,
@@ -267,16 +415,86 @@ namespace sasktran2::solartransmission {
 
         auto& start_phase = m_start_source_cache[threadidx];
         auto& end_phase = m_end_source_cache[threadidx];
-        auto& start_active_derivative_indices =
-            m_start_active_derivative_indices[threadidx];
-        auto& end_active_derivative_indices =
-            m_end_active_derivative_indices[threadidx];
 
-        const bool use_active_derivatives = m_geometry_2d != nullptr;
+        // Exact solar-transmission rows are expressed directly in atmosphere
+        // extinction coordinates, so the derivative of an endpoint source only
+        // touches the nonzero solar-path columns plus the local interpolation
+        // stencil. This is sparse for both 1D and 2D geometries. The table
+        // source uses an intermediate table-coordinate matrix, so retain its
+        // dense derivative path until that mapping is explicitly composed.
         const bool use_lower_interpolation =
             m_geometry_1d != nullptr &&
             m_geometry_1d->altitude_grid().interpolation_method() ==
                 grids::interpolation::lower;
+        const bool use_fused_exact_derivatives =
+            calculate_derivatives && std::is_same_v<S, SolarTransmissionExact>;
+
+        if (use_fused_exact_derivatives) {
+            double source_factor;
+            double source_factor_derivative;
+            if (std::abs(shell_od.od) < 1e-12) {
+                source_factor = 1.0;
+                source_factor_derivative = -0.5;
+            } else {
+                source_factor = -std::expm1(-shell_od.od) / shell_od.od;
+                source_factor_derivative =
+                    1 / shell_od.od - source_factor * (1 + 1 / shell_od.od);
+            }
+
+            const auto* start_weights = &entrance_weights;
+            const auto* end_weights = &exit_weights;
+            bool start_is_entrance = true;
+            bool end_is_entrance = false;
+            if (use_lower_interpolation) {
+                if (layer.r_exit > layer.r_entrance) {
+                    end_weights = &entrance_weights;
+                    end_is_entrance = true;
+                } else {
+                    start_weights = &exit_weights;
+                    start_is_entrance = false;
+                }
+            }
+
+            const Eigen::Vector<double, NSTOKES> start_value =
+                accumulate_exact_scattering_source(
+                    m_phase_handler, wavel_threadidx, losidx, layeridx,
+                    wavelidx, *start_weights, start_is_entrance,
+                    solar_trans_entrance, *m_atmosphere,
+                    Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator(
+                        m_geometry_sparse, entrance_index),
+                    source_factor * layer.od_quad_start, source);
+            const Eigen::Vector<double, NSTOKES> end_value =
+                accumulate_exact_scattering_source(
+                    m_phase_handler, wavel_threadidx, losidx, layeridx,
+                    wavelidx, *end_weights, end_is_entrance, solar_trans_exit,
+                    *m_atmosphere,
+                    Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator(
+                        m_geometry_sparse, exit_index),
+                    source_factor * layer.od_quad_end, source);
+
+            const Eigen::Vector<double, NSTOKES> source_value =
+                source_factor *
+                (start_value.array() * layer.od_quad_start_fraction +
+                 end_value.array() * layer.od_quad_end_fraction) *
+                layer.layer_distance;
+            source.value += source_value;
+
+            for (auto derivative = shell_od.deriv_iter; derivative;
+                 ++derivative) {
+                source.deriv.col(derivative.index()) +=
+                    derivative.value() * source_factor_derivative *
+                    (start_value * layer.od_quad_start +
+                     end_value * layer.od_quad_end);
+            }
+
+#ifdef SASKTRAN_DEBUG_ASSERTS
+            if (source_value.hasNaN()) {
+                spdlog::error(
+                    "NaN detected in fused exact single scatter source");
+            }
+#endif
+            return;
+        }
 
         if (use_lower_interpolation) {
             if (layer.r_exit > layer.r_entrance) {
@@ -286,8 +504,7 @@ namespace sasktran2::solartransmission {
                     *m_atmosphere,
                     Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator(
                         m_geometry_sparse, entrance_index),
-                    calculate_derivatives, use_active_derivatives,
-                    start_active_derivative_indices, start_phase);
+                    calculate_derivatives, start_phase);
 
                 scattering_source(
                     m_phase_handler, wavel_threadidx, losidx, layeridx,
@@ -295,8 +512,7 @@ namespace sasktran2::solartransmission {
                     *m_atmosphere,
                     Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator(
                         m_geometry_sparse, exit_index),
-                    calculate_derivatives, use_active_derivatives,
-                    end_active_derivative_indices, end_phase);
+                    calculate_derivatives, end_phase);
             } else {
                 scattering_source(
                     m_phase_handler, wavel_threadidx, losidx, layeridx,
@@ -304,8 +520,7 @@ namespace sasktran2::solartransmission {
                     *m_atmosphere,
                     Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator(
                         m_geometry_sparse, entrance_index),
-                    calculate_derivatives, use_active_derivatives,
-                    start_active_derivative_indices, start_phase);
+                    calculate_derivatives, start_phase);
 
                 scattering_source(
                     m_phase_handler, wavel_threadidx, losidx, layeridx,
@@ -313,8 +528,7 @@ namespace sasktran2::solartransmission {
                     *m_atmosphere,
                     Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator(
                         m_geometry_sparse, exit_index),
-                    calculate_derivatives, use_active_derivatives,
-                    end_active_derivative_indices, end_phase);
+                    calculate_derivatives, end_phase);
             }
         } else {
             scattering_source(
@@ -322,16 +536,14 @@ namespace sasktran2::solartransmission {
                 entrance_weights, true, solar_trans_entrance, *m_atmosphere,
                 Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator(
                     m_geometry_sparse, entrance_index),
-                calculate_derivatives, use_active_derivatives,
-                start_active_derivative_indices, start_phase);
+                calculate_derivatives, start_phase);
 
             scattering_source(
                 m_phase_handler, wavel_threadidx, losidx, layeridx, wavelidx,
                 exit_weights, false, solar_trans_exit, *m_atmosphere,
                 Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator(
                     m_geometry_sparse, exit_index),
-                calculate_derivatives, use_active_derivatives,
-                end_active_derivative_indices, end_phase);
+                calculate_derivatives, end_phase);
         }
 
         double source_factor1;
@@ -386,29 +598,10 @@ namespace sasktran2::solartransmission {
                     (start_phase.value.array() * layer.od_quad_start +
                      end_phase.value.array() * layer.od_quad_end);
             }
-            // And add on d_phase. Structured 2D endpoints touch only a small
-            // subset of the full atmosphere derivative vector, so avoid a
-            // dense pass over every horizontal grid location for each layer.
-            if (use_active_derivatives) {
-                for (const int derivative_index :
-                     start_active_derivative_indices) {
-                    source.deriv.col(derivative_index) +=
-                        source_factor1 * layer.od_quad_start *
-                        start_phase.deriv.col(derivative_index);
-                }
-                for (const int derivative_index :
-                     end_active_derivative_indices) {
-                    source.deriv.col(derivative_index) +=
-                        source_factor1 * layer.od_quad_end *
-                        end_phase.deriv.col(derivative_index);
-                }
-            } else {
-                source.deriv.array() +=
-                    source_factor1 * start_phase.deriv.array() *
-                        layer.od_quad_start +
-                    source_factor1 * end_phase.deriv.array() *
-                        layer.od_quad_end;
-            }
+            source.deriv.array() +=
+                source_factor1 * start_phase.deriv.array() *
+                    layer.od_quad_start +
+                source_factor1 * end_phase.deriv.array() * layer.od_quad_end;
         }
 
 #ifdef SASKTRAN_DEBUG_ASSERTS

--- a/cpp/lib/sourceintegrator/sourceintegrator.cpp
+++ b/cpp/lib/sourceintegrator/sourceintegrator.cpp
@@ -12,6 +12,9 @@ namespace sasktran2 {
     void SourceIntegrator<NSTOKES>::initialize_geometry(
         const std::vector<sasktran2::raytracing::TracedRay>& traced_rays,
         const Geometry& geometry) {
+        m_use_sparse_derivative_tracking = false;
+        m_attenuation_active_derivative_ranges.clear();
+
         // Construct the optical depth matrices.
         // This is the matrix so that matrix @ extinction = layer od, one matrix
         // for each ray Calculating this matrix beforehand makes calculating
@@ -33,6 +36,9 @@ namespace sasktran2 {
     template <int NSTOKES>
     void SourceIntegrator<NSTOKES>::initialize_atmosphere(
         const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmo) {
+        m_use_sparse_derivative_tracking = false;
+        m_attenuation_active_derivative_ranges.clear();
+
         if (atmo.storage().total_extinction.rows() !=
             m_num_geometry_locations) {
             throw std::invalid_argument(
@@ -57,6 +63,84 @@ namespace sasktran2 {
         // atmospheres. Do not let a derivative-free call permanently disable
         // attenuation derivatives for later calculations.
         m_calculate_derivatives = m_derivatives_enabled && atmo.num_deriv() > 0;
+    }
+
+    template <int NSTOKES>
+    void SourceIntegrator<NSTOKES>::initialize_derivative_sparsity(
+        const std::vector<SourceTermInterface<NSTOKES>*>& source_terms) {
+        m_use_sparse_derivative_tracking = false;
+        m_attenuation_active_derivative_ranges.clear();
+
+        if (!m_calculate_derivatives || m_traced_rays == nullptr ||
+            source_terms.empty()) {
+            return;
+        }
+
+        for (const auto* source : source_terms) {
+            if (!source->supports_sparse_derivative_tracking()) {
+                return;
+            }
+        }
+
+        const auto sort_and_deduplicate = [](std::vector<int>& indices) {
+            std::sort(indices.begin(), indices.end());
+            indices.erase(std::unique(indices.begin(), indices.end()),
+                          indices.end());
+        };
+
+        const auto assign_contiguous_ranges =
+            [](const std::vector<int>& indices,
+               std::vector<std::pair<int, int>>& ranges) {
+                ranges.clear();
+                for (const int index : indices) {
+                    if (ranges.empty() ||
+                        index != ranges.back().first + ranges.back().second) {
+                        ranges.emplace_back(index, 1);
+                    } else {
+                        ++ranges.back().second;
+                    }
+                }
+            };
+
+        m_attenuation_active_derivative_ranges.resize(m_traced_rays->size());
+        for (std::size_t ray_index = 0; ray_index < m_traced_rays->size();
+             ++ray_index) {
+            const auto& ray = (*m_traced_rays)[ray_index];
+            auto& ray_active =
+                m_attenuation_active_derivative_ranges[ray_index];
+            ray_active.resize(ray.layers.size());
+
+            std::vector<int> cumulative_active;
+            for (const auto* source : source_terms) {
+                source->append_end_of_ray_active_derivatives(
+                    static_cast<int>(ray_index), cumulative_active);
+            }
+            sort_and_deduplicate(cumulative_active);
+
+            for (std::size_t layer_index = 0; layer_index < ray.layers.size();
+                 ++layer_index) {
+                for (Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator
+                         derivative(m_traced_ray_od_matrix[ray_index],
+                                    static_cast<int>(layer_index));
+                     derivative; ++derivative) {
+                    cumulative_active.push_back(derivative.index());
+                }
+                sort_and_deduplicate(cumulative_active);
+                assign_contiguous_ranges(cumulative_active,
+                                         ray_active[layer_index]);
+
+                for (const auto* source : source_terms) {
+                    if (source->has_interior_source()) {
+                        source->append_interior_active_derivatives(
+                            static_cast<int>(ray_index),
+                            static_cast<int>(layer_index), cumulative_active);
+                    }
+                }
+                sort_and_deduplicate(cumulative_active);
+            }
+        }
+
+        m_use_sparse_derivative_tracking = true;
     }
 
     template <int NSTOKES>
@@ -125,7 +209,17 @@ namespace sasktran2 {
             }
             radiance.value *= local_shell_od.exp_minus_od;
             if (m_calculate_derivatives) {
-                radiance.deriv *= local_shell_od.exp_minus_od;
+                if (m_use_sparse_derivative_tracking) {
+                    for (const auto& [derivative_start, derivative_count] :
+                         m_attenuation_active_derivative_ranges[rayidx]
+                                                               [layeridx]) {
+                        radiance.deriv.middleCols(derivative_start,
+                                                  derivative_count) *=
+                            local_shell_od.exp_minus_od;
+                    }
+                } else {
+                    radiance.deriv *= local_shell_od.exp_minus_od;
+                }
             }
 
             const auto& layer = ray.layers[layeridx];


### PR DESCRIPTION
## Summary

- track the exact single-scatter derivative columns that can be active along each line of sight
- accumulate exact endpoint source and phase derivatives directly into the integrated ray result
- preserve the dense derivative path whenever another source cannot report exact sparsity
- invalidate cached sparsity whenever geometry, atmosphere, or derivative configuration changes

## Motivation

Exact single-scatter weighting functions are structurally sparse, but the integration path repeatedly reset, copied, and attenuated every derivative column. For wavelength-dense calculations, those dense passes dominated the source calculation even though most columns were still zero.

This change composes the known solar-path, local extinction/SSA, phase, surface, and layer optical-depth derivative columns ahead of integration. It retains the existing dense behavior for table transmission and mixed-source configurations where sparsity cannot be proven.

## Manual benchmark

For 5,000 wavelengths, 60 lines of sight, 33 altitude levels, derivatives enabled, and three single-scatter moments:

| Threads | Before | After | Change |
| --- | ---: | ---: | ---: |
| 1 | 2.376 s | 1.300 s | 1.83x faster |
| 8 | 0.903 s | 0.349 s | 2.59x faster |

A warm 1,000-wavelength H2O workflow improved from 0.172 s to 0.119 s (1.45x faster).

The `run-benchmark` label is attached so the ASV suite can provide the repository-standard comparison.

## Validation

- `pixi run build`
- `pixi run pre-commit`
- `pixi run test`: 428 passed, 13 skipped
- scalar, polarized, 2-D, zero-extinction/SSA boundary, and mixed-source derivative paths are covered by the test suite

