### PR TITLE
Optimize DISCO derivative calculations

### DIFF
--- a/cpp/include/sktran_disco/sktran_do_linalg.h
+++ b/cpp/include/sktran_disco/sktran_do_linalg.h
@@ -247,20 +247,13 @@ namespace sasktran_disco {
         inline void assign_rhs_d_bvp(int colindex, Eigen::MatrixXd& d_b,
                                      const Eigen::VectorXd& b) {
 
-            // Then subtract off the multiplication terms
-            for (uint i = 0; i < m_data.rows(); ++i) {
-                for (uint j = 0; j < m_data.cols(); ++j) {
-                    d_b(i + m_row_offset, colindex) -=
-                        b[j + m_col_offset] * m_data(i, j);
-                }
-            }
+            d_b.col(colindex).segment(m_row_offset, m_data.rows()).noalias() -=
+                m_data * b.segment(m_col_offset, m_data.cols());
 
-            for (uint i = 0; i < m_upper_data.rows(); ++i) {
-                for (uint j = 0; j < m_upper_data.cols(); ++j) {
-                    d_b(i + m_upper_row_offset, colindex) -=
-                        b[j + m_upper_col_offset] * m_upper_data(i, j);
-                }
-            }
+            d_b.col(colindex)
+                .segment(m_upper_row_offset, m_upper_data.rows())
+                .noalias() -= m_upper_data * b.segment(m_upper_col_offset,
+                                                       m_upper_data.cols());
         }
 
       private:

--- a/cpp/include/sktran_disco/sktran_do_opticallayer.h
+++ b/cpp/include/sktran_disco/sktran_do_opticallayer.h
@@ -206,6 +206,15 @@ namespace sasktran_disco {
         inline HomogType d_streamTransmittance(
             Location loc, AEOrder m, SolutionIndex j, uint derivIndex,
             const LayerInputDerivative<NSTOKES>& deriv) const {
+            return d_streamTransmittance(loc, m, j, derivIndex, deriv,
+                                         streamTransmittance(loc, m, j));
+        }
+
+        inline HomogType
+        d_streamTransmittance(Location loc, AEOrder m, SolutionIndex j,
+                              uint derivIndex,
+                              const LayerInputDerivative<NSTOKES>& deriv,
+                              HomogType stream_transmittance) const {
             if (loc != Location::INSIDE) {
                 abort();
             }
@@ -214,7 +223,7 @@ namespace sasktran_disco {
             return -(m_solutions[m].value.dual_eigval().deriv(derivIndex, j) *
                          M_OPTICAL_THICKNESS +
                      m_solutions[m].value.eigval(j) * d_od) *
-                   streamTransmittance(loc, m, j);
+                   stream_transmittance;
         }
 
         /**
@@ -240,7 +249,8 @@ namespace sasktran_disco {
             // Have no cross derivatives
             for (uint i = 0; i < deriv.numDerivativeLayer(M_INDEX); ++i) {
                 result.deriv[i + derivStart] = d_streamTransmittance(
-                    loc, m, j, i, deriv.layerDerivatives()[derivStart + i]);
+                    loc, m, j, i, deriv.layerDerivatives()[derivStart + i],
+                    result.value);
             }
 
             return result;

--- a/cpp/lib/sktran_disco/sktran_do_rte.cpp
+++ b/cpp/lib/sktran_disco/sktran_do_rte.cpp
@@ -1938,10 +1938,11 @@ void sasktran_disco::RTESolver<NSTOKES, CNSTR>::bvpTOACondition(
 
     for (StreamIndex i = 0; i < N * NSTOKES; ++i) {
         for (SolutionIndex j = 0; j < N * NSTOKES; ++j) {
+            const auto stream_transmittance =
+                layer.streamTransmittance(Location::INSIDE, m, j);
             mat(i, j) = solution.homog_plus(i, j);
             mat(i, j + N * NSTOKES) =
-                solution.homog_minus(i, j) *
-                layer.streamTransmittance(Location::INSIDE, m, j);
+                solution.homog_minus(i, j) * stream_transmittance;
 
             // This condition does not contain any cross derivatives
             for (uint l = 0; l < numDeriv; ++l) {
@@ -1949,12 +1950,12 @@ void sasktran_disco::RTESolver<NSTOKES, CNSTR>::bvpTOACondition(
 
                 d_mat(i, j) = solution.d_homog_plus(i, j, l);
                 d_mat(i, j + N * NSTOKES) =
-                    solution.d_homog_minus(i, j, l) *
-                        layer.streamTransmittance(Location::INSIDE, m, j) +
+                    solution.d_homog_minus(i, j, l) * stream_transmittance +
                     solution.homog_minus(i, j) *
                         layer.d_streamTransmittance(
                             Location::INSIDE, m, j, l,
-                            input_deriv[l + derivStartIndex]);
+                            input_deriv[l + derivStartIndex],
+                            stream_transmittance);
             }
         }
     }
@@ -1990,15 +1991,15 @@ void sasktran_disco::RTESolver<NSTOKES, CNSTR>::bvpContinuityCondition(
     for (StreamIndex i = 0; i < N * NSTOKES; ++i) {
         for (SolutionIndex j = 0, j_top = 0, j_bot = this->M_NSTR * NSTOKES;
              j < N * NSTOKES; ++j, ++j_top, ++j_bot) {
-            mat(i + N * NSTOKES, j_top) =
-                upper.solution.homog_plus(i, j) *
+            const auto upper_stream_transmittance =
                 upper.optical.streamTransmittance(Location::INSIDE, m, j);
+            mat(i + N * NSTOKES, j_top) =
+                upper.solution.homog_plus(i, j) * upper_stream_transmittance;
             mat(i + N * NSTOKES, j_bot) = -lower.solution.homog_plus(i, j);
 
-            mat(i, j_top) =
-                sasktran_disco::stokes_negation_factor<NSTOKES>(i) *
-                upper.solution.homog_minus(i, j) *
-                upper.optical.streamTransmittance(Location::INSIDE, m, j);
+            mat(i, j_top) = sasktran_disco::stokes_negation_factor<NSTOKES>(i) *
+                            upper.solution.homog_minus(i, j) *
+                            upper_stream_transmittance;
             mat(i, j_bot) =
                 -sasktran_disco::stokes_negation_factor<NSTOKES>(i) *
                 lower.solution.homog_minus(i, j);
@@ -2010,22 +2011,22 @@ void sasktran_disco::RTESolver<NSTOKES, CNSTR>::bvpContinuityCondition(
 
                 d_mat(i + N * NSTOKES, j_top) =
                     upper.solution.d_homog_plus(i, j, k) *
-                        upper.optical.streamTransmittance(Location::INSIDE, m,
-                                                          j) +
+                        upper_stream_transmittance +
                     upper.solution.homog_plus(i, j) *
                         upper.optical.d_streamTransmittance(
                             Location::INSIDE, m, j, k,
-                            input_deriv[upper.layerDerivStart + k]);
+                            input_deriv[upper.layerDerivStart + k],
+                            upper_stream_transmittance);
 
                 d_mat(i, j_top) =
                     sasktran_disco::stokes_negation_factor<NSTOKES>(i) *
                     (upper.solution.d_homog_minus(i, j, k) *
-                         upper.optical.streamTransmittance(Location::INSIDE, m,
-                                                           j) +
+                         upper_stream_transmittance +
                      upper.solution.homog_minus(i, j) *
                          upper.optical.d_streamTransmittance(
                              Location::INSIDE, m, j, k,
-                             input_deriv[upper.layerDerivStart + k]));
+                             input_deriv[upper.layerDerivStart + k],
+                             upper_stream_transmittance));
             }
             for (uint k = 0; k < lower.numDeriv; ++k) {
                 auto& d_mat = d_A[lower.layerDerivStart + k].layer();
@@ -2041,17 +2042,17 @@ void sasktran_disco::RTESolver<NSTOKES, CNSTR>::bvpContinuityCondition(
                            j_bot = this->M_NSTR * NSTOKES +
                                    this->M_NSTR / 2 * NSTOKES;
              j < N * NSTOKES; ++j, ++j_top, ++j_bot) {
+            const auto lower_stream_transmittance =
+                lower.optical.streamTransmittance(Location::INSIDE, m, j);
             mat(i + N * NSTOKES, j_top) = upper.solution.homog_minus(i, j);
             mat(i + N * NSTOKES, j_bot) =
-                -lower.solution.homog_minus(i, j) *
-                lower.optical.streamTransmittance(Location::INSIDE, m, j);
+                -lower.solution.homog_minus(i, j) * lower_stream_transmittance;
 
             mat(i, j_top) = sasktran_disco::stokes_negation_factor<NSTOKES>(i) *
                             upper.solution.homog_plus(i, j);
             mat(i, j_bot) =
                 -sasktran_disco::stokes_negation_factor<NSTOKES>(i) *
-                lower.solution.homog_plus(i, j) *
-                lower.optical.streamTransmittance(Location::INSIDE, m, j);
+                lower.solution.homog_plus(i, j) * lower_stream_transmittance;
 
             // We still have no cross derivatives, but we have to treat the
             // derivatives for the upper and lower layers separately
@@ -2060,22 +2061,22 @@ void sasktran_disco::RTESolver<NSTOKES, CNSTR>::bvpContinuityCondition(
 
                 d_mat(i + N * NSTOKES, j_bot) =
                     -lower.solution.d_homog_minus(i, j, k) *
-                        lower.optical.streamTransmittance(Location::INSIDE, m,
-                                                          j) -
+                        lower_stream_transmittance -
                     lower.solution.homog_minus(i, j) *
                         lower.optical.d_streamTransmittance(
                             Location::INSIDE, m, j, k,
-                            input_deriv[lower.layerDerivStart + k]);
+                            input_deriv[lower.layerDerivStart + k],
+                            lower_stream_transmittance);
 
                 d_mat(i, j_bot) =
                     -sasktran_disco::stokes_negation_factor<NSTOKES>(i) *
                     (lower.solution.d_homog_plus(i, j, k) *
-                         lower.optical.streamTransmittance(Location::INSIDE, m,
-                                                           j) +
+                         lower_stream_transmittance +
                      lower.solution.homog_plus(i, j) *
                          lower.optical.d_streamTransmittance(
                              Location::INSIDE, m, j, k,
-                             input_deriv[lower.layerDerivStart + k]));
+                             input_deriv[lower.layerDerivStart + k],
+                             lower_stream_transmittance));
             }
             for (uint k = 0; k < upper.numDeriv; ++k) {
                 auto& d_mat = d_A[upper.layerDerivStart + k].upper();
@@ -2114,10 +2115,11 @@ void sasktran_disco::RTESolver<NSTOKES, CNSTR>::bvpGroundCondition(
     // Build the LHS bottom layer to ground coupling condition
     for (StreamIndex i = 0; i < N * NSTOKES; ++i) {
         for (SolutionIndex j = 0; j < N * NSTOKES; ++j) {
+            const auto stream_transmittance =
+                layer.streamTransmittance(Location::INSIDE, m, j);
             sum_vm = v_minus(m, layer, i, j);
             mat(i, j) = sasktran_disco::stokes_negation_factor<NSTOKES>(i) *
-                        sum_vm *
-                        layer.streamTransmittance(Location::INSIDE, m, j);
+                        sum_vm * stream_transmittance;
 
             sum_vp = v_plus(m, layer, i, j);
             mat(i, j + N * NSTOKES) =
@@ -2130,10 +2132,11 @@ void sasktran_disco::RTESolver<NSTOKES, CNSTR>::bvpGroundCondition(
                                   input_deriv[layerDerivStart + k]);
                 d_mat(i, j) =
                     sasktran_disco::stokes_negation_factor<NSTOKES>(i) *
-                    (d_sum * layer.streamTransmittance(Location::INSIDE, m, j) +
+                    (d_sum * stream_transmittance +
                      sum_vm * layer.d_streamTransmittance(
                                   Location::INSIDE, m, j, k,
-                                  input_deriv[layerDerivStart + k]));
+                                  input_deriv[layerDerivStart + k],
+                                  stream_transmittance));
 
                 d_sum = d_v_plus(m, layer, i, j, k,
                                  input_deriv[layerDerivStart + k]);


### PR DESCRIPTION
## Summary

- Reuse already-computed stream transmittances throughout DISCO boundary-value derivative assembly.
- Replace scalar nested loops for the derivative BVP right-hand side with Eigen matrix-vector operations.
- Preserve the existing `d_streamTransmittance` overload for source compatibility.

## Motivation

Forward and reverse derivative calculations repeated stream-transmittance exponentials and assembled dense derivative products element by element. These small changes remove that duplicate work while leaving the derivative equations unchanged.

## Performance

The benchmark used one thread, 101 samples per case, and reports lower-decile timings against the original `main` binary.

| Workload | Forward | Reverse |
| --- | ---: | ---: |
| Scalar, 8 streams, 40 layers, 1 LOS | 17.227 to 16.786 ms (2.6% faster) | 5.987 to 5.515 ms (7.9% faster) |
| Scalar, 16 streams, 20 layers, 1 LOS | 56.812 to 55.296 ms (2.7% faster) | 28.197 to 26.983 ms (4.3% faster) |
| Scalar, 8 streams, 40 layers, 16 LOS | 18.339 to 17.771 ms (3.1% faster) | 10.828 to 10.248 ms (5.4% faster) |
| Polarized, 4 streams, 20 layers, 1 LOS | 11.553 to 10.926 ms (5.4% faster) | 7.168 to 6.584 ms (8.1% faster) |

Several other candidate micro-optimizations were benchmarked independently and omitted because they did not produce consistent improvements.

## Validation

- `pixi run build`
- `pixi run pytest tests/weightingfunctions/test_lowlevel.py -q -k 'wf_extinction or wf_ssa or wf_legendre'` (3 passed)
- `pixi run pre-commit`
