### PR TITLE
Fix ECEF ground ray conversion

### DIFF
--- a/src/sasktran2/viewinggeo/ecef.py
+++ b/src/sasktran2/viewinggeo/ecef.py
@@ -7,22 +7,23 @@ import sasktran2 as sk
 
 
 def ecef_to_sasktran2_ray(
-    observer: np.array,
-    look_vector: np.array,
+    observer: np.ndarray,
+    look_vector: np.ndarray,
     time: pd.Timestamp,
     geoid: sk.Geodetic | None = None,
-    solar_handler: sk.SolarGeometryHandlerBase | None = None,
+    solar_handler: sk.solar.SolarGeometryHandlerBase | None = None,
     ground_elevation: float = 0.0,
-) -> sk.ViewingGeometry:
+) -> sk.GroundViewingSolar | sk.TangentAltitudeSolar:
     """
     Converts an observer, look vector in ECEF coordinates and time to a sasktran2 viewing ray object
 
     Parameters
     ----------
-    observer : np.array
+    observer : np.ndarray
         Observer position in ECEF (ITRF) coordinates
-    look_vector : np.array
-        Local lok vector in ECEF (ITRF) coordinates
+    look_vector : np.ndarray
+        Look vector from the observer in ECEF (ITRF) coordinates. The vector
+        does not need to be normalized.
     time: pd.Timestamp
         Time of the observation.  Used to lookup the sun position if applicable.
     geoid : sk.Geodetic
@@ -32,13 +33,23 @@ def ecef_to_sasktran2_ray(
 
     Returns
     -------
-    sk.ViewingGeometryBase
+    sk.GroundViewingSolar or sk.TangentAltitudeSolar
+        A ground-viewing ray when the look vector intersects the requested
+        ground elevation, otherwise a limb-viewing ray.
     """
     if solar_handler is None:
-        solar_handler = sk.SolarGeometryHandlerForced(0, 0)
+        solar_handler = sk.solar.SolarGeometryHandlerForced(0, 0)
 
     if geoid is None:
         geoid = sk.WGS84()
+
+    observer = np.asarray(observer, dtype=float)
+    look_vector = np.asarray(look_vector, dtype=float)
+    look_vector_norm = np.linalg.norm(look_vector)
+    if not np.isfinite(look_vector_norm) or look_vector_norm == 0:
+        msg = "look_vector must be finite and non-zero"
+        raise ValueError(msg)
+    look_vector = look_vector / look_vector_norm
 
     # Start by determining the observer's geodetic coordinates
     geoid.from_xyz(observer)
@@ -78,16 +89,20 @@ def ecef_to_sasktran2_ray(
         geoid.latitude, geoid.longitude, geoid.altitude, time
     )
 
-    cos_viewing_zenith = np.dot(look_vector, geoid.local_up)
+    # GroundViewingSolar defines the viewing cosine from the ground toward the
+    # observer, opposite to the supplied observer-to-ground look vector.
+    cos_viewing_zenith = -np.dot(look_vector, geoid.local_up)
 
     if np.abs(cos_viewing_zenith) > (1 - 1e-8):
         # Basically nadir viewing and so we can't get an observer azimuth
         viewing_azimuth = 0.0
     else:
         # Get the viewing azimuth angle
-        viewing_azimuth = -np.arctan2(
-            np.dot(look_vector, geoid.local_west),
-            -np.dot(look_vector, geoid.local_south),
+        viewing_azimuth = -np.rad2deg(
+            np.arctan2(
+                np.dot(look_vector, geoid.local_west),
+                -np.dot(look_vector, geoid.local_south),
+            )
         )
 
     return sk.GroundViewingSolar(

--- a/tests/viewing_geometry/test_ray_conversions.py
+++ b/tests/viewing_geometry/test_ray_conversions.py
@@ -5,6 +5,15 @@ import pandas as pd
 import sasktran2 as sk
 
 
+def ray_parameters(ray) -> dict[str, float]:
+    string = str(ray).split(": ", 1)[1]
+    return {
+        key.strip(): float(value)
+        for pair in string.split(", ")
+        for key, value in [pair.split(": ")]
+    }
+
+
 def test_limb_viewing_ray_conversion():
     time = pd.Timestamp.now()
 
@@ -26,16 +35,7 @@ def test_limb_viewing_ray_conversion():
 
         assert isinstance(ray, sk.TangentAltitudeSolar)
 
-        string = str(ray).split(": ", 1)[1]
-
-        # Split into individual parameter pairs
-        pairs = string.split(", ")
-
-        # Convert to dictionary
-        param_dict = {}
-        for pair in pairs:
-            key, value = pair.split(": ")
-            param_dict[key.strip()] = float(value)
+        param_dict = ray_parameters(ray)
 
         np.testing.assert_allclose(param_dict["cos_sza"], np.cos(np.deg2rad(45)))
         np.testing.assert_allclose(
@@ -45,3 +45,76 @@ def test_limb_viewing_ray_conversion():
             param_dict["tangentaltitude"], tan_alt, atol=0.1
         )  # Check to accurate within 0.1 m
         np.testing.assert_allclose(param_dict["observeraltitude"], 700000)
+
+
+def test_ground_viewing_ray_conversion():
+    time = pd.Timestamp("2020-01-01")
+    solar_zenith = 48.0
+    solar_azimuth = 137.0
+    solar = sk.solar.SolarGeometryHandlerForced(solar_zenith, solar_azimuth)
+
+    observer_geo = sk.WGS84()
+    observer_geo.from_lat_lon_alt(20.0, 30.0, 700000.0)
+
+    target_geo = sk.WGS84()
+    target_geo.from_lat_lon_alt(18.0, 34.0, 0.0)
+
+    look_vector = target_geo.location - observer_geo.location
+    look_vector /= np.linalg.norm(look_vector)
+
+    # A scaled look vector verifies that the conversion normalizes its input.
+    ray = sk.viewinggeo.ecef.ecef_to_sasktran2_ray(
+        observer_geo.location,
+        3.0 * look_vector,
+        time,
+        sk.WGS84(),
+        solar,
+    )
+
+    assert isinstance(ray, sk.GroundViewingSolar)
+    param_dict = ray_parameters(ray)
+
+    intercept_geo = sk.WGS84()
+    intercept = intercept_geo.altitude_intercepts(
+        0.0, observer_geo.location, look_vector
+    )[0]
+    intercept_geo.from_xyz(intercept)
+
+    expected_viewing_azimuth = -np.rad2deg(
+        np.arctan2(
+            np.dot(look_vector, intercept_geo.local_west),
+            -np.dot(look_vector, intercept_geo.local_south),
+        )
+    )
+
+    np.testing.assert_allclose(param_dict["cos_sza"], np.cos(np.deg2rad(solar_zenith)))
+    np.testing.assert_allclose(
+        param_dict["relative_azimuth_angle"],
+        np.deg2rad(solar_azimuth - expected_viewing_azimuth),
+    )
+    np.testing.assert_allclose(
+        param_dict["cos_viewing_zenith"],
+        -np.dot(look_vector, intercept_geo.local_up),
+    )
+    assert param_dict["cos_viewing_zenith"] > 0
+    np.testing.assert_allclose(param_dict["observer_altitude_m"], 700000.0)
+
+
+def test_ray_conversion_uses_default_solar_handler():
+    time = pd.Timestamp("2020-01-01")
+
+    observer_geo = sk.WGS84()
+    observer_geo.from_lat_lon_alt(20.0, 30.0, 700000.0)
+
+    target_geo = sk.WGS84()
+    target_geo.from_lat_lon_alt(20.0, 30.0, 0.0)
+
+    look_vector = target_geo.location - observer_geo.location
+    ray = sk.viewinggeo.ecef.ecef_to_sasktran2_ray(
+        observer_geo.location, look_vector, time
+    )
+
+    assert isinstance(ray, sk.GroundViewingSolar)
+    param_dict = ray_parameters(ray)
+    np.testing.assert_allclose(param_dict["cos_sza"], 1.0)
+    np.testing.assert_allclose(param_dict["relative_azimuth_angle"], 0.0)


### PR DESCRIPTION
## Summary

- normalize ECEF look vectors and reject non-finite or zero-length inputs
- use the public solar-handler namespace for the documented default behavior
- convert ground-ray viewing azimuths to degrees before combining them with solar azimuths
- reverse the observer-to-ground cosine to the ground-to-observer convention required by `GroundViewingSolar`
- add regression coverage for oblique ground rays, non-unit look vectors, and the default solar handler

## Root cause and impact

`ecef_to_sasktran2_ray` passed an observer-to-ground cosine directly to `GroundViewingSolar`, whose geometry is defined from the ground toward the observer. In spherical geometry this selected the nearly antipodal quadratic solution instead of reconstructing the intended observer position. The ground branch also subtracted a viewing azimuth in radians from a solar azimuth in degrees, collapsing nearly 360 degrees of relative azimuth variation into about 6.28 degrees.

Together these errors produced incorrect ground-ray paths and radiances, while raw `SolarAnglesObserverLocation` rays remained sensible because their negative viewing cosine is defined at the observer.

## Validation

- `pixi run pytest tests/viewing_geometry/test_ray_conversions.py -q` — 3 passed
- `pixi run pre-commit` — passed
- `pixi run test` — 430 passed, 13 skipped
