### PR TITLE
Add radiance JVP and VJP interface

### DIFF
--- a/cpp/c_api/atmosphere.cpp
+++ b/cpp/c_api/atmosphere.cpp
@@ -470,6 +470,42 @@ int sk_atmosphere_apply_delta_m_scaling(Atmosphere* atmosphere, int order) {
     return 0;
 }
 
+int sk_atmosphere_mark_changed(Atmosphere* atmosphere) {
+    if (atmosphere == nullptr || atmosphere->impl == nullptr) {
+        return -1;
+    }
+    if (auto* impl = dynamic_cast<sasktran2::atmosphere::Atmosphere<1>*>(
+            atmosphere->impl.get())) {
+        impl->mark_changed();
+        return 0;
+    }
+    if (auto* impl = dynamic_cast<sasktran2::atmosphere::Atmosphere<3>*>(
+            atmosphere->impl.get())) {
+        impl->mark_changed();
+        return 0;
+    }
+    return -2;
+}
+
+int sk_atmosphere_get_revision(Atmosphere* atmosphere,
+                               unsigned long long* revision) {
+    if (atmosphere == nullptr || atmosphere->impl == nullptr ||
+        revision == nullptr) {
+        return -1;
+    }
+    if (auto* impl = dynamic_cast<sasktran2::atmosphere::Atmosphere<1>*>(
+            atmosphere->impl.get())) {
+        *revision = static_cast<unsigned long long>(impl->revision());
+        return 0;
+    }
+    if (auto* impl = dynamic_cast<sasktran2::atmosphere::Atmosphere<3>*>(
+            atmosphere->impl.get())) {
+        *revision = static_cast<unsigned long long>(impl->revision());
+        return 0;
+    }
+    return -2;
+}
+
 int sk_atmosphere_storage_finalize_scattering_derivatives(
     AtmosphereStorage* storage) {
     if (storage == nullptr) {

--- a/cpp/c_api/deriv_mapping.cpp
+++ b/cpp/c_api/deriv_mapping.cpp
@@ -135,6 +135,16 @@ int sk_deriv_mapping_set_log_radiance_space(DerivativeMapping* mapping,
     return 0;
 }
 
+int sk_deriv_mapping_get_log_radiance_space(DerivativeMapping* mapping,
+                                            int* log_radiance_space) {
+    if (mapping == nullptr || mapping->impl == nullptr ||
+        log_radiance_space == nullptr) {
+        return -1;
+    }
+    *log_radiance_space = mapping->impl->log_radiance_space() ? 1 : 0;
+    return 0;
+}
+
 int sk_deriv_mapping_is_scattering_derivative(DerivativeMapping* mapping,
                                               int* is_scattering_derivative) {
     if (mapping == nullptr) {

--- a/cpp/c_api/engine.cpp
+++ b/cpp/c_api/engine.cpp
@@ -168,6 +168,94 @@ int sk_engine_supports_linearization(Engine* engine, int mode, int* supported) {
     }
 }
 
+int sk_engine_linearization_backend(Engine* engine, int mode, int* backend) {
+    try {
+        if (engine == nullptr || !engine->impl || backend == nullptr) {
+            return -1;
+        }
+        if (mode < static_cast<int>(sasktran2::LinearizationMode::Jacobian) ||
+            mode > static_cast<int>(sasktran2::LinearizationMode::VJP)) {
+            return -2;
+        }
+        const auto linearization_mode =
+            static_cast<sasktran2::LinearizationMode>(mode);
+        if (engine->_config->impl.num_stokes() == 1) {
+            auto* impl = dynamic_cast<Sasktran2<1>*>(engine->impl.get());
+            *backend = static_cast<int>(
+                impl->linearization_backend(linearization_mode));
+            return 0;
+        }
+        if (engine->_config->impl.num_stokes() == 3) {
+            auto* impl = dynamic_cast<Sasktran2<3>*>(engine->impl.get());
+            *backend = static_cast<int>(
+                impl->linearization_backend(linearization_mode));
+            return 0;
+        }
+        return -2;
+    } catch (const std::exception&) {
+        return -3;
+    }
+}
+
+int sk_engine_calculate_jvp(Engine* engine, Atmosphere* atmosphere,
+                            OutputJVP* output) {
+    if (engine == nullptr || atmosphere == nullptr || output == nullptr) {
+        return -1;
+    }
+    try {
+        if (engine->_config->impl.num_stokes() == 1) {
+            auto* impl = dynamic_cast<Sasktran2<1>*>(engine->impl.get());
+            impl->calculate_radiance(
+                *static_cast<sasktran2::atmosphere::Atmosphere<1>*>(
+                    atmosphere->impl.get()),
+                *static_cast<sasktran2::Output<1>*>(output->impl.get()));
+            return 0;
+        }
+        if (engine->_config->impl.num_stokes() == 3) {
+            auto* impl = dynamic_cast<Sasktran2<3>*>(engine->impl.get());
+            impl->calculate_radiance(
+                *static_cast<sasktran2::atmosphere::Atmosphere<3>*>(
+                    atmosphere->impl.get()),
+                *static_cast<sasktran2::Output<3>*>(output->impl.get()));
+            return 0;
+        }
+        return -2;
+    } catch (const std::exception&) {
+        return -3;
+    }
+}
+
+int sk_engine_calculate_vjp(Engine* engine, Atmosphere* atmosphere,
+                            OutputVJP* output) {
+    if (engine == nullptr || atmosphere == nullptr || output == nullptr) {
+        return -1;
+    }
+    try {
+        int result = -2;
+        if (engine->_config->impl.num_stokes() == 1) {
+            auto* impl = dynamic_cast<Sasktran2<1>*>(engine->impl.get());
+            impl->calculate_radiance(
+                *static_cast<sasktran2::atmosphere::Atmosphere<1>*>(
+                    atmosphere->impl.get()),
+                *static_cast<sasktran2::Output<1>*>(output->impl.get()));
+            result = 0;
+        } else if (engine->_config->impl.num_stokes() == 3) {
+            auto* impl = dynamic_cast<Sasktran2<3>*>(engine->impl.get());
+            impl->calculate_radiance(
+                *static_cast<sasktran2::atmosphere::Atmosphere<3>*>(
+                    atmosphere->impl.get()),
+                *static_cast<sasktran2::Output<3>*>(output->impl.get()));
+            result = 0;
+        }
+        if (result == 0) {
+            result = output->finalize();
+        }
+        return result;
+    } catch (const std::exception&) {
+        return -3;
+    }
+}
+
 int sk_engine_calculate_radiance_block_thread(Engine* engine, OutputC* output,
                                               int wavelength_start,
                                               int wavelength_count,

--- a/cpp/c_api/engine.cpp
+++ b/cpp/c_api/engine.cpp
@@ -138,6 +138,36 @@ int sk_engine_effective_wavelength_batch_size(Engine* engine,
     }
 }
 
+int sk_engine_supports_linearization(Engine* engine, int mode, int* supported) {
+    try {
+        if (engine == nullptr || !engine->impl || supported == nullptr) {
+            return -1;
+        }
+        if (mode < static_cast<int>(sasktran2::LinearizationMode::Jacobian) ||
+            mode > static_cast<int>(sasktran2::LinearizationMode::VJP)) {
+            return -2;
+        }
+
+        const auto linearization_mode =
+            static_cast<sasktran2::LinearizationMode>(mode);
+        if (engine->_config->impl.num_stokes() == 1) {
+            auto* impl = dynamic_cast<Sasktran2<1>*>(engine->impl.get());
+            *supported =
+                impl->supports_linearization(linearization_mode) ? 1 : 0;
+            return 0;
+        }
+        if (engine->_config->impl.num_stokes() == 3) {
+            auto* impl = dynamic_cast<Sasktran2<3>*>(engine->impl.get());
+            *supported =
+                impl->supports_linearization(linearization_mode) ? 1 : 0;
+            return 0;
+        }
+        return -2;
+    } catch (const std::exception&) {
+        return -3;
+    }
+}
+
 int sk_engine_calculate_radiance_block_thread(Engine* engine, OutputC* output,
                                               int wavelength_start,
                                               int wavelength_count,

--- a/cpp/c_api/output.cpp
+++ b/cpp/c_api/output.cpp
@@ -19,6 +19,112 @@ OutputC::OutputC(double* radiance, int nrad, int nstokes, double* flux,
     }
 }
 
+OutputJVP::OutputJVP(double* radiance, double* jvp, int nrad, int nstokes) {
+    Eigen::Map<Eigen::VectorXd> radiance_map(radiance, nrad * nstokes);
+    Eigen::Map<Eigen::VectorXd> jvp_map(jvp, nrad * nstokes);
+    if (nstokes == 1) {
+        impl = std::make_unique<sasktran2::OutputJVP<1>>(radiance_map, jvp_map);
+    } else if (nstokes == 3) {
+        impl = std::make_unique<sasktran2::OutputJVP<3>>(radiance_map, jvp_map);
+    }
+}
+
+int OutputJVP::assign_derivative_tangent(const char* name,
+                                         const double* tangent, int nparam) {
+    if (impl == nullptr || tangent == nullptr || nparam < 0) {
+        return -1;
+    }
+    Eigen::Map<const Eigen::VectorXd> tangent_map(tangent, nparam);
+    if (auto* output = dynamic_cast<sasktran2::OutputJVP<1>*>(impl.get())) {
+        output->set_derivative_tangent(name, tangent_map);
+        return 0;
+    }
+    if (auto* output = dynamic_cast<sasktran2::OutputJVP<3>*>(impl.get())) {
+        output->set_derivative_tangent(name, tangent_map);
+        return 0;
+    }
+    return -2;
+}
+
+int OutputJVP::assign_surface_tangent(const char* name, const double* tangent,
+                                      int nparam) {
+    if (impl == nullptr || tangent == nullptr || nparam < 0) {
+        return -1;
+    }
+    Eigen::Map<const Eigen::VectorXd> tangent_map(tangent, nparam);
+    if (auto* output = dynamic_cast<sasktran2::OutputJVP<1>*>(impl.get())) {
+        output->set_surface_tangent(name, tangent_map);
+        return 0;
+    }
+    if (auto* output = dynamic_cast<sasktran2::OutputJVP<3>*>(impl.get())) {
+        output->set_surface_tangent(name, tangent_map);
+        return 0;
+    }
+    return -2;
+}
+
+OutputVJP::OutputVJP(double* radiance, const double* cotangent, int nrad,
+                     int nstokes) {
+    Eigen::Map<Eigen::VectorXd> radiance_map(radiance, nrad * nstokes);
+    Eigen::Map<const Eigen::VectorXd> cotangent_map(cotangent, nrad * nstokes);
+    if (nstokes == 1) {
+        impl = std::make_unique<sasktran2::OutputVJP<1>>(radiance_map,
+                                                         cotangent_map);
+    } else if (nstokes == 3) {
+        impl = std::make_unique<sasktran2::OutputVJP<3>>(radiance_map,
+                                                         cotangent_map);
+    }
+}
+
+int OutputVJP::assign_derivative_gradient(const char* name, double* gradient,
+                                          int nparam) {
+    if (impl == nullptr || gradient == nullptr || nparam < 0) {
+        return -1;
+    }
+    Eigen::Map<Eigen::VectorXd> gradient_map(gradient, nparam);
+    if (auto* output = dynamic_cast<sasktran2::OutputVJP<1>*>(impl.get())) {
+        output->set_derivative_gradient_memory(name, gradient_map);
+        return 0;
+    }
+    if (auto* output = dynamic_cast<sasktran2::OutputVJP<3>*>(impl.get())) {
+        output->set_derivative_gradient_memory(name, gradient_map);
+        return 0;
+    }
+    return -2;
+}
+
+int OutputVJP::assign_surface_gradient(const char* name, double* gradient,
+                                       int nparam) {
+    if (impl == nullptr || gradient == nullptr || nparam < 0) {
+        return -1;
+    }
+    Eigen::Map<Eigen::VectorXd> gradient_map(gradient, nparam);
+    if (auto* output = dynamic_cast<sasktran2::OutputVJP<1>*>(impl.get())) {
+        output->set_surface_gradient_memory(name, gradient_map);
+        return 0;
+    }
+    if (auto* output = dynamic_cast<sasktran2::OutputVJP<3>*>(impl.get())) {
+        output->set_surface_gradient_memory(name, gradient_map);
+        return 0;
+    }
+    return -2;
+}
+
+int OutputVJP::finalize() {
+    if (impl == nullptr) {
+        return -1;
+    }
+    if (auto* output = dynamic_cast<sasktran2::OutputVJP<1>*>(impl.get())) {
+        output->finalize();
+        return 0;
+    }
+    if (auto* output = dynamic_cast<sasktran2::OutputVJP<3>*>(impl.get())) {
+        output->finalize();
+        return 0;
+    }
+    return -2;
+}
+
 int OutputC::assign_derivative_memory(const char* name,
                                       double* derivative_mapping, int nrad,
                                       int nstokes, int nderiv) {
@@ -194,5 +300,52 @@ int sk_output_get_los_optical_depth(OutputC* output, double** od) {
         // Handle error case
         return -1;
     }
+}
+
+OutputJVP* sk_output_jvp_create(double* radiance, double* jvp, int nrad,
+                                int nstokes) {
+    return new OutputJVP(radiance, jvp, nrad, nstokes);
+}
+
+void sk_output_jvp_destroy(OutputJVP* output) { delete output; }
+
+int sk_output_jvp_assign_derivative_tangent(OutputJVP* output, const char* name,
+                                            const double* tangent, int nparam) {
+    return output == nullptr
+               ? -1
+               : output->assign_derivative_tangent(name, tangent, nparam);
+}
+
+int sk_output_jvp_assign_surface_tangent(OutputJVP* output, const char* name,
+                                         const double* tangent, int nparam) {
+    return output == nullptr
+               ? -1
+               : output->assign_surface_tangent(name, tangent, nparam);
+}
+
+OutputVJP* sk_output_vjp_create(double* radiance, const double* cotangent,
+                                int nrad, int nstokes) {
+    return new OutputVJP(radiance, cotangent, nrad, nstokes);
+}
+
+void sk_output_vjp_destroy(OutputVJP* output) { delete output; }
+
+int sk_output_vjp_assign_derivative_gradient(OutputVJP* output,
+                                             const char* name, double* gradient,
+                                             int nparam) {
+    return output == nullptr
+               ? -1
+               : output->assign_derivative_gradient(name, gradient, nparam);
+}
+
+int sk_output_vjp_assign_surface_gradient(OutputVJP* output, const char* name,
+                                          double* gradient, int nparam) {
+    return output == nullptr
+               ? -1
+               : output->assign_surface_gradient(name, gradient, nparam);
+}
+
+int sk_output_vjp_finalize(OutputVJP* output) {
+    return output == nullptr ? -1 : output->finalize();
 }
 }

--- a/cpp/include/c_api/atmosphere.h
+++ b/cpp/include/c_api/atmosphere.h
@@ -149,6 +149,11 @@ void sk_atmosphere_destroy(Atmosphere* atmosphere);
 
 int sk_atmosphere_apply_delta_m_scaling(Atmosphere* atmosphere, int order);
 
+int sk_atmosphere_mark_changed(Atmosphere* atmosphere);
+
+int sk_atmosphere_get_revision(Atmosphere* atmosphere,
+                               unsigned long long* revision);
+
 // ---------------------
 // SURFACE METHODS
 // ---------------------

--- a/cpp/include/c_api/deriv_mapping.h
+++ b/cpp/include/c_api/deriv_mapping.h
@@ -35,6 +35,8 @@ int sk_deriv_mapping_set_assign_name(DerivativeMapping* mapping,
                                      const char* name);
 int sk_deriv_mapping_set_log_radiance_space(DerivativeMapping* mapping,
                                             int log_radiance_space);
+int sk_deriv_mapping_get_log_radiance_space(DerivativeMapping* mapping,
+                                            int* log_radiance_space);
 int sk_deriv_mapping_is_scattering_derivative(DerivativeMapping* mapping,
                                               int* is_scattering_derivative);
 

--- a/cpp/include/c_api/engine.h
+++ b/cpp/include/c_api/engine.h
@@ -22,6 +22,7 @@ int sk_engine_calculate_radiance(Engine* engine, Atmosphere* atmosphere,
                                  OutputC* output, int only_initialize);
 int sk_engine_effective_wavelength_batch_size(Engine* engine,
                                               int num_wavelengths);
+int sk_engine_supports_linearization(Engine* engine, int mode, int* supported);
 int sk_engine_calculate_radiance_block_thread(Engine* engine, OutputC* output,
                                               int wavelength_start,
                                               int wavelength_count,

--- a/cpp/include/c_api/engine.h
+++ b/cpp/include/c_api/engine.h
@@ -11,6 +11,8 @@ typedef struct Geometry1D Geometry1D;
 typedef struct Geometry2D Geometry2D;
 typedef struct ViewingGeometry ViewingGeometry;
 typedef struct OutputC OutputC;
+typedef struct OutputJVP OutputJVP;
+typedef struct OutputVJP OutputVJP;
 
 Engine* sk_engine_create(Config* engine, Geometry1D* geometry,
                          ViewingGeometry* viewing_geometry);
@@ -23,6 +25,11 @@ int sk_engine_calculate_radiance(Engine* engine, Atmosphere* atmosphere,
 int sk_engine_effective_wavelength_batch_size(Engine* engine,
                                               int num_wavelengths);
 int sk_engine_supports_linearization(Engine* engine, int mode, int* supported);
+int sk_engine_linearization_backend(Engine* engine, int mode, int* backend);
+int sk_engine_calculate_jvp(Engine* engine, Atmosphere* atmosphere,
+                            OutputJVP* output);
+int sk_engine_calculate_vjp(Engine* engine, Atmosphere* atmosphere,
+                            OutputVJP* output);
 int sk_engine_calculate_radiance_block_thread(Engine* engine, OutputC* output,
                                               int wavelength_start,
                                               int wavelength_count,

--- a/cpp/include/c_api/internal_types.h
+++ b/cpp/include/c_api/internal_types.h
@@ -98,6 +98,26 @@ struct OutputC {
                                               int nrad);
 };
 
+struct OutputJVP {
+    std::unique_ptr<sasktran2::OutputInterface> impl;
+
+    OutputJVP(double* radiance, double* jvp, int nrad, int nstokes);
+    int assign_derivative_tangent(const char* name, const double* tangent,
+                                  int nparam);
+    int assign_surface_tangent(const char* name, const double* tangent,
+                               int nparam);
+};
+
+struct OutputVJP {
+    std::unique_ptr<sasktran2::OutputInterface> impl;
+
+    OutputVJP(double* radiance, const double* cotangent, int nrad, int nstokes);
+    int assign_derivative_gradient(const char* name, double* gradient,
+                                   int nparam);
+    int assign_surface_gradient(const char* name, double* gradient, int nparam);
+    int finalize();
+};
+
 struct ViewingGeometry {
     sasktran2::viewinggeometry::ViewingGeometryContainer impl;
 

--- a/cpp/include/c_api/output.h
+++ b/cpp/include/c_api/output.h
@@ -5,6 +5,8 @@ extern "C" {
 #endif
 
 typedef struct OutputC OutputC;
+typedef struct OutputJVP OutputJVP;
+typedef struct OutputVJP OutputVJP;
 
 OutputC* sk_output_create(double* radiance, int nrad, int nstokes, double* flux,
                           int nflux);
@@ -29,6 +31,24 @@ int sk_output_assign_surface_flux_derivative_memory(OutputC* output,
                                                     int nrad);
 
 int sk_output_get_los_optical_depth(OutputC* output, double** od);
+
+OutputJVP* sk_output_jvp_create(double* radiance, double* jvp, int nrad,
+                                int nstokes);
+void sk_output_jvp_destroy(OutputJVP* output);
+int sk_output_jvp_assign_derivative_tangent(OutputJVP* output, const char* name,
+                                            const double* tangent, int nparam);
+int sk_output_jvp_assign_surface_tangent(OutputJVP* output, const char* name,
+                                         const double* tangent, int nparam);
+
+OutputVJP* sk_output_vjp_create(double* radiance, const double* cotangent,
+                                int nrad, int nstokes);
+void sk_output_vjp_destroy(OutputVJP* output);
+int sk_output_vjp_assign_derivative_gradient(OutputVJP* output,
+                                             const char* name, double* gradient,
+                                             int nparam);
+int sk_output_vjp_assign_surface_gradient(OutputVJP* output, const char* name,
+                                          double* gradient, int nparam);
+int sk_output_vjp_finalize(OutputVJP* output);
 
 #ifdef __cplusplus
 }

--- a/cpp/include/sasktran2/atmosphere/atmosphere.h
+++ b/cpp/include/sasktran2/atmosphere/atmosphere.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../geometry.h"
+#include <cstdint>
 #include <sasktran2/config.h>
 #include <sasktran2/atmosphere/grid_storage.h>
 #include <sasktran2/atmosphere/surface.h>
@@ -36,6 +37,8 @@ namespace sasktran2::atmosphere {
                                          derivatives */
         bool m_include_emission_derivatives; /** True if we are going to include
                                                 emission derivatives */
+        std::uint64_t m_revision = 0; /** Monotonic revision of the built native
+                                         atmosphere state. */
 
       public:
         /** Directly constructs the atmosphere from it's base objects, taking
@@ -142,5 +145,11 @@ namespace sasktran2::atmosphere {
         bool include_emission_derivatives() const {
             return m_include_emission_derivatives;
         }
+
+        /** Marks the native atmosphere state as changed. */
+        void mark_changed() { ++m_revision; }
+
+        /** Revision of the native atmosphere state. */
+        std::uint64_t revision() const { return m_revision; }
     };
 } // namespace sasktran2::atmosphere

--- a/cpp/include/sasktran2/derivative_mapping.h
+++ b/cpp/include/sasktran2/derivative_mapping.h
@@ -366,6 +366,10 @@ namespace sasktran2 {
             return m_interpolator;
         }
 
+        const std::optional<Eigen::MatrixXd>& get_interpolator_const() const {
+            return m_interpolator;
+        }
+
         /**
          * @brief Set the interpolator object
          *

--- a/cpp/include/sasktran2/engine.h
+++ b/cpp/include/sasktran2/engine.h
@@ -141,6 +141,13 @@ template <int NSTOKES> class Sasktran2 : public Sasktran2Interface {
 
     int effective_wavelength_batch_size(int num_wavelengths) const;
 
+    /** Reports whether the complete line-of-sight model supports a native
+     * derivative execution mode. */
+    bool supports_linearization(sasktran2::LinearizationMode mode) const {
+        return m_source_integrator->supports_linearization(mode,
+                                                           m_los_source_terms);
+    }
+
     void
     calculate_radiance_block_thread(sasktran2::Output<NSTOKES>& output,
                                     const sasktran2::WavelengthBlock<>& batch,

--- a/cpp/include/sasktran2/engine.h
+++ b/cpp/include/sasktran2/engine.h
@@ -148,6 +148,19 @@ template <int NSTOKES> class Sasktran2 : public Sasktran2Interface {
                                                            m_los_source_terms);
     }
 
+    /** Selects the best executable backend for a derivative product. */
+    sasktran2::LinearizationBackend
+    linearization_backend(sasktran2::LinearizationMode mode) const {
+        if (supports_linearization(mode)) {
+            return sasktran2::LinearizationBackend::Native;
+        }
+        if (mode != sasktran2::LinearizationMode::Jacobian &&
+            supports_linearization(sasktran2::LinearizationMode::Jacobian)) {
+            return sasktran2::LinearizationBackend::StreamingJacobian;
+        }
+        return sasktran2::LinearizationBackend::Unavailable;
+    }
+
     void
     calculate_radiance_block_thread(sasktran2::Output<NSTOKES>& output,
                                     const sasktran2::WavelengthBlock<>& batch,

--- a/cpp/include/sasktran2/output.h
+++ b/cpp/include/sasktran2/output.h
@@ -306,4 +306,91 @@ namespace sasktran2 {
                     int fluxidx, int wavelidx, int threadidx,
                     int flux_type_idx) override;
     };
+
+    /** Output adapter that contracts each native radiance derivative row with
+     * one labeled parameter direction without storing a Jacobian. */
+    template <int NSTOKES> class OutputJVP : public Output<NSTOKES> {
+      private:
+        Eigen::Map<Eigen::VectorXd> m_radiance;
+        Eigen::Map<Eigen::VectorXd> m_jvp;
+        std::map<std::string, Eigen::VectorXd> m_derivative_tangents;
+        std::map<std::string, Eigen::VectorXd> m_surface_tangents;
+        std::vector<Eigen::MatrixXd> m_native_thread_storage;
+        std::vector<Eigen::MatrixXd> m_mapped_thread_storage;
+
+        void resize();
+
+        template <typename Radiance>
+        void assign_lane(const Radiance& radiance, int losidx, int wavelidx,
+                         int threadidx);
+
+      public:
+        OutputJVP(Eigen::Map<Eigen::VectorXd> radiance,
+                  Eigen::Map<Eigen::VectorXd> jvp)
+            : m_radiance(radiance), m_jvp(jvp) {}
+
+        void set_derivative_tangent(const std::string& name,
+                                    Eigen::Ref<const Eigen::VectorXd> tangent) {
+            m_derivative_tangents[name] = tangent;
+        }
+
+        void set_surface_tangent(const std::string& name,
+                                 Eigen::Ref<const Eigen::VectorXd> tangent) {
+            m_surface_tangents[name] = tangent;
+        }
+
+        void assign(const sasktran2::WavelengthBlock<>& block,
+                    const sasktran2::WavelengthBlockDual<NSTOKES>& radiance,
+                    int losidx, int threadidx) override;
+
+        void assign_flux(
+            const sasktran2::Dual<double, sasktran2::dualstorage::dense, 1>&,
+            int, int, int, int) override {}
+    };
+
+    /** Output adapter that contracts radiance cotangents with each native
+     * derivative row and accumulates labeled parameter gradients. */
+    template <int NSTOKES> class OutputVJP : public Output<NSTOKES> {
+      private:
+        Eigen::Map<Eigen::VectorXd> m_radiance;
+        Eigen::Map<const Eigen::VectorXd> m_cotangent;
+        std::map<std::string, Eigen::Map<Eigen::VectorXd>>
+            m_derivative_gradients;
+        std::map<std::string, Eigen::Map<Eigen::VectorXd>> m_surface_gradients;
+        std::vector<std::map<std::string, Eigen::VectorXd>>
+            m_thread_derivative_gradients;
+        std::vector<std::map<std::string, Eigen::VectorXd>>
+            m_thread_surface_gradients;
+        std::vector<Eigen::MatrixXd> m_native_thread_storage;
+
+        void resize();
+
+        template <typename Radiance>
+        void assign_lane(const Radiance& radiance, int losidx, int wavelidx,
+                         int threadidx);
+
+      public:
+        OutputVJP(Eigen::Map<Eigen::VectorXd> radiance,
+                  Eigen::Map<const Eigen::VectorXd> cotangent)
+            : m_radiance(radiance), m_cotangent(cotangent) {}
+
+        void set_derivative_gradient_memory(
+            const std::string& name,
+            Eigen::Map<Eigen::VectorXd> derivative_gradient);
+
+        void set_surface_gradient_memory(
+            const std::string& name,
+            Eigen::Map<Eigen::VectorXd> derivative_gradient);
+
+        void assign(const sasktran2::WavelengthBlock<>& block,
+                    const sasktran2::WavelengthBlockDual<NSTOKES>& radiance,
+                    int losidx, int threadidx) override;
+
+        void assign_flux(
+            const sasktran2::Dual<double, sasktran2::dualstorage::dense, 1>&,
+            int, int, int, int) override {}
+
+        /** Reduces thread-local gradient accumulation into caller memory. */
+        void finalize();
+    };
 } // namespace sasktran2

--- a/cpp/include/sasktran2/source_integrator.h
+++ b/cpp/include/sasktran2/source_integrator.h
@@ -3,6 +3,7 @@
 #include <sasktran2/internal_common.h>
 #include <sasktran2/raytracing.h>
 #include <sasktran2/source_interface.h>
+#include <algorithm>
 
 namespace sasktran2 {
 
@@ -137,6 +138,22 @@ namespace sasktran2 {
          * active source can report its derivative sparsity exactly. */
         void initialize_derivative_sparsity(
             const std::vector<SourceTermInterface<NSTOKES>*>& source_terms);
+
+        /** Returns true when the integrator and every active source implement
+         * the requested native derivative execution mode. */
+        bool
+        supports_linearization(sasktran2::LinearizationMode mode,
+                               const std::vector<SourceTermInterface<NSTOKES>*>&
+                                   source_terms) const {
+            if (mode != sasktran2::LinearizationMode::Jacobian) {
+                return false;
+            }
+            return std::all_of(
+                source_terms.begin(), source_terms.end(),
+                [mode](const SourceTermInterface<NSTOKES>* source) {
+                    return source->supports_linearization(mode);
+                });
+        }
 
         /** Integrates the source terms and stores the result in radiance
          *

--- a/cpp/include/sasktran2/source_interface.h
+++ b/cpp/include/sasktran2/source_interface.h
@@ -15,6 +15,11 @@ namespace sasktran2 {
      * implement. Capability reporting is kept separate from execution so
      * specialized JVP/VJP interfaces can be added without placeholder hooks. */
     enum class LinearizationMode { Jacobian = 0, JVP = 1, VJP = 2 };
+    enum class LinearizationBackend {
+        Unavailable = 0,
+        StreamingJacobian = 1,
+        Native = 2
+    };
 } // namespace sasktran2
 
 /** Base interface class that provides source term functionality to the Engine

--- a/cpp/include/sasktran2/source_interface.h
+++ b/cpp/include/sasktran2/source_interface.h
@@ -10,7 +10,12 @@
 
 namespace sasktran2 {
     template <int NSTOKES> class SourceIntegrator;
-}
+
+    /** Native derivative execution modes that an engine component may
+     * implement. Capability reporting is kept separate from execution so
+     * specialized JVP/VJP interfaces can be added without placeholder hooks. */
+    enum class LinearizationMode { Jacobian = 0, JVP = 1, VJP = 2 };
+} // namespace sasktran2
 
 /** Base interface class that provides source term functionality to the Engine
  *
@@ -211,6 +216,12 @@ template <int NSTOKES> class SourceTermInterface {
 
     /** Returns true when the source contributes within atmospheric layers. */
     virtual bool has_interior_source() const { return true; }
+
+    /** Reports native support for a derivative execution mode. */
+    virtual bool
+    supports_linearization(sasktran2::LinearizationMode mode) const {
+        return mode == sasktran2::LinearizationMode::Jacobian;
+    }
 
     /** Returns whether this source supports the requested atmosphere
      * dimensionality. Sources without an interior contribution are independent

--- a/cpp/lib/CMakeLists.txt
+++ b/cpp/lib/CMakeLists.txt
@@ -45,6 +45,7 @@ add_library(
   output/outputsensor.cpp
   output/outputderivmapped.cpp
   output/outputc.cpp
+  output/outputlinearization.cpp
   engine/engine.cpp
   hr/diffuse_point.cpp
   hr/diffuse_table.cpp

--- a/cpp/lib/output/outputlinearization.cpp
+++ b/cpp/lib/output/outputlinearization.cpp
@@ -1,0 +1,384 @@
+#include "sasktran2/output.h"
+
+namespace sasktran2 {
+    namespace {
+        template <int NSTOKES, typename Radiance>
+        void mapped_volume_derivatives(
+            const Radiance& radiance,
+            const sasktran2::DerivativeMapping& mapping, int wavelidx,
+            int ngeometry, int num_scattering_groups,
+            bool include_emission_derivatives, Eigen::MatrixXd& native) {
+            const auto d_rad_by_ssa = radiance.d_ssa(ngeometry);
+            const auto d_rad_by_extinction = radiance.d_extinction(ngeometry);
+            const auto& d_ssa = mapping.native_mapping().d_ssa.value();
+            const auto& d_extinction =
+                mapping.native_mapping().d_extinction.value();
+
+            for (int stokes = 0; stokes < NSTOKES; ++stokes) {
+                native.row(stokes).array() =
+                    d_ssa.col(wavelidx).transpose().array() *
+                        d_rad_by_ssa(stokes, Eigen::placeholders::all).array() +
+                    d_extinction.col(wavelidx).transpose().array() *
+                        d_rad_by_extinction(stokes, Eigen::placeholders::all)
+                            .array();
+            }
+
+            if (mapping.is_scattering_derivative()) {
+                const auto d_rad_by_scattering = radiance.d_scatterer(
+                    ngeometry, mapping.get_scattering_index());
+                const auto& scattering_factor =
+                    mapping.native_mapping().scat_factor.value();
+                for (int stokes = 0; stokes < NSTOKES; ++stokes) {
+                    native.row(stokes).array() +=
+                        scattering_factor.col(wavelidx).transpose().array() *
+                        d_rad_by_scattering(stokes, Eigen::placeholders::all)
+                            .array();
+                }
+            }
+
+            if (mapping.native_mapping().d_emission.has_value() &&
+                include_emission_derivatives) {
+                const auto d_rad_by_emission =
+                    radiance.d_emission(ngeometry, num_scattering_groups);
+                const auto& d_emission =
+                    mapping.native_mapping().d_emission.value();
+                native.row(0).array() +=
+                    d_emission.col(wavelidx).transpose().array() *
+                    d_rad_by_emission(0, Eigen::placeholders::all).array();
+            }
+        }
+
+        template <int NSTOKES, typename Radiance>
+        Eigen::Matrix<double, NSTOKES, 1> mapped_surface_derivative(
+            const Radiance& radiance,
+            const sasktran2::SurfaceDerivativeMapping& mapping, int wavelidx,
+            int ngeometry, int num_source_groups, int num_surface_derivatives,
+            int surface_emission_index, bool include_emission_derivatives) {
+            Eigen::Matrix<double, NSTOKES, 1> result;
+            result.setZero();
+            if (mapping.native_surface_mapping().d_brdf.has_value()) {
+                const auto d_rad_by_surface = radiance.d_brdf(
+                    ngeometry, num_source_groups, num_surface_derivatives);
+                for (int stokes = 0; stokes < NSTOKES; ++stokes) {
+                    result(stokes) =
+                        d_rad_by_surface(stokes, Eigen::placeholders::all)
+                            .dot(mapping.native_surface_mapping()
+                                     .d_brdf.value()
+                                     .row(wavelidx));
+                }
+            }
+            if (mapping.native_surface_mapping().d_emission.has_value() &&
+                include_emission_derivatives) {
+                result(0) +=
+                    radiance.deriv(0, surface_emission_index) *
+                    mapping.native_surface_mapping().d_emission.value()(
+                        wavelidx, 0);
+            }
+            return result;
+        }
+
+        template <int NSTOKES>
+        Eigen::Matrix<double, NSTOKES, 1>
+        rotate_stokes(const Eigen::Matrix<double, NSTOKES, 1>& value, double c,
+                      double s) {
+            auto result = value;
+            if constexpr (NSTOKES >= 3) {
+                result(1) = c * value(1) - s * value(2);
+                result(2) = s * value(1) + c * value(2);
+            }
+            return result;
+        }
+
+        template <int NSTOKES>
+        Eigen::Matrix<double, NSTOKES, 1>
+        transpose_rotate_stokes(const Eigen::Matrix<double, NSTOKES, 1>& value,
+                                double c, double s) {
+            auto result = value;
+            if constexpr (NSTOKES >= 3) {
+                result(1) = c * value(1) + s * value(2);
+                result(2) = -s * value(1) + c * value(2);
+            }
+            return result;
+        }
+    } // namespace
+
+    template <int NSTOKES> void OutputJVP<NSTOKES>::resize() {
+        m_jvp.setZero();
+        m_native_thread_storage.resize(this->m_config->num_threads());
+        m_mapped_thread_storage.resize(this->m_config->num_threads());
+        int max_output = 1;
+        for (const auto& [name, tangent] : m_derivative_tangents) {
+            max_output = std::max(max_output, static_cast<int>(tangent.size()));
+        }
+        for (int thread = 0; thread < this->m_config->num_threads(); ++thread) {
+            m_native_thread_storage[thread].resize(NSTOKES, this->m_ngeometry);
+            m_mapped_thread_storage[thread].resize(NSTOKES, max_output);
+        }
+    }
+
+    template <int NSTOKES>
+    template <typename Radiance>
+    void OutputJVP<NSTOKES>::assign_lane(const Radiance& radiance, int losidx,
+                                         int wavelidx, int threadidx) {
+        const int linear_index =
+            NSTOKES * this->m_nlos * wavelidx + NSTOKES * losidx;
+        double c = 1.0;
+        double s = 0.0;
+        if constexpr (NSTOKES >= 3) {
+            c = this->m_stokes_C[losidx];
+            s = this->m_stokes_S[losidx];
+        }
+
+        Eigen::Matrix<double, NSTOKES, 1> value;
+        Eigen::Matrix<double, NSTOKES, 1> directional;
+        directional.setZero();
+        for (int stokes = 0; stokes < NSTOKES; ++stokes) {
+            value(stokes) = radiance.value(stokes);
+        }
+
+        auto& native = m_native_thread_storage[threadidx];
+        auto& mapped = m_mapped_thread_storage[threadidx];
+        for (const auto& [name, tangent] : m_derivative_tangents) {
+            const auto& mapping =
+                this->m_atmosphere->storage().derivative_mappings_const().at(
+                    name);
+            mapped_volume_derivatives<NSTOKES>(
+                radiance, mapping, wavelidx, this->m_ngeometry,
+                this->m_atmosphere->num_scattering_deriv_groups(),
+                this->m_atmosphere->include_emission_derivatives(), native);
+            if (mapping.get_interpolator_const().has_value()) {
+                const auto& interpolator =
+                    mapping.get_interpolator_const().value();
+                if (tangent.size() != interpolator.cols()) {
+                    throw std::invalid_argument(
+                        "Volume linearization tangent has incorrect size");
+                }
+                mapped.leftCols(interpolator.cols()).noalias() =
+                    native * interpolator;
+                directional.noalias() +=
+                    mapped.leftCols(interpolator.cols()) * tangent;
+            } else {
+                if (tangent.size() != native.cols()) {
+                    throw std::invalid_argument(
+                        "Volume linearization tangent has incorrect size");
+                }
+                directional.noalias() += native * tangent;
+            }
+        }
+
+        for (const auto& [name, tangent] : m_surface_tangents) {
+            const auto& mapping =
+                this->m_atmosphere->surface().derivative_mappings().at(name);
+            double parameter_direction = 0.0;
+            if (mapping.get_interpolator_const().has_value()) {
+                const auto& interpolator =
+                    mapping.get_interpolator_const().value();
+                if (tangent.size() != interpolator.cols()) {
+                    throw std::invalid_argument(
+                        "Surface linearization tangent has incorrect size");
+                }
+                parameter_direction = interpolator.row(wavelidx).dot(tangent);
+            } else {
+                if (tangent.size() != this->m_nwavel) {
+                    throw std::invalid_argument(
+                        "Native spectral surface tangent has incorrect size");
+                }
+                parameter_direction = tangent(wavelidx);
+            }
+            directional +=
+                parameter_direction *
+                mapped_surface_derivative<NSTOKES>(
+                    radiance, mapping, wavelidx, this->m_ngeometry,
+                    this->m_atmosphere->num_source_deriv_groups(),
+                    this->m_atmosphere->surface().num_deriv(),
+                    this->m_atmosphere->surface_emission_deriv_start_index(),
+                    this->m_atmosphere->include_emission_derivatives());
+        }
+
+        value = rotate_stokes<NSTOKES>(value, c, s);
+        directional = rotate_stokes<NSTOKES>(directional, c, s);
+        for (int stokes = 0; stokes < NSTOKES; ++stokes) {
+            m_radiance(linear_index + stokes) = value(stokes);
+            m_jvp(linear_index + stokes) = directional(stokes);
+        }
+    }
+
+    template <int NSTOKES>
+    void OutputJVP<NSTOKES>::assign(
+        const sasktran2::WavelengthBlock<>& block,
+        const sasktran2::WavelengthBlockDual<NSTOKES>& radiance, int losidx,
+        int threadidx) {
+        for (int lane = 0; lane < block.count; ++lane) {
+            const sasktran2::WavelengthBlockConstLaneDualView<NSTOKES>
+                radiance_lane(radiance, lane);
+            assign_lane(radiance_lane, losidx, block.start + lane, threadidx);
+        }
+    }
+
+    template <int NSTOKES>
+    void OutputVJP<NSTOKES>::set_derivative_gradient_memory(
+        const std::string& name,
+        Eigen::Map<Eigen::VectorXd> derivative_gradient) {
+        m_derivative_gradients.insert(
+            {name, Eigen::Map<Eigen::VectorXd>(nullptr, 0)});
+        auto* target = &m_derivative_gradients.at(name);
+        new (target) Eigen::Map<Eigen::VectorXd>(derivative_gradient.data(),
+                                                 derivative_gradient.size());
+    }
+
+    template <int NSTOKES>
+    void OutputVJP<NSTOKES>::set_surface_gradient_memory(
+        const std::string& name,
+        Eigen::Map<Eigen::VectorXd> derivative_gradient) {
+        m_surface_gradients.insert(
+            {name, Eigen::Map<Eigen::VectorXd>(nullptr, 0)});
+        auto* target = &m_surface_gradients.at(name);
+        new (target) Eigen::Map<Eigen::VectorXd>(derivative_gradient.data(),
+                                                 derivative_gradient.size());
+    }
+
+    template <int NSTOKES> void OutputVJP<NSTOKES>::resize() {
+        const int num_threads = this->m_config->num_threads();
+        m_native_thread_storage.resize(num_threads);
+        m_thread_derivative_gradients.resize(num_threads);
+        m_thread_surface_gradients.resize(num_threads);
+        for (auto& [name, gradient] : m_derivative_gradients) {
+            gradient.setZero();
+        }
+        for (auto& [name, gradient] : m_surface_gradients) {
+            gradient.setZero();
+        }
+        for (int thread = 0; thread < num_threads; ++thread) {
+            m_native_thread_storage[thread].resize(NSTOKES, this->m_ngeometry);
+            for (const auto& [name, gradient] : m_derivative_gradients) {
+                m_thread_derivative_gradients[thread][name] =
+                    Eigen::VectorXd::Zero(gradient.size());
+            }
+            for (const auto& [name, gradient] : m_surface_gradients) {
+                m_thread_surface_gradients[thread][name] =
+                    Eigen::VectorXd::Zero(gradient.size());
+            }
+        }
+    }
+
+    template <int NSTOKES>
+    template <typename Radiance>
+    void OutputVJP<NSTOKES>::assign_lane(const Radiance& radiance, int losidx,
+                                         int wavelidx, int threadidx) {
+        const int linear_index =
+            NSTOKES * this->m_nlos * wavelidx + NSTOKES * losidx;
+        double c = 1.0;
+        double s = 0.0;
+        if constexpr (NSTOKES >= 3) {
+            c = this->m_stokes_C[losidx];
+            s = this->m_stokes_S[losidx];
+        }
+
+        Eigen::Matrix<double, NSTOKES, 1> value;
+        Eigen::Matrix<double, NSTOKES, 1> external_cotangent;
+        for (int stokes = 0; stokes < NSTOKES; ++stokes) {
+            value(stokes) = radiance.value(stokes);
+            external_cotangent(stokes) = m_cotangent(linear_index + stokes);
+        }
+        const auto internal_cotangent =
+            transpose_rotate_stokes<NSTOKES>(external_cotangent, c, s);
+        value = rotate_stokes<NSTOKES>(value, c, s);
+        for (int stokes = 0; stokes < NSTOKES; ++stokes) {
+            m_radiance(linear_index + stokes) = value(stokes);
+        }
+
+        auto& native = m_native_thread_storage[threadidx];
+        for (const auto& [name, gradient] : m_derivative_gradients) {
+            const auto& mapping =
+                this->m_atmosphere->storage().derivative_mappings_const().at(
+                    name);
+            mapped_volume_derivatives<NSTOKES>(
+                radiance, mapping, wavelidx, this->m_ngeometry,
+                this->m_atmosphere->num_scattering_deriv_groups(),
+                this->m_atmosphere->include_emission_derivatives(), native);
+            const Eigen::VectorXd native_gradient =
+                native.transpose() * internal_cotangent;
+            auto& thread_gradient =
+                m_thread_derivative_gradients[threadidx].at(name);
+            if (mapping.get_interpolator_const().has_value()) {
+                const auto& interpolator =
+                    mapping.get_interpolator_const().value();
+                if (thread_gradient.size() != interpolator.cols()) {
+                    throw std::invalid_argument(
+                        "Volume linearization gradient has incorrect size");
+                }
+                thread_gradient.noalias() +=
+                    interpolator.transpose() * native_gradient;
+            } else {
+                if (thread_gradient.size() != native_gradient.size()) {
+                    throw std::invalid_argument(
+                        "Volume linearization gradient has incorrect size");
+                }
+                thread_gradient += native_gradient;
+            }
+        }
+
+        for (const auto& [name, gradient] : m_surface_gradients) {
+            const auto& mapping =
+                this->m_atmosphere->surface().derivative_mappings().at(name);
+            const auto native_derivative = mapped_surface_derivative<NSTOKES>(
+                radiance, mapping, wavelidx, this->m_ngeometry,
+                this->m_atmosphere->num_source_deriv_groups(),
+                this->m_atmosphere->surface().num_deriv(),
+                this->m_atmosphere->surface_emission_deriv_start_index(),
+                this->m_atmosphere->include_emission_derivatives());
+            const double native_gradient =
+                native_derivative.dot(internal_cotangent);
+            auto& thread_gradient =
+                m_thread_surface_gradients[threadidx].at(name);
+            if (mapping.get_interpolator_const().has_value()) {
+                const auto& interpolator =
+                    mapping.get_interpolator_const().value();
+                if (thread_gradient.size() != interpolator.cols()) {
+                    throw std::invalid_argument(
+                        "Surface linearization gradient has incorrect size");
+                }
+                thread_gradient.noalias() +=
+                    interpolator.row(wavelidx).transpose() * native_gradient;
+            } else {
+                if (thread_gradient.size() != this->m_nwavel) {
+                    throw std::invalid_argument(
+                        "Native spectral surface gradient has incorrect size");
+                }
+                thread_gradient(wavelidx) += native_gradient;
+            }
+        }
+    }
+
+    template <int NSTOKES>
+    void OutputVJP<NSTOKES>::assign(
+        const sasktran2::WavelengthBlock<>& block,
+        const sasktran2::WavelengthBlockDual<NSTOKES>& radiance, int losidx,
+        int threadidx) {
+        for (int lane = 0; lane < block.count; ++lane) {
+            const sasktran2::WavelengthBlockConstLaneDualView<NSTOKES>
+                radiance_lane(radiance, lane);
+            assign_lane(radiance_lane, losidx, block.start + lane, threadidx);
+        }
+    }
+
+    template <int NSTOKES> void OutputVJP<NSTOKES>::finalize() {
+        for (auto& [name, gradient] : m_derivative_gradients) {
+            gradient.setZero();
+            for (const auto& thread_gradients : m_thread_derivative_gradients) {
+                gradient += thread_gradients.at(name);
+            }
+        }
+        for (auto& [name, gradient] : m_surface_gradients) {
+            gradient.setZero();
+            for (const auto& thread_gradients : m_thread_surface_gradients) {
+                gradient += thread_gradients.at(name);
+            }
+        }
+    }
+
+    template class OutputJVP<1>;
+    template class OutputJVP<3>;
+    template class OutputVJP<1>;
+    template class OutputVJP<3>;
+} // namespace sasktran2

--- a/cpp/lib/tests/atmosphere/surface.cpp
+++ b/cpp/lib/tests/atmosphere/surface.cpp
@@ -4,6 +4,19 @@
 
 #include <sasktran2.h>
 
+TEST_CASE("Atmosphere native revision is monotonic",
+          "[sasktran2][atmosphere]") {
+    sasktran2::atmosphere::AtmosphereGridStorageFull<1> storage(2, 3, 4);
+    sasktran2::atmosphere::Surface<1> surface(2);
+    sasktran2::atmosphere::Atmosphere<1> atmosphere(std::move(storage),
+                                                    std::move(surface), true);
+
+    REQUIRE(atmosphere.revision() == 0);
+    atmosphere.mark_changed();
+    atmosphere.mark_changed();
+    REQUIRE(atmosphere.revision() == 2);
+}
+
 TEST_CASE("Validate Surface BRDF WF's in Single Scatter/DO",
           "[sasktran2][engine]") {
 #ifdef USE_OMP

--- a/cpp/lib/tests/sourceintegrator/test_occultation2d.cpp
+++ b/cpp/lib/tests/sourceintegrator/test_occultation2d.cpp
@@ -155,6 +155,33 @@ TEST_CASE("Atmosphere allocates flattened storage from Geometry2D",
     REQUIRE(atmosphere.num_deriv() >= 2 * geometry.size());
 }
 
+TEST_CASE("SourceIntegrator reports native linearization capabilities",
+          "[sourceintegrator][linearization]") {
+    class NoJacobianSource : public InteriorTestSource {
+      public:
+        bool
+        supports_linearization(sasktran2::LinearizationMode) const override {
+            return false;
+        }
+    };
+
+    sasktran2::SourceIntegrator<1> integrator(true);
+    InteriorTestSource default_source;
+    std::vector<SourceTermInterface<1>*> default_sources = {&default_source};
+    REQUIRE(integrator.supports_linearization(
+        sasktran2::LinearizationMode::Jacobian, default_sources));
+    REQUIRE_FALSE(integrator.supports_linearization(
+        sasktran2::LinearizationMode::JVP, default_sources));
+    REQUIRE_FALSE(integrator.supports_linearization(
+        sasktran2::LinearizationMode::VJP, default_sources));
+
+    NoJacobianSource unsupported_source;
+    std::vector<SourceTermInterface<1>*> unsupported_sources = {
+        &default_source, &unsupported_source};
+    REQUIRE_FALSE(integrator.supports_linearization(
+        sasktran2::LinearizationMode::Jacobian, unsupported_sources));
+}
+
 TEST_CASE("SourceIntegrator applies 2D occultation transmission and native "
           "derivatives",
           "[sourceintegrator][occultation][geometry2d]") {

--- a/docs/sphinx/source/weighting_functions.md
+++ b/docs/sphinx/source/weighting_functions.md
@@ -90,17 +90,28 @@ The same derivatives are available as a local linear model of the radiance:
     # Propagate a scalar objective's radiance sensitivity back to every input.
     parameter_gradients = linearization.vjp(radiance_sensitivity)
 
-The linearization.value property is the radiance at the linearization point
-and linearization.jacobian contains one labeled block per semantic parameter
-(for example, ozone_vmr rather than wf_ozone_vmr). In the initial
-implementation the complete radiance Jacobian is calculated and cached when
-linearize is called. Repeated JVP and VJP operations reuse that cache, but
-the memory cost is therefore the same as requesting all weighting functions.
-Flux and diagnostic outputs are not part of this linearization interface.
-The tangent_template property describes the shape, dimensions, and coordinates
-of every parameter without accessing the full Jacobian. A linearization is
-fixed at the atmosphere state captured by linearize; changing the atmosphere
-afterward does not alter its value, JVPs, or VJPs.
+The `linearization.value` property is the radiance at the linearization point.
+JVP and VJP operations contract the native derivative rows as they are produced,
+so they do not allocate the complete mapped Jacobian. Accessing
+`linearization.jacobian` materializes and caches one labeled block per semantic
+parameter (for example, `ozone_vmr` rather than `wf_ozone_vmr`). The
+`tangent_template` property describes the shape, dimensions, and coordinates of
+every parameter without materializing the Jacobian. Flux and diagnostic outputs
+are not part of this interface.
+
+A linearization keeps a reference to the atmosphere; it does not copy it. The
+atmosphere's revision is recorded when the linearization is created. Rebuilding
+a constituent-backed atmosphere advances this revision automatically. When
+modifying a borrowed raw-storage NumPy view, call `atmosphere.mark_changed()`
+after the modification. Once the revision changes, new JVPs, VJPs, and a
+first-time Jacobian materialization raise `StaleLinearizationError`; already
+cached `value` and `jacobian` objects remain readable. Create a new
+linearization to evaluate derivatives at the changed state.
+
+Weighting functions configured in log-radiance space are converted back to
+radiance derivatives by this interface, so `jvp`, `vjp`, and `jacobian` always
+describe the derivative of `linearization.value`. The legacy
+`calculate_radiance()` output is unchanged.
 
 ## The Details
 

--- a/docs/sphinx/source/weighting_functions.md
+++ b/docs/sphinx/source/weighting_functions.md
@@ -90,11 +90,27 @@ The same derivatives are available as a local linear model of the radiance:
     # Propagate a scalar objective's radiance sensitivity back to every input.
     parameter_gradients = linearization.vjp(radiance_sensitivity)
 
+    # Retrievals can request only their active parameters. Unrequested
+    # derivative mappings are then excluded from the VJP calculation.
+    retrieval_gradients = linearization.vjp(
+        radiance_sensitivity,
+        parameters=("ozone_vmr",),
+    )
+
 The `linearization.value` property is the radiance at the linearization point.
 JVP and VJP operations contract the native derivative rows as they are produced,
-so they do not allocate the complete mapped Jacobian. Accessing
-`linearization.jacobian` materializes and caches one labeled block per semantic
-parameter (for example, `ozone_vmr` rather than `wf_ozone_vmr`). The
+so they do not allocate the complete mapped Jacobian.
+
+The read-only `linearization.backends` mapping reports whether each product
+uses a `LinearizationBackend.Native`, `StreamingJacobian`, or
+`MaterializedJacobian` implementation. A streaming-Jacobian product avoids
+allocating the complete mapped Jacobian, but repeats the full derivative
+propagation for every call. Iterative solvers may therefore prefer a native
+product backend, or explicitly materialize the Jacobian once when only a
+streaming backend is available.
+
+Accessing `linearization.jacobian` materializes and caches one labeled block per
+semantic parameter (for example, `ozone_vmr` rather than `wf_ozone_vmr`). The
 `tangent_template` property describes the shape, dimensions, and coordinates of
 every parameter without materializing the Jacobian. Flux and diagnostic outputs
 are not part of this interface.
@@ -107,6 +123,13 @@ after the modification. Once the revision changes, new JVPs, VJPs, and a
 first-time Jacobian materialization raise `StaleLinearizationError`; already
 cached `value` and `jacobian` objects remain readable. Create a new
 linearization to evaluate derivatives at the changed state.
+
+Trust-region solvers may need to evaluate a trial atmosphere while retaining
+the linearization at the currently accepted state. Use two distinct
+`Atmosphere` instances for these states. Linearisations backed by distinct
+atmospheres can coexist and be evaluated sequentially with the same `Engine`;
+rebuilding one atmosphere does not invalidate a linearization backed by the
+other. Concurrent calls on a shared engine are not supported.
 
 Weighting functions configured in log-radiance space are converted back to
 radiance derivatives by this interface, so `jvp`, `vjp`, and `jacobian` always

--- a/docs/sphinx/source/weighting_functions.md
+++ b/docs/sphinx/source/weighting_functions.md
@@ -22,6 +22,7 @@ For example, if we set up a simple calculation,
 ```{code-cell} ipython3
 import sasktran2 as sk
 import numpy as np
+import xarray as xr
 
 config = sk.Config()
 
@@ -74,6 +75,32 @@ We can take a look at one of the weighting functions,
 ```{code-cell} ipython3
 radiance["wf_ozone_vmr"].isel(los=1, stokes=0).sel(wavelength=330, method="nearest").plot(y="ozone_altitude")
 ```
+
+## Jacobian-vector and vector-Jacobian products
+
+The same derivatives are available as a local linear model of the radiance:
+
+    linearization = engine.linearize(atmosphere)
+
+    # A labeled perturbation. Parameters not included here are held fixed.
+    tangent = linearization.tangent_template[["ozone_vmr"]]
+    tangent["ozone_vmr"].data[:] = ozone_perturbation
+    radiance_perturbation = linearization.jvp(tangent)
+
+    # Propagate a scalar objective's radiance sensitivity back to every input.
+    parameter_gradients = linearization.vjp(radiance_sensitivity)
+
+The linearization.value property is the radiance at the linearization point
+and linearization.jacobian contains one labeled block per semantic parameter
+(for example, ozone_vmr rather than wf_ozone_vmr). In the initial
+implementation the complete radiance Jacobian is calculated and cached when
+linearize is called. Repeated JVP and VJP operations reuse that cache, but
+the memory cost is therefore the same as requesting all weighting functions.
+Flux and diagnostic outputs are not part of this linearization interface.
+The tangent_template property describes the shape, dimensions, and coordinates
+of every parameter without accessing the full Jacobian. A linearization is
+fixed at the atmosphere state captured by linearize; changing the atmosphere
+afterward does not alter its value, JVPs, or VJPs.
 
 ## The Details
 

--- a/rust/sasktran2-py-ext/src/atmosphere.rs
+++ b/rust/sasktran2-py-ext/src/atmosphere.rs
@@ -131,6 +131,15 @@ impl PyAtmosphere {
             .into_pyresult()?;
         Ok(())
     }
+
+    fn mark_changed(&self) -> PyResult<()> {
+        self.atmosphere.mark_changed().into_pyresult()
+    }
+
+    #[getter]
+    fn revision(&self) -> PyResult<u64> {
+        self.atmosphere.revision().into_pyresult()
+    }
 }
 
 #[pymethods]
@@ -182,9 +191,9 @@ impl PyAtmosphereStorageView {
     }
 
     fn derivative_mapping_names(&self) -> PyResult<Vec<String>> {
-        self.storage.derivative_mapping_names().map_err(|err| {
-            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(err)
-        })
+        self.storage
+            .derivative_mapping_names()
+            .map_err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>)
     }
 
     fn normalize_by_extinctions(&mut self) -> PyResult<()> {
@@ -242,6 +251,12 @@ impl PyAtmosphereSurfaceView {
         };
 
         Python::attach(|py| Py::new(py, mapping_view))
+    }
+
+    fn derivative_mapping_names(&self) -> PyResult<Vec<String>> {
+        self.surface
+            .derivative_mapping_names()
+            .map_err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>)
     }
 
     fn set_zero(&mut self) -> PyResult<()> {

--- a/rust/sasktran2-py-ext/src/derivative_mapping.rs
+++ b/rust/sasktran2-py-ext/src/derivative_mapping.rs
@@ -94,6 +94,11 @@ impl PyDerivativeMappingView {
         self.derivative_mapping
             .set_log_radiance_space(log_radiance_space);
     }
+
+    #[getter]
+    fn get_log_radiance_space(&self) -> bool {
+        self.derivative_mapping.log_radiance_space()
+    }
 }
 
 #[pyclass(unsendable)]

--- a/rust/sasktran2-py-ext/src/engine.rs
+++ b/rust/sasktran2-py-ext/src/engine.rs
@@ -1,6 +1,8 @@
+use numpy::{PyReadonlyArray1, PyReadonlyArray3};
 use pyo3::prelude::*;
-use pyo3::types::PyAny;
+use pyo3::types::{PyAny, PyDict};
 use sasktran2_rs::bindings::engine::{self, LinearizationMode};
+use std::collections::HashMap;
 
 use crate::config::PyConfig;
 use crate::geometry::{PyGeometry1D, PyGeometry2D};
@@ -93,4 +95,79 @@ impl PyEngine {
         };
         self.engine.supports_linearization(mode).into_pyresult()
     }
+
+    fn _linearization_backend(&self, mode: u8) -> PyResult<u8> {
+        let mode = match mode {
+            0 => LinearizationMode::Jacobian,
+            1 => LinearizationMode::Jvp,
+            2 => LinearizationMode::Vjp,
+            _ => {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "linearization mode must be 0 (Jacobian), 1 (JVP), or 2 (VJP)",
+                ));
+            }
+        };
+        Ok(self.engine.linearization_backend(mode).into_pyresult()? as u8)
+    }
+
+    fn _calculate_jvp(
+        &self,
+        py: Python,
+        atmosphere: PyRef<crate::atmosphere::PyAtmosphere>,
+        derivative_tangents: &Bound<PyDict>,
+        surface_tangents: &Bound<PyDict>,
+    ) -> PyResult<Py<crate::output::PyJvpOutput>> {
+        let derivative_tangents = array_dict(derivative_tangents)?;
+        let surface_tangents = array_dict(surface_tangents)?;
+        let output = self
+            .engine
+            .calculate_jvp(
+                &atmosphere.atmosphere,
+                &derivative_tangents,
+                &surface_tangents,
+            )
+            .into_pyresult()?;
+        Py::new(py, crate::output::PyJvpOutput { output })
+    }
+
+    fn _calculate_vjp(
+        &self,
+        py: Python,
+        atmosphere: PyRef<crate::atmosphere::PyAtmosphere>,
+        cotangent: PyReadonlyArray3<f64>,
+        derivative_sizes: &Bound<PyDict>,
+        surface_sizes: &Bound<PyDict>,
+    ) -> PyResult<Py<crate::output::PyVjpOutput>> {
+        let cotangent = cotangent.as_array().to_owned();
+        let derivative_sizes = size_dict(derivative_sizes)?;
+        let surface_sizes = size_dict(surface_sizes)?;
+        let output = self
+            .engine
+            .calculate_vjp(
+                &atmosphere.atmosphere,
+                &cotangent,
+                &derivative_sizes,
+                &surface_sizes,
+            )
+            .into_pyresult()?;
+        Py::new(py, crate::output::PyVjpOutput { output })
+    }
+}
+
+fn array_dict(dict: &Bound<PyDict>) -> PyResult<HashMap<String, ndarray::Array1<f64>>> {
+    let mut result = HashMap::new();
+    for (name, value) in dict.iter() {
+        let name = name.extract::<String>()?;
+        let value = value.extract::<PyReadonlyArray1<f64>>()?;
+        result.insert(name, value.as_array().to_owned());
+    }
+    Ok(result)
+}
+
+fn size_dict(dict: &Bound<PyDict>) -> PyResult<HashMap<String, usize>> {
+    let mut result = HashMap::new();
+    for (name, value) in dict.iter() {
+        result.insert(name.extract::<String>()?, value.extract::<usize>()?);
+    }
+    Ok(result)
 }

--- a/rust/sasktran2-py-ext/src/engine.rs
+++ b/rust/sasktran2-py-ext/src/engine.rs
@@ -1,6 +1,6 @@
 use pyo3::prelude::*;
 use pyo3::types::PyAny;
-use sasktran2_rs::bindings::engine;
+use sasktran2_rs::bindings::engine::{self, LinearizationMode};
 
 use crate::config::PyConfig;
 use crate::geometry::{PyGeometry1D, PyGeometry2D};
@@ -78,5 +78,19 @@ impl PyEngine {
             .into_pyresult()?;
 
         Py::new(py, crate::output::PyOutput { output })
+    }
+
+    fn _supports_linearization(&self, mode: u8) -> PyResult<bool> {
+        let mode = match mode {
+            0 => LinearizationMode::Jacobian,
+            1 => LinearizationMode::Jvp,
+            2 => LinearizationMode::Vjp,
+            _ => {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "linearization mode must be 0 (Jacobian), 1 (JVP), or 2 (VJP)",
+                ));
+            }
+        };
+        self.engine.supports_linearization(mode).into_pyresult()
     }
 }

--- a/rust/sasktran2-py-ext/src/lib.rs
+++ b/rust/sasktran2-py-ext/src/lib.rs
@@ -77,6 +77,8 @@ fn _core_rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<viewing_geometry::PySolarAnglesObserverLocation>()?;
     m.add_class::<viewing_geometry::PyFluxObserverSolar>()?;
     m.add_class::<viewing_geometry::PyViewingGeometry>()?;
+    m.add_class::<output::PyJvpOutput>()?;
+    m.add_class::<output::PyVjpOutput>()?;
 
     // Engine
     m.add_class::<engine::PyEngine>()?;

--- a/rust/sasktran2-py-ext/src/output.rs
+++ b/rust/sasktran2-py-ext/src/output.rs
@@ -1,10 +1,64 @@
-use numpy::{PyArray2, PyArray3, PyArray4};
+use numpy::{PyArray1, PyArray2, PyArray3, PyArray4};
 use pyo3::{prelude::*, types::PyDict};
 use sasktran2_rs::bindings::output;
 
 #[pyclass(unsendable)]
 pub struct PyOutput {
     pub output: output::Output,
+}
+
+#[pyclass(unsendable)]
+pub struct PyJvpOutput {
+    pub output: output::JvpOutput,
+}
+
+#[pymethods]
+impl PyJvpOutput {
+    #[getter]
+    fn get_radiance<'py>(this: Bound<'py, Self>) -> PyResult<Bound<'py, PyArray3<f64>>> {
+        let array = &this.borrow().output.radiance;
+        unsafe { Ok(PyArray3::borrow_from_array(array, this.into_any())) }
+    }
+
+    #[getter]
+    fn get_jvp<'py>(this: Bound<'py, Self>) -> PyResult<Bound<'py, PyArray3<f64>>> {
+        let array = &this.borrow().output.jvp;
+        unsafe { Ok(PyArray3::borrow_from_array(array, this.into_any())) }
+    }
+}
+
+#[pyclass(unsendable)]
+pub struct PyVjpOutput {
+    pub output: output::VjpOutput,
+}
+
+#[pymethods]
+impl PyVjpOutput {
+    #[getter]
+    fn get_radiance<'py>(this: Bound<'py, Self>) -> PyResult<Bound<'py, PyArray3<f64>>> {
+        let array = &this.borrow().output.radiance;
+        unsafe { Ok(PyArray3::borrow_from_array(array, this.into_any())) }
+    }
+
+    #[getter]
+    fn get_derivative_gradients<'py>(this: Bound<'py, Self>) -> PyResult<Bound<'py, PyDict>> {
+        let result = PyDict::new(this.py());
+        for (name, gradient) in &this.borrow().output.derivative_gradients {
+            let array = unsafe { PyArray1::borrow_from_array(gradient, this.clone().into_any()) };
+            result.set_item(name, array)?;
+        }
+        Ok(result)
+    }
+
+    #[getter]
+    fn get_surface_gradients<'py>(this: Bound<'py, Self>) -> PyResult<Bound<'py, PyDict>> {
+        let result = PyDict::new(this.py());
+        for (name, gradient) in &this.borrow().output.surface_gradients {
+            let array = unsafe { PyArray1::borrow_from_array(gradient, this.clone().into_any()) };
+            result.set_item(name, array)?;
+        }
+        Ok(result)
+    }
 }
 
 impl PyOutput {

--- a/rust/sasktran2-rs/src/bindings/atmosphere.rs
+++ b/rust/sasktran2-rs/src/bindings/atmosphere.rs
@@ -78,6 +78,23 @@ impl Atmosphere {
         Ok(())
     }
 
+    pub fn mark_changed(&self) -> Result<()> {
+        let result = unsafe { ffi::sk_atmosphere_mark_changed(self.atmosphere) };
+        if result != 0 {
+            return Err(anyhow!("Error marking atmosphere changed: {}", result));
+        }
+        Ok(())
+    }
+
+    pub fn revision(&self) -> Result<u64> {
+        let mut revision = 0u64;
+        let result = unsafe { ffi::sk_atmosphere_get_revision(self.atmosphere, &mut revision) };
+        if result != 0 {
+            return Err(anyhow!("Error getting atmosphere revision: {}", result));
+        }
+        Ok(revision)
+    }
+
     /// Number of stokes parameters
     pub fn num_stokes(&self) -> usize {
         self.nstokes
@@ -116,6 +133,9 @@ mod tests {
 
         // check that atmosphere storage is not null
         assert!(!atmosphere.atmosphere.is_null());
+        assert_eq!(atmosphere.revision().unwrap(), 0);
+        atmosphere.mark_changed().unwrap();
+        assert_eq!(atmosphere.revision().unwrap(), 1);
     }
 
     #[test]

--- a/rust/sasktran2-rs/src/bindings/deriv_mapping.rs
+++ b/rust/sasktran2-rs/src/bindings/deriv_mapping.rs
@@ -170,6 +170,14 @@ impl DerivativeMapping {
             ffi::sk_deriv_mapping_set_log_radiance_space(self.mapping, log_radiance_space);
         }
     }
+
+    pub fn log_radiance_space(&self) -> bool {
+        let mut log_radiance_space = 0;
+        unsafe {
+            ffi::sk_deriv_mapping_get_log_radiance_space(self.mapping, &mut log_radiance_space);
+        }
+        log_radiance_space != 0
+    }
 }
 
 impl Drop for DerivativeMapping {

--- a/rust/sasktran2-rs/src/bindings/engine.rs
+++ b/rust/sasktran2-rs/src/bindings/engine.rs
@@ -4,12 +4,14 @@ use super::atmosphere::Atmosphere;
 use super::common::openmp_support_enabled;
 use super::config::{Config, ThreadingLib};
 use super::geometry::{Geometry1D, Geometry2D};
-use super::output::Output;
+use super::output::{JvpOutput, Output, VjpOutput};
 use super::prelude::*;
 use super::viewing_geometry::ViewingGeometry;
+use ndarray::{Array1, Array3};
 use rayon::current_thread_index;
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 use sasktran2_sys::ffi;
+use std::collections::HashMap;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(i32)]
@@ -17,6 +19,14 @@ pub enum LinearizationMode {
     Jacobian = 0,
     Jvp = 1,
     Vjp = 2,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+pub enum LinearizationBackend {
+    Unavailable = 0,
+    StreamingJacobian = 1,
+    Native = 2,
 }
 
 pub enum EngineGeometry<'a> {
@@ -146,6 +156,27 @@ impl<'a> Engine<'a> {
                 "Failed to query linearization support: {}",
                 result
             ))
+        }
+    }
+
+    pub fn linearization_backend(&self, mode: LinearizationMode) -> Result<LinearizationBackend> {
+        let mut backend = 0i32;
+        let result =
+            unsafe { ffi::sk_engine_linearization_backend(self.engine, mode as i32, &mut backend) };
+        if result != 0 {
+            return Err(anyhow::anyhow!(
+                "Failed to select linearization backend: {}",
+                result
+            ));
+        }
+        match backend {
+            0 => Ok(LinearizationBackend::Unavailable),
+            1 => Ok(LinearizationBackend::StreamingJacobian),
+            2 => Ok(LinearizationBackend::Native),
+            _ => Err(anyhow::anyhow!(
+                "Unknown linearization backend: {}",
+                backend
+            )),
         }
     }
 
@@ -291,6 +322,77 @@ impl<'a> Engine<'a> {
 
         Ok(output)
     }
+
+    pub fn calculate_jvp(
+        &self,
+        atmosphere: &Atmosphere,
+        derivative_tangents: &HashMap<String, Array1<f64>>,
+        surface_tangents: &HashMap<String, Array1<f64>>,
+    ) -> Result<JvpOutput> {
+        crate::threading::set_num_threads(self.config.num_threads()?)?;
+        let mut output = JvpOutput::new(
+            atmosphere.num_wavel(),
+            self.viewing_geometry.num_rays()?,
+            self.config.num_stokes()?,
+        );
+        for (name, tangent) in derivative_tangents {
+            output
+                .with_derivative_tangent(name, tangent)
+                .map_err(anyhow::Error::msg)?;
+        }
+        for (name, tangent) in surface_tangents {
+            output
+                .with_surface_tangent(name, tangent)
+                .map_err(anyhow::Error::msg)?;
+        }
+        let result = unsafe {
+            ffi::sk_engine_calculate_jvp(self.engine, atmosphere.atmosphere, output.output)
+        };
+        if result != 0 {
+            return Err(anyhow::anyhow!("Failed to calculate JVP: {}", result));
+        }
+        Ok(output)
+    }
+
+    pub fn calculate_vjp(
+        &self,
+        atmosphere: &Atmosphere,
+        cotangent: &Array3<f64>,
+        derivative_sizes: &HashMap<String, usize>,
+        surface_sizes: &HashMap<String, usize>,
+    ) -> Result<VjpOutput> {
+        crate::threading::set_num_threads(self.config.num_threads()?)?;
+        let expected = (
+            atmosphere.num_wavel(),
+            self.viewing_geometry.num_rays()?,
+            self.config.num_stokes()?,
+        );
+        if cotangent.dim() != expected {
+            return Err(anyhow::anyhow!(
+                "Radiance cotangent shape {:?} does not match {:?}",
+                cotangent.dim(),
+                expected
+            ));
+        }
+        let mut output = VjpOutput::new(cotangent);
+        for (name, size) in derivative_sizes {
+            output
+                .with_derivative_gradient(name, *size)
+                .map_err(anyhow::Error::msg)?;
+        }
+        for (name, size) in surface_sizes {
+            output
+                .with_surface_gradient(name, *size)
+                .map_err(anyhow::Error::msg)?;
+        }
+        let result = unsafe {
+            ffi::sk_engine_calculate_vjp(self.engine, atmosphere.atmosphere, output.output)
+        };
+        if result != 0 {
+            return Err(anyhow::anyhow!("Failed to calculate VJP: {}", result));
+        }
+        Ok(output)
+    }
 }
 impl<'a> Drop for Engine<'a> {
     fn drop(&mut self) {
@@ -334,15 +436,39 @@ mod tests {
         let engine = Engine::new(&config, &geometry, &viewing_geometry).unwrap();
 
         assert!(!engine.engine.is_null());
-        assert!(engine
-            .supports_linearization(LinearizationMode::Jacobian)
-            .unwrap());
-        assert!(!engine
-            .supports_linearization(LinearizationMode::Jvp)
-            .unwrap());
-        assert!(!engine
-            .supports_linearization(LinearizationMode::Vjp)
-            .unwrap());
+        assert!(
+            engine
+                .supports_linearization(LinearizationMode::Jacobian)
+                .unwrap()
+        );
+        assert!(
+            !engine
+                .supports_linearization(LinearizationMode::Jvp)
+                .unwrap()
+        );
+        assert!(
+            !engine
+                .supports_linearization(LinearizationMode::Vjp)
+                .unwrap()
+        );
+        assert_eq!(
+            engine
+                .linearization_backend(LinearizationMode::Jacobian)
+                .unwrap(),
+            LinearizationBackend::Native
+        );
+        assert_eq!(
+            engine
+                .linearization_backend(LinearizationMode::Jvp)
+                .unwrap(),
+            LinearizationBackend::StreamingJacobian
+        );
+        assert_eq!(
+            engine
+                .linearization_backend(LinearizationMode::Vjp)
+                .unwrap(),
+            LinearizationBackend::StreamingJacobian
+        );
     }
 
     #[test]

--- a/rust/sasktran2-rs/src/bindings/engine.rs
+++ b/rust/sasktran2-rs/src/bindings/engine.rs
@@ -11,6 +11,14 @@ use rayon::current_thread_index;
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 use sasktran2_sys::ffi;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+pub enum LinearizationMode {
+    Jacobian = 0,
+    Jvp = 1,
+    Vjp = 2,
+}
+
 pub enum EngineGeometry<'a> {
     OneDimensional(&'a Geometry1D),
     TwoDimensional(&'a Geometry2D),
@@ -124,6 +132,21 @@ impl<'a> Engine<'a> {
             geometry: EngineGeometry::TwoDimensional(geometry),
             viewing_geometry,
         })
+    }
+
+    pub fn supports_linearization(&self, mode: LinearizationMode) -> Result<bool> {
+        let mut supported = 0i32;
+        let result = unsafe {
+            ffi::sk_engine_supports_linearization(self.engine, mode as i32, &mut supported)
+        };
+        if result == 0 {
+            Ok(supported != 0)
+        } else {
+            Err(anyhow::anyhow!(
+                "Failed to query linearization support: {}",
+                result
+            ))
+        }
     }
 
     pub fn calculate_radiance(&self, atmosphere: &Atmosphere) -> Result<Output> {
@@ -311,6 +334,15 @@ mod tests {
         let engine = Engine::new(&config, &geometry, &viewing_geometry).unwrap();
 
         assert!(!engine.engine.is_null());
+        assert!(engine
+            .supports_linearization(LinearizationMode::Jacobian)
+            .unwrap());
+        assert!(!engine
+            .supports_linearization(LinearizationMode::Jvp)
+            .unwrap());
+        assert!(!engine
+            .supports_linearization(LinearizationMode::Vjp)
+            .unwrap());
     }
 
     #[test]

--- a/rust/sasktran2-rs/src/bindings/output.rs
+++ b/rust/sasktran2-rs/src/bindings/output.rs
@@ -4,6 +4,159 @@ use std::ffi::CString;
 use ndarray::*;
 use sasktran2_sys::ffi;
 
+pub struct JvpOutput {
+    pub output: *mut ffi::OutputJVP,
+    pub radiance: Array3<f64>,
+    pub jvp: Array3<f64>,
+}
+
+impl JvpOutput {
+    pub fn new(num_wavel: usize, num_los: usize, num_stokes: usize) -> Self {
+        let mut radiance = Array3::<f64>::zeros((num_wavel, num_los, num_stokes));
+        let mut jvp = Array3::<f64>::zeros((num_wavel, num_los, num_stokes));
+        let output = unsafe {
+            ffi::sk_output_jvp_create(
+                radiance.as_mut_ptr(),
+                jvp.as_mut_ptr(),
+                (num_wavel * num_los) as i32,
+                num_stokes as i32,
+            )
+        };
+        Self {
+            output,
+            radiance,
+            jvp,
+        }
+    }
+
+    pub fn with_derivative_tangent(
+        &mut self,
+        name: &str,
+        tangent: &Array1<f64>,
+    ) -> Result<(), String> {
+        let name = CString::new(name).map_err(|err| err.to_string())?;
+        let result = unsafe {
+            ffi::sk_output_jvp_assign_derivative_tangent(
+                self.output,
+                name.as_ptr(),
+                tangent.as_ptr(),
+                tangent.len() as i32,
+            )
+        };
+        if result == 0 {
+            Ok(())
+        } else {
+            Err(format!("Failed to register JVP tangent: {result}"))
+        }
+    }
+
+    pub fn with_surface_tangent(
+        &mut self,
+        name: &str,
+        tangent: &Array1<f64>,
+    ) -> Result<(), String> {
+        let name = CString::new(name).map_err(|err| err.to_string())?;
+        let result = unsafe {
+            ffi::sk_output_jvp_assign_surface_tangent(
+                self.output,
+                name.as_ptr(),
+                tangent.as_ptr(),
+                tangent.len() as i32,
+            )
+        };
+        if result == 0 {
+            Ok(())
+        } else {
+            Err(format!("Failed to register surface JVP tangent: {result}"))
+        }
+    }
+}
+
+impl Drop for JvpOutput {
+    fn drop(&mut self) {
+        unsafe { ffi::sk_output_jvp_destroy(self.output) }
+    }
+}
+
+pub struct VjpOutput {
+    pub output: *mut ffi::OutputVJP,
+    pub radiance: Array3<f64>,
+    pub derivative_gradients: HashMap<String, Array1<f64>>,
+    pub surface_gradients: HashMap<String, Array1<f64>>,
+    _cotangent: Array3<f64>,
+}
+
+impl VjpOutput {
+    pub fn new(cotangent: &Array3<f64>) -> Self {
+        // The C++ output holds a non-owning map for the duration of its
+        // lifetime, so keep an owned cotangent alongside it.
+        let cotangent = cotangent.to_owned();
+        let (num_wavel, num_los, num_stokes) = cotangent.dim();
+        let mut radiance = Array3::<f64>::zeros(cotangent.raw_dim());
+        let output = unsafe {
+            ffi::sk_output_vjp_create(
+                radiance.as_mut_ptr(),
+                cotangent.as_ptr(),
+                (num_wavel * num_los) as i32,
+                num_stokes as i32,
+            )
+        };
+        Self {
+            output,
+            radiance,
+            derivative_gradients: HashMap::new(),
+            surface_gradients: HashMap::new(),
+            _cotangent: cotangent,
+        }
+    }
+
+    pub fn with_derivative_gradient(&mut self, name: &str, size: usize) -> Result<(), String> {
+        self.derivative_gradients
+            .insert(name.to_string(), Array1::zeros(size));
+        let gradient = self.derivative_gradients.get_mut(name).unwrap();
+        let name_c = CString::new(name).map_err(|err| err.to_string())?;
+        let result = unsafe {
+            ffi::sk_output_vjp_assign_derivative_gradient(
+                self.output,
+                name_c.as_ptr(),
+                gradient.as_mut_ptr(),
+                size as i32,
+            )
+        };
+        if result == 0 {
+            Ok(())
+        } else {
+            Err(format!("Failed to register VJP gradient: {result}"))
+        }
+    }
+
+    pub fn with_surface_gradient(&mut self, name: &str, size: usize) -> Result<(), String> {
+        self.surface_gradients
+            .insert(name.to_string(), Array1::zeros(size));
+        let gradient = self.surface_gradients.get_mut(name).unwrap();
+        let name_c = CString::new(name).map_err(|err| err.to_string())?;
+        let result = unsafe {
+            ffi::sk_output_vjp_assign_surface_gradient(
+                self.output,
+                name_c.as_ptr(),
+                gradient.as_mut_ptr(),
+                size as i32,
+            )
+        };
+        if result == 0 {
+            Ok(())
+        } else {
+            Err(format!("Failed to register surface VJP gradient: {result}"))
+        }
+    }
+}
+
+impl Drop for VjpOutput {
+    fn drop(&mut self) {
+        unsafe { ffi::sk_output_vjp_destroy(self.output) }
+    }
+}
+
 ///  Wrapper around the C++ Output object
 /// This is typically only constructed internally by the Engine, and then used by the user
 pub struct Output {

--- a/rust/sasktran2-sys/src/bindings.rs
+++ b/rust/sasktran2-sys/src/bindings.rs
@@ -991,6 +991,13 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    pub fn sk_engine_supports_linearization(
+        engine: *mut Engine,
+        mode: ::std::os::raw::c_int,
+        supported: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
     pub fn sk_engine_calculate_radiance_block_thread(
         engine: *mut Engine,
         output: *mut OutputC,

--- a/rust/sasktran2-sys/src/bindings.rs
+++ b/rust/sasktran2-sys/src/bindings.rs
@@ -205,6 +205,12 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    pub fn sk_deriv_mapping_get_log_radiance_space(
+        mapping: *mut DerivativeMapping,
+        log_radiance_space: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
     pub fn sk_deriv_mapping_is_scattering_derivative(
         mapping: *mut DerivativeMapping,
         is_scattering_derivative: *mut ::std::os::raw::c_int,
@@ -398,6 +404,15 @@ unsafe extern "C" {
     pub fn sk_atmosphere_apply_delta_m_scaling(
         atmosphere: *mut Atmosphere,
         order: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn sk_atmosphere_mark_changed(atmosphere: *mut Atmosphere) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn sk_atmosphere_get_revision(
+        atmosphere: *mut Atmosphere,
+        revision: *mut ::std::os::raw::c_ulonglong,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
@@ -903,6 +918,16 @@ unsafe extern "C" {
 pub struct OutputC {
     _unused: [u8; 0],
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct OutputJVP {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct OutputVJP {
+    _unused: [u8; 0],
+}
 unsafe extern "C" {
     pub fn sk_output_create(
         radiance: *mut f64,
@@ -957,6 +982,63 @@ unsafe extern "C" {
         od: *mut *mut f64,
     ) -> ::std::os::raw::c_int;
 }
+unsafe extern "C" {
+    pub fn sk_output_jvp_create(
+        radiance: *mut f64,
+        jvp: *mut f64,
+        nrad: ::std::os::raw::c_int,
+        nstokes: ::std::os::raw::c_int,
+    ) -> *mut OutputJVP;
+}
+unsafe extern "C" {
+    pub fn sk_output_jvp_destroy(output: *mut OutputJVP);
+}
+unsafe extern "C" {
+    pub fn sk_output_jvp_assign_derivative_tangent(
+        output: *mut OutputJVP,
+        name: *const ::std::os::raw::c_char,
+        tangent: *const f64,
+        nparam: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn sk_output_jvp_assign_surface_tangent(
+        output: *mut OutputJVP,
+        name: *const ::std::os::raw::c_char,
+        tangent: *const f64,
+        nparam: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn sk_output_vjp_create(
+        radiance: *mut f64,
+        cotangent: *const f64,
+        nrad: ::std::os::raw::c_int,
+        nstokes: ::std::os::raw::c_int,
+    ) -> *mut OutputVJP;
+}
+unsafe extern "C" {
+    pub fn sk_output_vjp_destroy(output: *mut OutputVJP);
+}
+unsafe extern "C" {
+    pub fn sk_output_vjp_assign_derivative_gradient(
+        output: *mut OutputVJP,
+        name: *const ::std::os::raw::c_char,
+        gradient: *mut f64,
+        nparam: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn sk_output_vjp_assign_surface_gradient(
+        output: *mut OutputVJP,
+        name: *const ::std::os::raw::c_char,
+        gradient: *mut f64,
+        nparam: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn sk_output_vjp_finalize(output: *mut OutputVJP) -> ::std::os::raw::c_int;
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Engine {
@@ -995,6 +1077,27 @@ unsafe extern "C" {
         engine: *mut Engine,
         mode: ::std::os::raw::c_int,
         supported: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn sk_engine_linearization_backend(
+        engine: *mut Engine,
+        mode: ::std::os::raw::c_int,
+        backend: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn sk_engine_calculate_jvp(
+        engine: *mut Engine,
+        atmosphere: *mut Atmosphere,
+        output: *mut OutputJVP,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn sk_engine_calculate_vjp(
+        engine: *mut Engine,
+        atmosphere: *mut Atmosphere,
+        output: *mut OutputVJP,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {

--- a/src/sasktran2/__init__.py
+++ b/src/sasktran2/__init__.py
@@ -42,6 +42,7 @@ from .config import Config
 from .engine import Engine
 from .geodetic import WGS84, Geodetic, SphericalGeoid
 from .geometry import Geometry1D, Geometry2D
+from .linearization import Linearization
 from .viewinggeo.wrappers import (
     FluxObserverSolar,
     GroundViewingSolar,

--- a/src/sasktran2/__init__.py
+++ b/src/sasktran2/__init__.py
@@ -42,7 +42,7 @@ from .config import Config
 from .engine import Engine
 from .geodetic import WGS84, Geodetic, SphericalGeoid
 from .geometry import Geometry1D, Geometry2D
-from .linearization import Linearization
+from .linearization import Linearization, StaleLinearizationError
 from .viewinggeo.wrappers import (
     FluxObserverSolar,
     GroundViewingSolar,

--- a/src/sasktran2/__init__.py
+++ b/src/sasktran2/__init__.py
@@ -42,7 +42,11 @@ from .config import Config
 from .engine import Engine
 from .geodetic import WGS84, Geodetic, SphericalGeoid
 from .geometry import Geometry1D, Geometry2D
-from .linearization import Linearization, StaleLinearizationError
+from .linearization import (
+    Linearization,
+    LinearizationBackend,
+    StaleLinearizationError,
+)
 from .viewinggeo.wrappers import (
     FluxObserverSolar,
     GroundViewingSolar,

--- a/src/sasktran2/atmosphere.py
+++ b/src/sasktran2/atmosphere.py
@@ -351,6 +351,20 @@ class Atmosphere:
         return self._calculate_derivatives
 
     @property
+    def revision(self) -> int:
+        """Monotonic revision of the built native atmosphere state."""
+        return self._atmosphere.revision
+
+    def mark_changed(self) -> None:
+        """Indicate that directly mutable native atmosphere storage changed.
+
+        Constituent-backed atmospheres call this automatically when their
+        native representation is rebuilt. Users of the raw storage interface
+        must call it after modifying a borrowed NumPy storage view.
+        """
+        self._atmosphere.mark_changed()
+
+    @property
     def calculate_temperature_derivative(self) -> bool:
         """
         True if we are calculating the derivative with respect to temperature
@@ -715,6 +729,10 @@ class Atmosphere:
 
         if len(self._constituents) > 0:
             logging.debug("Setting atmosphere from constituents")
+            # Rebuilding mutates shared native storage. Invalidate existing
+            # linearization sessions before any mutation, including rebuilds
+            # that subsequently fail.
+            self.mark_changed()
             # Using the constituent interface
             if self._storage_needs_reset:
                 self._zero_storage()

--- a/src/sasktran2/atmosphere.py
+++ b/src/sasktran2/atmosphere.py
@@ -346,6 +346,11 @@ class Atmosphere:
         return self._nstokes
 
     @property
+    def calculate_derivatives(self) -> bool:
+        """Whether the atmosphere registers and calculates derivatives."""
+        return self._calculate_derivatives
+
+    @property
     def calculate_temperature_derivative(self) -> bool:
         """
         True if we are calculating the derivative with respect to temperature

--- a/src/sasktran2/engine.py
+++ b/src/sasktran2/engine.py
@@ -9,6 +9,7 @@ import sasktran2 as sk
 from sasktran2._core_rust import PyEngine
 from sasktran2.linearization import (
     Linearization,
+    LinearizationBackend,
     _ParameterSpec,
     _semantic_parameter_name,
 )
@@ -184,6 +185,14 @@ class Engine:
         initial_output = self._engine._calculate_jvp(native_atmosphere, {}, {})
         value = self._radiance_dataarray(initial_output.radiance, atmosphere)
         registry = self._linearization_registry(atmosphere)
+        backend_names = {
+            1: LinearizationBackend.StreamingJacobian,
+            2: LinearizationBackend.Native,
+        }
+        backends = {
+            mode: backend_names[self._engine._linearization_backend(mode_index)]
+            for mode, mode_index in (("jvp", 1), ("vjp", 2))
+        }
 
         def load_jacobian() -> xr.Dataset:
             result, _ = self._calculate_radiance(
@@ -225,24 +234,37 @@ class Engine:
             )
             return self._radiance_dataarray(output.jvp, atmosphere)
 
-        def evaluate_vjp(cotangent: xr.DataArray) -> xr.Dataset:
+        def evaluate_vjp(
+            cotangent: xr.DataArray, parameters: tuple[str, ...]
+        ) -> xr.Dataset:
+            if not parameters:
+                return xr.Dataset()
+            volume_sizes = {
+                name: registry.volume_sizes[name]
+                for parameter in parameters
+                for name in registry.volume_names.get(parameter, ())
+            }
+            surface_sizes = {
+                name: registry.surface_sizes[name]
+                for parameter in parameters
+                for name in registry.surface_names.get(parameter, ())
+            }
             output = self._engine._calculate_vjp(
                 native_atmosphere,
                 np.ascontiguousarray(cotangent.values, dtype=np.float64),
-                registry.volume_sizes,
-                registry.surface_sizes,
+                volume_sizes,
+                surface_sizes,
             )
             gradients = {
                 parameter: xr.zeros_like(registry.tangent_template[parameter])
-                for parameter in registry.specs
+                for parameter in parameters
             }
-            for parameter, names in registry.volume_names.items():
-                for name in names:
+            for parameter in parameters:
+                for name in registry.volume_names.get(parameter, ()):
                     gradients[parameter].data += np.asarray(
                         output.derivative_gradients[name]
                     ).reshape(gradients[parameter].shape)
-            for parameter, names in registry.surface_names.items():
-                for name in names:
+                for name in registry.surface_names.get(parameter, ()):
                     gradients[parameter].data += np.asarray(
                         output.surface_gradients[name]
                     ).reshape(gradients[parameter].shape)
@@ -257,6 +279,7 @@ class Engine:
             load_jacobian,
             evaluate_jvp,
             evaluate_vjp,
+            backends,
             (self, native_atmosphere),
         )
 

--- a/src/sasktran2/engine.py
+++ b/src/sasktran2/engine.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import numpy as np
 import xarray as xr
 
 import sasktran2 as sk
 from sasktran2._core_rust import PyEngine
-from sasktran2.linearization import Linearization, _ParameterSpec
+from sasktran2.linearization import (
+    Linearization,
+    _ParameterSpec,
+    _semantic_parameter_name,
+)
 from sasktran2.viewinggeo.base import ViewingGeometryContainer
 
 
@@ -46,6 +52,18 @@ def atmosphere_derivative_dataarray(
         derivative.reshape((*output_shape, *derivative.shape[1:])),
         dims=["horizontal_angle", "altitude", *trailing_dims],
     )
+
+
+@dataclass(frozen=True)
+class _LinearizationRegistry:
+    specs: dict[str, _ParameterSpec]
+    tangent_template: xr.Dataset
+    volume_names: dict[str, tuple[str, ...]]
+    surface_names: dict[str, tuple[str, ...]]
+    volume_sizes: dict[str, int]
+    surface_sizes: dict[str, int]
+    output_names: dict[str, str]
+    log_parameters: frozenset[str]
 
 
 class Engine:
@@ -135,11 +153,9 @@ class Engine:
     def linearize(self, atmosphere: sk.Atmosphere) -> Linearization:
         """Construct the local linear radiance model for an atmosphere.
 
-        The initial implementation calculates and caches the complete
-        structured radiance Jacobian. JVP and VJP operations on the returned
-        object do not run the radiative-transfer model again. The returned
-        linearization is fixed at the atmosphere state captured by this call;
-        subsequent changes to ``atmosphere`` do not affect it.
+        JVP and VJP operations stream contractions through the native output
+        path without allocating the complete structured radiance Jacobian.
+        The Jacobian is calculated and cached only if requested.
 
         Parameters
         ----------
@@ -152,6 +168,7 @@ class Engine:
         Linearization
             The radiance and local derivative operations.
         """
+        self._validate_atmosphere_geometry(atmosphere)
         if not atmosphere.calculate_derivatives:
             msg = (
                 "Engine.linearize requires an atmosphere constructed with "
@@ -162,12 +179,215 @@ class Engine:
             msg = "The configured engine does not support full-Jacobian linearization"
             raise NotImplementedError(msg)
 
-        result, specs = self._calculate_radiance(atmosphere)
-        return Linearization._from_result(result, specs)
+        native_atmosphere = atmosphere.internal_object()
+        revision = atmosphere.revision
+        initial_output = self._engine._calculate_jvp(native_atmosphere, {}, {})
+        value = self._radiance_dataarray(initial_output.radiance, atmosphere)
+        registry = self._linearization_registry(atmosphere)
 
-    def _calculate_radiance(
+        def load_jacobian() -> xr.Dataset:
+            result, _ = self._calculate_radiance(
+                atmosphere, internal_atmosphere=native_atmosphere
+            )
+            jacobian: dict[str, xr.DataArray] = {}
+            for parameter, output_name in registry.output_names.items():
+                block = result[output_name]
+                if parameter in registry.log_parameters:
+                    block = block * result["radiance"]
+                jacobian[parameter] = block
+            return xr.Dataset(jacobian)
+
+        def evaluate_jvp(tangent: xr.Dataset) -> xr.DataArray:
+            volume_tangents: dict[str, np.ndarray] = {}
+            surface_tangents: dict[str, np.ndarray] = {}
+            for parameter in tangent.data_vars:
+                values = np.ascontiguousarray(tangent[parameter].values).reshape(-1)
+                for name in registry.volume_names.get(parameter, ()):
+                    volume_tangents[name] = values
+                for name in registry.surface_names.get(parameter, ()):
+                    surface_tangents[name] = values
+            output = self._engine._calculate_jvp(
+                native_atmosphere, volume_tangents, surface_tangents
+            )
+            return self._radiance_dataarray(output.jvp, atmosphere)
+
+        def evaluate_vjp(cotangent: xr.DataArray) -> xr.Dataset:
+            output = self._engine._calculate_vjp(
+                native_atmosphere,
+                np.ascontiguousarray(cotangent.values),
+                registry.volume_sizes,
+                registry.surface_sizes,
+            )
+            gradients = {
+                parameter: xr.zeros_like(registry.tangent_template[parameter])
+                for parameter in registry.specs
+            }
+            for parameter, names in registry.volume_names.items():
+                for name in names:
+                    gradients[parameter].data += np.asarray(
+                        output.derivative_gradients[name]
+                    ).reshape(gradients[parameter].shape)
+            for parameter, names in registry.surface_names.items():
+                for name in names:
+                    gradients[parameter].data += np.asarray(
+                        output.surface_gradients[name]
+                    ).reshape(gradients[parameter].shape)
+            return xr.Dataset(gradients)
+
+        return Linearization._from_engine(
+            value,
+            registry.specs,
+            registry.tangent_template,
+            atmosphere,
+            revision,
+            load_jacobian,
+            evaluate_jvp,
+            evaluate_vjp,
+            (self, native_atmosphere),
+        )
+
+    def _radiance_dataarray(
+        self, radiance: np.ndarray, atmosphere: sk.Atmosphere
+    ) -> xr.DataArray:
+        dataset = xr.Dataset(
+            {"radiance": xr.DataArray(radiance, dims=["wavelength", "los", "stokes"])}
+        )
+        if atmosphere.wavelengths_nm is not None:
+            dataset.coords["wavelength"] = atmosphere.wavelengths_nm
+        dataset.coords["stokes"] = ["I", "Q", "U", "V"][: len(dataset.stokes)]
+        if isinstance(self._viewing_geometry, ViewingGeometryContainer):
+            dataset = self._viewing_geometry.add_geometry_to_radiance(dataset)
+        return dataset["radiance"]
+
+    def _linearization_registry(
         self, atmosphere: sk.Atmosphere
-    ) -> tuple[xr.Dataset, dict[str, _ParameterSpec]]:
+    ) -> _LinearizationRegistry:
+        specs: dict[str, _ParameterSpec] = {}
+        templates: dict[str, xr.DataArray] = {}
+        volume_names: dict[str, list[str]] = {}
+        surface_names: dict[str, list[str]] = {}
+        volume_sizes: dict[str, int] = {}
+        surface_sizes: dict[str, int] = {}
+        output_names: dict[str, str] = {}
+        log_parameters: set[str] = set()
+
+        def template_for(dims: tuple[str, ...], shape: tuple[int, ...]) -> xr.DataArray:
+            coords: dict[str, np.ndarray] = {}
+            for dim, size in zip(dims, shape, strict=True):
+                if dim == "wavelength" and atmosphere.wavelengths_nm is not None:
+                    coords[dim] = atmosphere.wavelengths_nm
+                elif dim == "altitude" and isinstance(
+                    atmosphere.model_geometry, sk.Geometry2D
+                ):
+                    coordinate = atmosphere.model_geometry.altitudes()
+                    if len(coordinate) == size:
+                        coords[dim] = coordinate
+                elif dim == "horizontal_angle" and isinstance(
+                    atmosphere.model_geometry, sk.Geometry2D
+                ):
+                    coordinate = atmosphere.model_geometry.horizontal_angles()
+                    if len(coordinate) == size:
+                        coords[dim] = coordinate
+            return xr.DataArray(np.zeros(shape), dims=dims, coords=coords)
+
+        def register(
+            internal_name: str,
+            output_name: str,
+            spec: _ParameterSpec,
+            template: xr.DataArray,
+            *,
+            surface: bool,
+            log_radiance_space: bool = False,
+        ) -> None:
+            parameter = _semantic_parameter_name(output_name)
+            if parameter in specs:
+                if specs[parameter] != spec or output_names[parameter] != output_name:
+                    msg = (
+                        "Multiple derivative mappings for semantic parameter "
+                        f"{parameter!r} have incompatible layouts"
+                    )
+                    raise ValueError(msg)
+                if (parameter in log_parameters) != log_radiance_space:
+                    msg = (
+                        f"Derivative mappings assigned to {parameter!r} mix "
+                        "radiance and log-radiance output spaces"
+                    )
+                    raise ValueError(msg)
+            else:
+                specs[parameter] = spec
+                templates[parameter] = template
+                output_names[parameter] = output_name
+            if log_radiance_space:
+                log_parameters.add(parameter)
+            target = surface_names if surface else volume_names
+            target.setdefault(parameter, []).append(internal_name)
+
+        for internal_name in atmosphere.storage.derivative_mapping_names():
+            mapping = atmosphere.storage.get_derivative_mapping(internal_name)
+            interpolator = np.asarray(mapping.interpolator)
+            size = (
+                int(interpolator.shape[1])
+                if interpolator.size
+                else atmosphere.num_locations
+            )
+            structured_shape = atmosphere.derivative_output_shape(internal_name)
+            if structured_shape is not None:
+                dims = ("horizontal_angle", "altitude")
+                shape = tuple(structured_shape)
+            else:
+                dims = (mapping.interp_dim,)
+                shape = (size,)
+            output_name = (
+                internal_name if mapping.assign_name == "" else mapping.assign_name
+            )
+            register(
+                internal_name,
+                output_name,
+                _ParameterSpec(dims),
+                template_for(dims, shape),
+                surface=False,
+                log_radiance_space=mapping.log_radiance_space,
+            )
+            volume_sizes[internal_name] = size
+
+        for internal_name in atmosphere.surface.derivative_mapping_names():
+            mapping = atmosphere.surface.get_derivative_mapping(internal_name)
+            interpolator = np.asarray(mapping.interpolator)
+            if interpolator.size:
+                size = int(interpolator.shape[1])
+                if mapping.interp_dim == "dummy":
+                    dims: tuple[str, ...] = ()
+                    shape: tuple[int, ...] = ()
+                else:
+                    dims = (mapping.interp_dim,)
+                    shape = (size,)
+                spec = _ParameterSpec(dims)
+            else:
+                size = atmosphere.num_wavel
+                dims = ("wavelength",)
+                shape = (size,)
+                spec = _ParameterSpec(dims, ("wavelength",))
+            register(
+                internal_name,
+                internal_name,
+                spec,
+                template_for(dims, shape),
+                surface=True,
+            )
+            surface_sizes[internal_name] = size
+
+        return _LinearizationRegistry(
+            specs,
+            xr.Dataset(templates),
+            {name: tuple(names) for name, names in volume_names.items()},
+            {name: tuple(names) for name, names in surface_names.items()},
+            volume_sizes,
+            surface_sizes,
+            output_names,
+            frozenset(log_parameters),
+        )
+
+    def _validate_atmosphere_geometry(self, atmosphere: sk.Atmosphere) -> None:
         if isinstance(self._geometry, sk.Geometry2D) != isinstance(
             atmosphere.model_geometry, sk.Geometry2D
         ):
@@ -186,7 +406,16 @@ class Engine:
             )
             raise ValueError(msg)
 
-        output = self._engine.calculate_radiance(atmosphere.internal_object())
+    def _calculate_radiance(
+        self,
+        atmosphere: sk.Atmosphere,
+        internal_atmosphere=None,
+    ) -> tuple[xr.Dataset, dict[str, _ParameterSpec]]:
+        self._validate_atmosphere_geometry(atmosphere)
+
+        if internal_atmosphere is None:
+            internal_atmosphere = atmosphere.internal_object()
+        output = self._engine.calculate_radiance(internal_atmosphere)
 
         out_ds = xr.Dataset()
         radiance_derivative_specs: dict[str, _ParameterSpec] = {}

--- a/src/sasktran2/engine.py
+++ b/src/sasktran2/engine.py
@@ -192,6 +192,18 @@ class Engine:
             jacobian: dict[str, xr.DataArray] = {}
             for parameter, output_name in registry.output_names.items():
                 block = result[output_name]
+                if not registry.specs[parameter].parameter_dims:
+                    scalar_dims = tuple(
+                        dim for dim in block.dims if dim not in value.dims
+                    )
+                    for dim in scalar_dims:
+                        if block.sizes[dim] != 1:
+                            msg = (
+                                f"Scalar parameter {parameter!r} has a non-scalar "
+                                f"Jacobian dimension {dim!r}"
+                            )
+                            raise ValueError(msg)
+                        block = block.isel({dim: 0}, drop=True)
                 if parameter in registry.log_parameters:
                     block = block * result["radiance"]
                 jacobian[parameter] = block
@@ -201,7 +213,9 @@ class Engine:
             volume_tangents: dict[str, np.ndarray] = {}
             surface_tangents: dict[str, np.ndarray] = {}
             for parameter in tangent.data_vars:
-                values = np.ascontiguousarray(tangent[parameter].values).reshape(-1)
+                values = np.ascontiguousarray(
+                    tangent[parameter].values, dtype=np.float64
+                ).reshape(-1)
                 for name in registry.volume_names.get(parameter, ()):
                     volume_tangents[name] = values
                 for name in registry.surface_names.get(parameter, ()):
@@ -214,7 +228,7 @@ class Engine:
         def evaluate_vjp(cotangent: xr.DataArray) -> xr.Dataset:
             output = self._engine._calculate_vjp(
                 native_atmosphere,
-                np.ascontiguousarray(cotangent.values),
+                np.ascontiguousarray(cotangent.values, dtype=np.float64),
                 registry.volume_sizes,
                 registry.surface_sizes,
             )
@@ -355,7 +369,7 @@ class Engine:
             interpolator = np.asarray(mapping.interpolator)
             if interpolator.size:
                 size = int(interpolator.shape[1])
-                if mapping.interp_dim == "dummy":
+                if mapping.interp_dim == "dummy" or size == 1:
                     dims: tuple[str, ...] = ()
                     shape: tuple[int, ...] = ()
                 else:

--- a/src/sasktran2/engine.py
+++ b/src/sasktran2/engine.py
@@ -5,6 +5,7 @@ import xarray as xr
 
 import sasktran2 as sk
 from sasktran2._core_rust import PyEngine
+from sasktran2.linearization import Linearization, _ParameterSpec
 from sasktran2.viewinggeo.base import ViewingGeometryContainer
 
 
@@ -128,6 +129,45 @@ class Engine:
         xr.Dataset
             An xarray dataset containing the radiance and derivatives
         """
+        result, _ = self._calculate_radiance(atmosphere)
+        return result
+
+    def linearize(self, atmosphere: sk.Atmosphere) -> Linearization:
+        """Construct the local linear radiance model for an atmosphere.
+
+        The initial implementation calculates and caches the complete
+        structured radiance Jacobian. JVP and VJP operations on the returned
+        object do not run the radiative-transfer model again. The returned
+        linearization is fixed at the atmosphere state captured by this call;
+        subsequent changes to ``atmosphere`` do not affect it.
+
+        Parameters
+        ----------
+        atmosphere : sk.Atmosphere
+            Atmosphere defining the linearization point. It must have been
+            constructed with calculate_derivatives=True.
+
+        Returns
+        -------
+        Linearization
+            The radiance and local derivative operations.
+        """
+        if not atmosphere.calculate_derivatives:
+            msg = (
+                "Engine.linearize requires an atmosphere constructed with "
+                "calculate_derivatives=True"
+            )
+            raise ValueError(msg)
+        if not self._engine._supports_linearization(0):
+            msg = "The configured engine does not support full-Jacobian linearization"
+            raise NotImplementedError(msg)
+
+        result, specs = self._calculate_radiance(atmosphere)
+        return Linearization._from_result(result, specs)
+
+    def _calculate_radiance(
+        self, atmosphere: sk.Atmosphere
+    ) -> tuple[xr.Dataset, dict[str, _ParameterSpec]]:
         if isinstance(self._geometry, sk.Geometry2D) != isinstance(
             atmosphere.model_geometry, sk.Geometry2D
         ):
@@ -149,6 +189,7 @@ class Engine:
         output = self._engine.calculate_radiance(atmosphere.internal_object())
 
         out_ds = xr.Dataset()
+        radiance_derivative_specs: dict[str, _ParameterSpec] = {}
 
         out_ds["radiance"] = xr.DataArray(
             output.radiance,
@@ -194,6 +235,14 @@ class Engine:
                 out_ds[name] += mapped_derivative
             else:
                 out_ds[name] = mapped_derivative
+            spec = _ParameterSpec(tuple(mapped_derivative.dims[:-3]))
+            previous_spec = radiance_derivative_specs.setdefault(name, spec)
+            if previous_spec != spec:
+                msg = (
+                    f"Radiance derivative mappings assigned to {name!r} have "
+                    "incompatible parameter dimensions"
+                )
+                raise ValueError(msg)
         for k, v in output.d_radiance_surf.items():
             mapping = atmosphere.surface.get_derivative_mapping(k)
 
@@ -203,6 +252,12 @@ class Engine:
             if mapping.interp_dim == "dummy":
                 mapped_derivative = mapped_derivative.isel(**{mapping.interp_dim: 0})
             out_ds[k] = mapped_derivative
+
+            if mapping.interpolator is None or len(mapping.interpolator) == 0:
+                spec = _ParameterSpec(("wavelength",), ("wavelength",))
+            else:
+                spec = _ParameterSpec(tuple(mapped_derivative.dims[:-3]))
+            radiance_derivative_specs[k] = spec
 
         for k, v in output.d_flux.items():
             mapping = atmosphere.storage.get_derivative_mapping(k)
@@ -260,4 +315,4 @@ class Engine:
                 dims=["wavelength", "los"],
             )
 
-        return out_ds
+        return out_ds, radiance_derivative_specs

--- a/src/sasktran2/linearization.py
+++ b/src/sasktran2/linearization.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+
+import numpy as np
+import xarray as xr
+
+
+@dataclass(frozen=True)
+class _ParameterSpec:
+    """Internal description of a parameter axis in a Jacobian block."""
+
+    parameter_dims: tuple[str, ...]
+    diagonal_dims: tuple[str, ...] = ()
+
+
+def _semantic_parameter_name(weighting_function_name: str) -> str:
+    if weighting_function_name.startswith("wf_"):
+        return weighting_function_name[3:]
+    return weighting_function_name
+
+
+def _dimension_coordinate(array: xr.DataArray, dim: str) -> xr.DataArray | None:
+    if dim not in array.coords:
+        return None
+
+    coordinate = array.coords[dim]
+    if coordinate.dims != (dim,):
+        return None
+    return coordinate
+
+
+def _validated_array(
+    array: xr.DataArray,
+    reference: xr.DataArray,
+    expected_dims: tuple[str, ...],
+    description: str,
+) -> xr.DataArray:
+    if not isinstance(array, xr.DataArray):
+        msg = f"{description} must be an xarray.DataArray"
+        raise TypeError(msg)
+
+    if len(array.dims) != len(expected_dims) or set(array.dims) != set(expected_dims):
+        msg = f"{description} must have dimensions {expected_dims}; got {array.dims}"
+        raise ValueError(msg)
+
+    array = array.transpose(*expected_dims)
+    for dim in expected_dims:
+        if array.sizes[dim] != reference.sizes[dim]:
+            msg = (
+                f"{description} dimension {dim!r} must have size "
+                f"{reference.sizes[dim]}; got {array.sizes[dim]}"
+            )
+            raise ValueError(msg)
+
+        expected_coordinate = _dimension_coordinate(reference, dim)
+        if expected_coordinate is None:
+            continue
+
+        actual_coordinate = _dimension_coordinate(array, dim)
+        if actual_coordinate is None:
+            msg = f"{description} is missing the coordinate for dimension {dim!r}"
+            raise ValueError(msg)
+        if not actual_coordinate.equals(expected_coordinate):
+            msg = f"{description} coordinate for dimension {dim!r} does not match"
+            raise ValueError(msg)
+
+    if not np.issubdtype(array.dtype, np.number):
+        msg = f"{description} must contain numeric values; got {array.dtype}"
+        raise ValueError(msg)
+
+    return array
+
+
+def _parameter_template(block: xr.DataArray, spec: _ParameterSpec) -> xr.DataArray:
+    """Construct a zero tangent carrying only a parameter's input grid."""
+    coordinates = {}
+    for dim in spec.parameter_dims:
+        coordinate = _dimension_coordinate(block, dim)
+        if coordinate is not None:
+            coordinates[dim] = coordinate
+
+    shape = tuple(block.sizes[dim] for dim in spec.parameter_dims)
+    return xr.DataArray(
+        np.zeros(shape, dtype=block.dtype),
+        dims=spec.parameter_dims,
+        coords=coordinates,
+    )
+
+
+class _FullJacobianBackend:
+    """Linearization backend that contracts a cached structured Jacobian."""
+
+    def __init__(
+        self,
+        value: xr.DataArray,
+        jacobian: xr.Dataset,
+        specs: Mapping[str, _ParameterSpec],
+        tangent_template: xr.Dataset,
+    ) -> None:
+        self.value = value
+        self.jacobian = jacobian
+        self.specs = MappingProxyType(dict(specs))
+        self.tangent_template = tangent_template
+
+    def jvp(self, tangent: xr.Dataset) -> xr.DataArray:
+        if not isinstance(tangent, xr.Dataset):
+            msg = "The JVP tangent must be an xarray.Dataset"
+            raise TypeError(msg)
+
+        unknown = set(tangent.data_vars) - set(self.specs)
+        if unknown:
+            names = ", ".join(sorted(unknown))
+            msg = f"Unknown tangent parameter(s): {names}"
+            raise ValueError(msg)
+
+        result = xr.zeros_like(self.value)
+        for name in tangent.data_vars:
+            spec = self.specs[name]
+            block = self.jacobian[name]
+            direction = _validated_array(
+                tangent[name],
+                self.tangent_template[name],
+                spec.parameter_dims,
+                f"Tangent parameter {name!r}",
+            )
+
+            contribution = block * direction
+            contraction_dims = tuple(
+                dim for dim in spec.parameter_dims if dim not in spec.diagonal_dims
+            )
+            if contraction_dims:
+                contribution = contribution.sum(dim=contraction_dims)
+
+            contribution = contribution.transpose(*self.value.dims)
+            result = result + contribution
+
+        return result
+
+    def vjp(self, cotangent: xr.DataArray) -> xr.Dataset:
+        cotangent = _validated_array(
+            cotangent,
+            self.value,
+            tuple(self.value.dims),
+            "The VJP radiance cotangent",
+        )
+
+        gradients: dict[str, xr.DataArray] = {}
+        output_dims = tuple(self.value.dims)
+        for name, spec in self.specs.items():
+            weighted = self.jacobian[name] * cotangent
+            contraction_dims = tuple(
+                dim for dim in output_dims if dim not in spec.diagonal_dims
+            )
+            if contraction_dims:
+                weighted = weighted.sum(dim=contraction_dims)
+            gradients[name] = weighted.transpose(*spec.parameter_dims)
+
+        return xr.Dataset(gradients)
+
+
+class Linearization:
+    """Radiance and its local linear model at a fixed atmosphere state.
+
+    Instances are created by sasktran2.Engine.linearize. The initial
+    implementation stores the complete structured radiance Jacobian and uses
+    it to evaluate both Jacobian-vector and vector-Jacobian products. A
+    linearization is a snapshot: later mutation or recalculation of the
+    atmosphere used to create it does not change its value or derivative
+    products.
+    """
+
+    def __init__(self, backend: _FullJacobianBackend) -> None:
+        self._backend = backend
+
+    @classmethod
+    def _from_result(
+        cls,
+        result: xr.Dataset,
+        weighting_function_specs: Mapping[str, _ParameterSpec],
+    ) -> Linearization:
+        jacobian_variables: dict[str, xr.DataArray] = {}
+        parameter_specs: dict[str, _ParameterSpec] = {}
+        tangent_variables: dict[str, xr.DataArray] = {}
+
+        for weighting_function_name, spec in weighting_function_specs.items():
+            parameter_name = _semantic_parameter_name(weighting_function_name)
+            if parameter_name in jacobian_variables:
+                msg = (
+                    "Multiple weighting functions map to the semantic parameter "
+                    f"name {parameter_name!r}"
+                )
+                raise ValueError(msg)
+            jacobian_variables[parameter_name] = result[weighting_function_name]
+            parameter_specs[parameter_name] = spec
+            tangent_variables[parameter_name] = _parameter_template(
+                result[weighting_function_name], spec
+            )
+
+        if not jacobian_variables:
+            msg = (
+                "No radiance derivative mappings are available. Construct the "
+                "atmosphere with calculate_derivatives=True and register at "
+                "least one differentiable parameter."
+            )
+            raise ValueError(msg)
+
+        backend = _FullJacobianBackend(
+            result["radiance"],
+            xr.Dataset(jacobian_variables),
+            parameter_specs,
+            xr.Dataset(tangent_variables),
+        )
+        return cls(backend)
+
+    @property
+    def value(self) -> xr.DataArray:
+        """Radiance at the linearization point."""
+        return self._backend.value
+
+    @property
+    def jacobian(self) -> xr.Dataset:
+        """Structured radiance Jacobian, keyed by semantic parameter name."""
+        return self._backend.jacobian
+
+    @property
+    def parameters(self) -> tuple[str, ...]:
+        """Parameters accepted by jvp and returned by vjp."""
+        return tuple(self._backend.specs)
+
+    @property
+    def parameter_dims(self) -> Mapping[str, tuple[str, ...]]:
+        """Expected tangent dimensions for every parameter."""
+        return MappingProxyType(
+            {name: spec.parameter_dims for name, spec in self._backend.specs.items()}
+        )
+
+    @property
+    def tangent_template(self) -> xr.Dataset:
+        """Zero tangent containing every parameter's input grid.
+
+        The returned dataset describes parameter shapes, dimensions, and
+        dimension coordinates without requiring access to :attr:`jacobian`.
+        It is an independent copy that callers may fill or subset before
+        passing it to :meth:`jvp`.
+        """
+        return self._backend.tangent_template.copy(deep=True)
+
+    def jvp(self, tangent: xr.Dataset) -> xr.DataArray:
+        """Apply the radiance Jacobian to one labeled tangent direction."""
+        return self._backend.jvp(tangent)
+
+    def vjp(self, cotangent: xr.DataArray) -> xr.Dataset:
+        """Apply the transpose radiance Jacobian to one radiance cotangent."""
+        return self._backend.vjp(cotangent)

--- a/src/sasktran2/linearization.py
+++ b/src/sasktran2/linearization.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
 
@@ -161,19 +161,129 @@ class _FullJacobianBackend:
         return xr.Dataset(gradients)
 
 
-class Linearization:
-    """Radiance and its local linear model at a fixed atmosphere state.
+class StaleLinearizationError(RuntimeError):
+    """Raised when an operation requires an atmosphere that has changed."""
 
-    Instances are created by sasktran2.Engine.linearize. The initial
-    implementation stores the complete structured radiance Jacobian and uses
-    it to evaluate both Jacobian-vector and vector-Jacobian products. A
-    linearization is a snapshot: later mutation or recalculation of the
-    atmosphere used to create it does not change its value or derivative
-    products.
+
+class _EngineBackend:
+    """Streaming engine backend with lazy full-Jacobian materialization."""
+
+    def __init__(
+        self,
+        value: xr.DataArray,
+        specs: Mapping[str, _ParameterSpec],
+        tangent_template: xr.Dataset,
+        atmosphere,
+        revision: int,
+        jacobian_loader: Callable[[], xr.Dataset],
+        jvp_evaluator: Callable[[xr.Dataset], xr.DataArray],
+        vjp_evaluator: Callable[[xr.DataArray], xr.Dataset],
+        owner,
+    ) -> None:
+        self.value = value
+        self.specs = MappingProxyType(dict(specs))
+        self.tangent_template = tangent_template
+        self._atmosphere = atmosphere
+        self._revision = revision
+        self._jacobian_loader = jacobian_loader
+        self._jvp_evaluator = jvp_evaluator
+        self._vjp_evaluator = vjp_evaluator
+        self._owner = owner
+        self._jacobian: xr.Dataset | None = None
+
+    def _require_current(self) -> None:
+        if self._atmosphere.revision != self._revision:
+            msg = (
+                "The atmosphere has changed since this linearization was "
+                "created. Call engine.linearize(atmosphere) again."
+            )
+            raise StaleLinearizationError(msg)
+
+    @property
+    def jacobian(self) -> xr.Dataset:
+        if self._jacobian is None:
+            self._require_current()
+            self._jacobian = self._jacobian_loader()
+        return self._jacobian
+
+    def jvp(self, tangent: xr.Dataset) -> xr.DataArray:
+        if not isinstance(tangent, xr.Dataset):
+            msg = "The JVP tangent must be an xarray.Dataset"
+            raise TypeError(msg)
+
+        unknown = set(tangent.data_vars) - set(self.specs)
+        if unknown:
+            names = ", ".join(sorted(unknown))
+            msg = f"Unknown tangent parameter(s): {names}"
+            raise ValueError(msg)
+
+        normalized: dict[str, xr.DataArray] = {}
+        for name in tangent.data_vars:
+            normalized[name] = _validated_array(
+                tangent[name],
+                self.tangent_template[name],
+                self.specs[name].parameter_dims,
+                f"Tangent parameter {name!r}",
+            )
+
+        self._require_current()
+        return self._jvp_evaluator(xr.Dataset(normalized))
+
+    def vjp(self, cotangent: xr.DataArray) -> xr.Dataset:
+        cotangent = _validated_array(
+            cotangent,
+            self.value,
+            tuple(self.value.dims),
+            "The VJP radiance cotangent",
+        )
+        self._require_current()
+        return self._vjp_evaluator(cotangent)
+
+
+class Linearization:
+    """Radiance and its local linear model at a built atmosphere state.
+
+    Engine-created instances stream Jacobian-vector and vector-Jacobian
+    contractions through the radiative-transfer output path. The complete
+    structured Jacobian is materialized only when requested.
     """
 
-    def __init__(self, backend: _FullJacobianBackend) -> None:
+    def __init__(self, backend: _FullJacobianBackend | _EngineBackend) -> None:
         self._backend = backend
+
+    @classmethod
+    def _from_engine(
+        cls,
+        value: xr.DataArray,
+        specs: Mapping[str, _ParameterSpec],
+        tangent_template: xr.Dataset,
+        atmosphere,
+        revision: int,
+        jacobian_loader: Callable[[], xr.Dataset],
+        jvp_evaluator: Callable[[xr.Dataset], xr.DataArray],
+        vjp_evaluator: Callable[[xr.DataArray], xr.Dataset],
+        owner,
+    ) -> Linearization:
+        if not specs:
+            msg = (
+                "No radiance derivative mappings are available. Construct the "
+                "atmosphere with calculate_derivatives=True and register at "
+                "least one differentiable parameter."
+            )
+            raise ValueError(msg)
+        return cls(
+            _EngineBackend(
+                value,
+                specs,
+                tangent_template,
+                atmosphere,
+                revision,
+                jacobian_loader,
+                jvp_evaluator,
+                vjp_evaluator,
+                owner,
+            )
+        )
 
     @classmethod
     def _from_result(

--- a/src/sasktran2/linearization.py
+++ b/src/sasktran2/linearization.py
@@ -67,8 +67,10 @@ def _validated_array(
             msg = f"{description} coordinate for dimension {dim!r} does not match"
             raise ValueError(msg)
 
-    if not np.issubdtype(array.dtype, np.number):
-        msg = f"{description} must contain numeric values; got {array.dtype}"
+    if not np.issubdtype(array.dtype, np.number) or np.issubdtype(
+        array.dtype, np.complexfloating
+    ):
+        msg = f"{description} must contain real numeric values; got {array.dtype}"
         raise ValueError(msg)
 
     return array

--- a/src/sasktran2/linearization.py
+++ b/src/sasktran2/linearization.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
+from enum import Enum
 from types import MappingProxyType
 
 import numpy as np
 import xarray as xr
+
+
+class LinearizationBackend(str, Enum):
+    """Execution strategy used for a radiance derivative product."""
+
+    Native = "native"
+    StreamingJacobian = "streaming_jacobian"
+    MaterializedJacobian = "materialized_jacobian"
 
 
 @dataclass(frozen=True)
@@ -92,6 +101,31 @@ def _parameter_template(block: xr.DataArray, spec: _ParameterSpec) -> xr.DataArr
     )
 
 
+def _selected_parameters(
+    parameters: Iterable[str] | None,
+    specs: Mapping[str, _ParameterSpec],
+) -> tuple[str, ...]:
+    if parameters is None:
+        return tuple(specs)
+    if isinstance(parameters, str):
+        parameters = (parameters,)
+
+    selected = tuple(parameters)
+    if any(not isinstance(name, str) for name in selected):
+        msg = "VJP parameter names must be strings"
+        raise TypeError(msg)
+    if len(set(selected)) != len(selected):
+        msg = "VJP parameter names must not contain duplicates"
+        raise ValueError(msg)
+
+    unknown = set(selected) - set(specs)
+    if unknown:
+        names = ", ".join(sorted(unknown))
+        msg = f"Unknown VJP parameter(s): {names}"
+        raise ValueError(msg)
+    return selected
+
+
 class _FullJacobianBackend:
     """Linearization backend that contracts a cached structured Jacobian."""
 
@@ -106,6 +140,12 @@ class _FullJacobianBackend:
         self.jacobian = jacobian
         self.specs = MappingProxyType(dict(specs))
         self.tangent_template = tangent_template
+        self.backends = MappingProxyType(
+            {
+                "jvp": LinearizationBackend.MaterializedJacobian,
+                "vjp": LinearizationBackend.MaterializedJacobian,
+            }
+        )
 
     def jvp(self, tangent: xr.Dataset) -> xr.DataArray:
         if not isinstance(tangent, xr.Dataset):
@@ -141,17 +181,23 @@ class _FullJacobianBackend:
 
         return result
 
-    def vjp(self, cotangent: xr.DataArray) -> xr.Dataset:
+    def vjp(
+        self,
+        cotangent: xr.DataArray,
+        parameters: Iterable[str] | None = None,
+    ) -> xr.Dataset:
         cotangent = _validated_array(
             cotangent,
             self.value,
             tuple(self.value.dims),
             "The VJP radiance cotangent",
         )
+        selected = _selected_parameters(parameters, self.specs)
 
         gradients: dict[str, xr.DataArray] = {}
         output_dims = tuple(self.value.dims)
-        for name, spec in self.specs.items():
+        for name in selected:
+            spec = self.specs[name]
             weighted = self.jacobian[name] * cotangent
             contraction_dims = tuple(
                 dim for dim in output_dims if dim not in spec.diagonal_dims
@@ -179,7 +225,8 @@ class _EngineBackend:
         revision: int,
         jacobian_loader: Callable[[], xr.Dataset],
         jvp_evaluator: Callable[[xr.Dataset], xr.DataArray],
-        vjp_evaluator: Callable[[xr.DataArray], xr.Dataset],
+        vjp_evaluator: Callable[[xr.DataArray, tuple[str, ...]], xr.Dataset],
+        backends: Mapping[str, LinearizationBackend],
         owner,
     ) -> None:
         self.value = value
@@ -190,6 +237,7 @@ class _EngineBackend:
         self._jacobian_loader = jacobian_loader
         self._jvp_evaluator = jvp_evaluator
         self._vjp_evaluator = vjp_evaluator
+        self.backends = MappingProxyType(dict(backends))
         self._owner = owner
         self._jacobian: xr.Dataset | None = None
 
@@ -231,15 +279,20 @@ class _EngineBackend:
         self._require_current()
         return self._jvp_evaluator(xr.Dataset(normalized))
 
-    def vjp(self, cotangent: xr.DataArray) -> xr.Dataset:
+    def vjp(
+        self,
+        cotangent: xr.DataArray,
+        parameters: Iterable[str] | None = None,
+    ) -> xr.Dataset:
         cotangent = _validated_array(
             cotangent,
             self.value,
             tuple(self.value.dims),
             "The VJP radiance cotangent",
         )
+        selected = _selected_parameters(parameters, self.specs)
         self._require_current()
-        return self._vjp_evaluator(cotangent)
+        return self._vjp_evaluator(cotangent, selected)
 
 
 class Linearization:
@@ -263,7 +316,8 @@ class Linearization:
         revision: int,
         jacobian_loader: Callable[[], xr.Dataset],
         jvp_evaluator: Callable[[xr.Dataset], xr.DataArray],
-        vjp_evaluator: Callable[[xr.DataArray], xr.Dataset],
+        vjp_evaluator: Callable[[xr.DataArray, tuple[str, ...]], xr.Dataset],
+        backends: Mapping[str, LinearizationBackend],
         owner,
     ) -> Linearization:
         if not specs:
@@ -283,6 +337,7 @@ class Linearization:
                 jacobian_loader,
                 jvp_evaluator,
                 vjp_evaluator,
+                backends,
                 owner,
             )
         )
@@ -350,6 +405,11 @@ class Linearization:
         )
 
     @property
+    def backends(self) -> Mapping[str, LinearizationBackend]:
+        """Derivative-product execution strategies selected by the engine."""
+        return self._backend.backends
+
+    @property
     def tangent_template(self) -> xr.Dataset:
         """Zero tangent containing every parameter's input grid.
 
@@ -364,6 +424,20 @@ class Linearization:
         """Apply the radiance Jacobian to one labeled tangent direction."""
         return self._backend.jvp(tangent)
 
-    def vjp(self, cotangent: xr.DataArray) -> xr.Dataset:
-        """Apply the transpose radiance Jacobian to one radiance cotangent."""
-        return self._backend.vjp(cotangent)
+    def vjp(
+        self,
+        cotangent: xr.DataArray,
+        parameters: Iterable[str] | None = None,
+    ) -> xr.Dataset:
+        """Apply the transpose radiance Jacobian to one radiance cotangent.
+
+        Parameters
+        ----------
+        cotangent
+            Labeled radiance cotangent matching :attr:`value`.
+        parameters
+            Semantic parameter names to return. By default every parameter is
+            returned. Restricting this collection also avoids evaluating
+            unrequested derivative mappings in engine-created backends.
+        """
+        return self._backend.vjp(cotangent, parameters)

--- a/tests/engine/test_geometry2d_transmission.py
+++ b/tests/engine/test_geometry2d_transmission.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 import sasktran2 as sk
+import xarray as xr
 
 EARTH_RADIUS_M = 6_372_000.0
 ALTITUDES_M = np.array([0.0, 10_000.0, 30_000.0])
@@ -274,6 +275,41 @@ def test_native_2d_extinction_derivative_matches_finite_difference():
     ]
     np.testing.assert_allclose(numeric, analytic, rtol=4.0e-5)
     np.testing.assert_array_equal(perturbed.radiance[1, 0, 0], base.radiance[1, 0, 0])
+
+
+def test_native_2d_linearization_products_preserve_structured_parameters():
+    config = transmission_config()
+    geometry = geometry2d()
+    viewing = sk.ViewingGeometry()
+    viewing.add_ray(tangent_ray())
+    atmosphere = sk.Atmosphere(
+        geometry,
+        config,
+        wavelengths_nm=WAVELENGTHS_NM,
+        legendre_derivative=False,
+    )
+    atmosphere.storage.total_extinction[:] = np.linspace(0.7e-5, 1.5e-5, 18).reshape(
+        9, 2
+    )
+    atmosphere.storage.ssa[:] = 0.0
+    engine = sk.Engine(config, geometry, viewing)
+    lin = engine.linearize(atmosphere)
+
+    assert lin.parameter_dims["extinction"] == ("horizontal_angle", "altitude")
+    tangent = lin.tangent_template[["extinction"]]
+    tangent["extinction"].data[:] = np.arange(9.0).reshape(3, 3)
+    xr.testing.assert_allclose(
+        lin.jvp(tangent),
+        (lin.jacobian["extinction"] * tangent["extinction"]).sum(
+            ("horizontal_angle", "altitude")
+        ),
+    )
+
+    cotangent = xr.ones_like(lin.value) * 0.4
+    xr.testing.assert_allclose(
+        lin.vjp(cotangent)["extinction"],
+        (lin.jacobian["extinction"] * cotangent).sum(lin.value.dims),
+    )
 
 
 def test_vector_transmission_has_only_intensity_component():

--- a/tests/engine/test_linearization.py
+++ b/tests/engine/test_linearization.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import sasktran2 as sk
+import xarray as xr
+from sasktran2.linearization import Linearization, _ParameterSpec
+
+
+def _synthetic_linearization() -> Linearization:
+    wavelength = xr.DataArray([300.0, 310.0], dims="wavelength")
+    value = xr.DataArray(
+        np.arange(4.0).reshape(2, 2, 1),
+        dims=("wavelength", "los", "stokes"),
+        coords={"wavelength": wavelength, "stokes": ["I"]},
+    )
+    profile = xr.DataArray(
+        np.arange(12.0).reshape(3, 2, 2, 1),
+        dims=("altitude", *value.dims),
+        coords={"altitude": [0.0, 10_000.0, 20_000.0], **value.coords},
+    )
+    diagonal_surface = xr.DataArray(
+        np.arange(4.0, 8.0).reshape(2, 2, 1),
+        dims=value.dims,
+        coords=value.coords,
+    )
+    scalar_surface = xr.DataArray(
+        np.arange(8.0, 12.0).reshape(2, 2, 1),
+        dims=value.dims,
+        coords=value.coords,
+    )
+    structured = xr.DataArray(
+        np.arange(24.0).reshape(2, 3, 2, 2, 1),
+        dims=("horizontal_angle", "altitude", *value.dims),
+        coords={
+            "horizontal_angle": [-0.1, 0.1],
+            "altitude": [0.0, 10_000.0, 20_000.0],
+            **value.coords,
+        },
+    )
+    result = xr.Dataset(
+        {
+            "radiance": value,
+            "wf_profile": profile,
+            "wf_surface": diagonal_surface,
+            "wf_scalar": scalar_surface,
+            "wf_structured": structured,
+        }
+    )
+    specs = {
+        "wf_profile": _ParameterSpec(("altitude",)),
+        "wf_surface": _ParameterSpec(("wavelength",), ("wavelength",)),
+        "wf_scalar": _ParameterSpec(()),
+        "wf_structured": _ParameterSpec(("horizontal_angle", "altitude")),
+    }
+    return Linearization._from_result(result, specs)
+
+
+def test_structured_jvp_vjp_and_adjoint_identity():
+    lin = _synthetic_linearization()
+    assert lin.parameters == ("profile", "surface", "scalar", "structured")
+    assert lin.parameter_dims["surface"] == ("wavelength",)
+
+    tangent = xr.Dataset(
+        {
+            "profile": xr.DataArray(
+                [1.0, 2.0, 3.0],
+                dims="altitude",
+                coords={"altitude": lin.jacobian.altitude},
+            ),
+            "surface": xr.DataArray(
+                [4.0, 5.0],
+                dims="wavelength",
+                coords={"wavelength": lin.value.wavelength},
+            ),
+            "scalar": xr.DataArray(6.0),
+            "structured": xr.DataArray(
+                np.arange(6.0).reshape(2, 3),
+                dims=("horizontal_angle", "altitude"),
+                coords={
+                    "horizontal_angle": lin.jacobian.horizontal_angle,
+                    "altitude": lin.jacobian.altitude,
+                },
+            ),
+        }
+    )
+
+    expected = (
+        (lin.jacobian["profile"] * tangent["profile"]).sum("altitude")
+        + lin.jacobian["surface"] * tangent["surface"]
+        + lin.jacobian["scalar"] * tangent["scalar"]
+        + (lin.jacobian["structured"] * tangent["structured"]).sum(
+            ("horizontal_angle", "altitude")
+        )
+    )
+    xr.testing.assert_allclose(lin.jvp(tangent), expected)
+
+    cotangent = xr.DataArray(
+        np.arange(1.0, 5.0).reshape(2, 2, 1),
+        dims=lin.value.dims,
+        coords=lin.value.coords,
+    )
+    gradient = lin.vjp(cotangent)
+    xr.testing.assert_allclose(
+        gradient["profile"],
+        (lin.jacobian["profile"] * cotangent).sum(lin.value.dims),
+    )
+    xr.testing.assert_allclose(
+        gradient["surface"],
+        (lin.jacobian["surface"] * cotangent).sum(("los", "stokes")),
+    )
+    xr.testing.assert_allclose(
+        gradient["scalar"],
+        (lin.jacobian["scalar"] * cotangent).sum(lin.value.dims),
+    )
+
+    lhs = float((lin.jvp(tangent) * cotangent).sum())
+    rhs = sum(float((tangent[name] * gradient[name]).sum()) for name in tangent)
+    np.testing.assert_allclose(lhs, rhs)
+
+
+def test_tangent_template_describes_parameter_domain():
+    lin = _synthetic_linearization()
+    template = lin.tangent_template
+
+    assert tuple(template.data_vars) == lin.parameters
+    assert template["profile"].dims == ("altitude",)
+    assert template["profile"].shape == (3,)
+    assert template["structured"].dims == ("horizontal_angle", "altitude")
+    assert template["structured"].shape == (2, 3)
+    assert template["surface"].dims == ("wavelength",)
+    assert template["scalar"].dims == ()
+    xr.testing.assert_identical(template["profile"].altitude, lin.jacobian.altitude)
+    xr.testing.assert_identical(template["surface"].wavelength, lin.value.wavelength)
+    assert all(np.count_nonzero(template[name]) == 0 for name in lin.parameters)
+
+    template["profile"].data[:] = 1
+    assert np.count_nonzero(lin.tangent_template["profile"]) == 0
+
+
+def test_jvp_validation_and_omitted_parameters():
+    lin = _synthetic_linearization()
+    xr.testing.assert_identical(lin.jvp(xr.Dataset()), xr.zeros_like(lin.value))
+
+    with pytest.raises(ValueError, match="Unknown tangent"):
+        lin.jvp(xr.Dataset({"missing": xr.DataArray(1.0)}))
+
+    with pytest.raises(ValueError, match="must have dimensions"):
+        lin.jvp(
+            xr.Dataset(
+                {
+                    "profile": xr.DataArray(
+                        np.ones(3),
+                        dims="wrong",
+                    )
+                }
+            )
+        )
+
+    with pytest.raises(ValueError, match="coordinate"):
+        lin.jvp(
+            xr.Dataset(
+                {
+                    "surface": xr.DataArray(
+                        np.ones(2),
+                        dims="wavelength",
+                        coords={"wavelength": [301.0, 311.0]},
+                    )
+                }
+            )
+        )
+
+
+def _raw_engine_scenario(*, calculate_derivatives: bool = True):
+    config = sk.Config()
+    config.single_scatter_source = sk.SingleScatterSource.Exact
+    geometry = sk.Geometry1D(
+        0.6,
+        0.0,
+        6_372_000.0,
+        np.arange(0.0, 30_001.0, 5_000.0),
+        sk.InterpolationMethod.LinearInterpolation,
+        sk.GeometryType.Spherical,
+    )
+    viewing = sk.ViewingGeometry()
+    viewing.add_ray(sk.GroundViewingSolar(0.6, 0.0, 0.8, 100_000.0))
+    if calculate_derivatives:
+        atmosphere = sk.test_util.scenarios.default_pure_scattering_atmosphere(
+            config, geometry, 0.8, albedo=0.3
+        )
+    else:
+        atmosphere = sk.Atmosphere(
+            geometry,
+            config,
+            numwavel=1,
+            calculate_derivatives=False,
+        )
+    return sk.Engine(config, geometry, viewing), atmosphere
+
+
+def test_engine_linearize_matches_weighting_function_output():
+    engine, atmosphere = _raw_engine_scenario()
+    expected = engine.calculate_radiance(atmosphere)
+    lin = engine.linearize(atmosphere)
+
+    assert engine._engine._supports_linearization(0)
+    assert not engine._engine._supports_linearization(1)
+    assert not engine._engine._supports_linearization(2)
+    xr.testing.assert_allclose(lin.value, expected["radiance"])
+    xr.testing.assert_allclose(lin.jacobian["extinction"], expected["wf_extinction"])
+    xr.testing.assert_allclose(lin.jacobian["ssa"], expected["wf_ssa"])
+    xr.testing.assert_allclose(lin.jacobian["albedo"], expected["wf_albedo"])
+
+
+def test_engine_linearization_is_fixed_at_atmosphere_state():
+    engine, atmosphere = _raw_engine_scenario()
+    lin = engine.linearize(atmosphere)
+    value_at_point = lin.value.copy(deep=True)
+
+    tangent = lin.tangent_template[["extinction"]]
+    tangent["extinction"].data[:] = 1
+    product_at_point = lin.jvp(tangent).copy(deep=True)
+
+    atmosphere.storage.total_extinction[:] = 0
+    updated_value = engine.calculate_radiance(atmosphere)["radiance"]
+
+    assert float(np.abs(updated_value - value_at_point).max()) > 0
+    xr.testing.assert_identical(lin.value, value_at_point)
+    xr.testing.assert_identical(lin.jvp(tangent), product_at_point)
+
+
+def test_engine_linearize_requires_derivatives():
+    engine, atmosphere = _raw_engine_scenario(calculate_derivatives=False)
+    with pytest.raises(ValueError, match="calculate_derivatives=True"):
+        engine.linearize(atmosphere)

--- a/tests/engine/test_linearization.py
+++ b/tests/engine/test_linearization.py
@@ -171,6 +171,39 @@ def test_jvp_validation_and_omitted_parameters():
         )
 
 
+@pytest.mark.parametrize("dtype", [np.int64, np.float32])
+def test_engine_products_accept_real_numeric_dtypes(dtype):
+    engine, atmosphere = _raw_engine_scenario()
+    lin = engine.linearize(atmosphere)
+
+    tangent = xr.Dataset(
+        {
+            "extinction": xr.DataArray(
+                np.ones(atmosphere.num_locations, dtype=dtype),
+                dims="altitude",
+                coords={"altitude": lin.tangent_template.altitude},
+            )
+        }
+    )
+    expected_jvp = lin.jacobian["extinction"].sum("altitude")
+    xr.testing.assert_allclose(lin.jvp(tangent), expected_jvp)
+
+    cotangent = xr.ones_like(lin.value).astype(dtype)
+    expected_vjp = (lin.jacobian["extinction"] * cotangent).sum(lin.value.dims)
+    xr.testing.assert_allclose(lin.vjp(cotangent)["extinction"], expected_vjp)
+
+
+def test_engine_products_reject_complex_inputs():
+    engine, atmosphere = _raw_engine_scenario()
+    lin = engine.linearize(atmosphere)
+    tangent = lin.tangent_template[["extinction"]].astype(np.complex128)
+
+    with pytest.raises(ValueError, match="real numeric"):
+        lin.jvp(tangent)
+    with pytest.raises(ValueError, match="real numeric"):
+        lin.vjp(xr.ones_like(lin.value).astype(np.complex128))
+
+
 def _raw_engine_scenario(*, calculate_derivatives: bool = True):
     config = sk.Config()
     config.single_scatter_source = sk.SingleScatterSource.Exact
@@ -264,6 +297,17 @@ def test_streaming_products_cover_surface_parameterizations(surface):
     cotangent = xr.ones_like(lin.value) * 0.7
     expected_vjp = (lin.jacobian[name] * cotangent).sum(lin.value.dims)
     xr.testing.assert_allclose(lin.vjp(cotangent)[name], expected_vjp)
+
+
+def test_constant_surface_parameter_has_scalar_domain():
+    engine, atmosphere = _constituent_engine_scenario(
+        sk.constituent.LambertianSurface(0.3)
+    )
+    lin = engine.linearize(atmosphere)
+
+    assert lin.parameter_dims["surface_albedo"] == ()
+    assert lin.tangent_template["surface_albedo"].dims == ()
+    assert lin.jacobian["surface_albedo"].dims == lin.value.dims
 
 
 def test_streaming_products_apply_polarized_output_rotation():

--- a/tests/engine/test_linearization.py
+++ b/tests/engine/test_linearization.py
@@ -60,6 +60,10 @@ def test_structured_jvp_vjp_and_adjoint_identity():
     lin = _synthetic_linearization()
     assert lin.parameters == ("profile", "surface", "scalar", "structured")
     assert lin.parameter_dims["surface"] == ("wavelength",)
+    assert lin.backends == {
+        "jvp": sk.LinearizationBackend.MaterializedJacobian,
+        "vjp": sk.LinearizationBackend.MaterializedJacobian,
+    }
 
     tangent = xr.Dataset(
         {
@@ -117,6 +121,36 @@ def test_structured_jvp_vjp_and_adjoint_identity():
     lhs = float((lin.jvp(tangent) * cotangent).sum())
     rhs = sum(float((tangent[name] * gradient[name]).sum()) for name in tangent)
     np.testing.assert_allclose(lhs, rhs)
+
+
+def test_vjp_can_select_parameters():
+    lin = _synthetic_linearization()
+    cotangent = xr.ones_like(lin.value)
+
+    selected = lin.vjp(cotangent, parameters=("structured", "scalar"))
+
+    assert tuple(selected.data_vars) == ("structured", "scalar")
+    xr.testing.assert_allclose(
+        selected["structured"],
+        (lin.jacobian["structured"] * cotangent).sum(lin.value.dims),
+    )
+    xr.testing.assert_allclose(
+        selected["scalar"],
+        (lin.jacobian["scalar"] * cotangent).sum(lin.value.dims),
+    )
+    assert len(lin.vjp(cotangent, parameters=()).data_vars) == 0
+
+
+def test_vjp_rejects_invalid_parameter_selection():
+    lin = _synthetic_linearization()
+    cotangent = xr.ones_like(lin.value)
+
+    with pytest.raises(ValueError, match="Unknown VJP parameter"):
+        lin.vjp(cotangent, parameters=("missing",))
+    with pytest.raises(ValueError, match="must not contain duplicates"):
+        lin.vjp(cotangent, parameters=("profile", "profile"))
+    with pytest.raises(TypeError, match="must be strings"):
+        lin.vjp(cotangent, parameters=("profile", 1))
 
 
 def test_tangent_template_describes_parameter_domain():
@@ -266,6 +300,10 @@ def test_engine_linearize_matches_weighting_function_output():
     assert engine._engine._linearization_backend(0) == 2
     assert engine._engine._linearization_backend(1) == 1
     assert engine._engine._linearization_backend(2) == 1
+    assert lin.backends == {
+        "jvp": sk.LinearizationBackend.StreamingJacobian,
+        "vjp": sk.LinearizationBackend.StreamingJacobian,
+    }
     xr.testing.assert_allclose(lin.value, expected["radiance"])
     xr.testing.assert_allclose(lin.jacobian["extinction"], expected["wf_extinction"])
     xr.testing.assert_allclose(lin.jacobian["ssa"], expected["wf_ssa"])
@@ -296,7 +334,9 @@ def test_streaming_products_cover_surface_parameterizations(surface):
 
     cotangent = xr.ones_like(lin.value) * 0.7
     expected_vjp = (lin.jacobian[name] * cotangent).sum(lin.value.dims)
-    xr.testing.assert_allclose(lin.vjp(cotangent)[name], expected_vjp)
+    gradient = lin.vjp(cotangent, parameters=(name,))
+    assert tuple(gradient.data_vars) == (name,)
+    xr.testing.assert_allclose(gradient[name], expected_vjp)
 
 
 def test_constant_surface_parameter_has_scalar_domain():
@@ -387,7 +427,17 @@ def test_scalar_surface_emission_products():
         np.full((7, 2), 1.0e-5), np.zeros((7, 2))
     )
     atmosphere["surface"] = sk.constituent.SurfaceThermalEmission(290.0, 0.8)
-    lin = sk.Engine(config, geometry, viewing).linearize(atmosphere)
+    engine = sk.Engine(config, geometry, viewing)
+    lin = engine.linearize(atmosphere)
+
+    assert not engine._engine._supports_linearization(1)
+    assert not engine._engine._supports_linearization(2)
+    assert engine._engine._linearization_backend(1) == 1
+    assert engine._engine._linearization_backend(2) == 1
+    assert lin.backends == {
+        "jvp": sk.LinearizationBackend.StreamingJacobian,
+        "vjp": sk.LinearizationBackend.StreamingJacobian,
+    }
 
     assert lin.parameter_dims["surface_temperature_k"] == ()
     assert lin.parameter_dims["surface_emissivity"] == ()
@@ -409,6 +459,12 @@ def test_scalar_surface_emission_products():
         xr.testing.assert_allclose(
             gradient[name], (lin.jacobian[name] * cotangent).sum(lin.value.dims)
         )
+    selected_gradient = lin.vjp(cotangent, parameters=("surface_temperature_k",))
+    assert tuple(selected_gradient.data_vars) == ("surface_temperature_k",)
+    xr.testing.assert_allclose(
+        selected_gradient["surface_temperature_k"],
+        gradient["surface_temperature_k"],
+    )
 
 
 def test_log_radiance_mapping_is_converted_for_linearization():
@@ -470,6 +526,40 @@ def test_engine_streaming_products_match_materialized_jacobian():
     lhs = float((lin.jvp(tangent) * cotangent).sum())
     rhs = sum(float((tangent[name] * gradient[name]).sum()) for name in tangent)
     np.testing.assert_allclose(lhs, rhs)
+
+
+def test_distinct_atmosphere_linearisations_coexist_on_one_engine():
+    engine, atmosphere_a = _constituent_engine_scenario(
+        sk.constituent.LambertianSurface(0.2)
+    )
+    _, atmosphere_b = _constituent_engine_scenario(
+        sk.constituent.LambertianSurface(0.6)
+    )
+
+    linearization_a = engine.linearize(atmosphere_a)
+    tangent_a = linearization_a.tangent_template[["surface_albedo"]]
+    tangent_a["surface_albedo"].data[...] = 0.4
+    expected_a = (
+        linearization_a.jacobian["surface_albedo"] * tangent_a["surface_albedo"]
+    )
+
+    linearization_b = engine.linearize(atmosphere_b)
+    tangent_b = linearization_b.tangent_template[["surface_albedo"]]
+    tangent_b["surface_albedo"].data[...] = -0.3
+    expected_b = (
+        linearization_b.jacobian["surface_albedo"] * tangent_b["surface_albedo"]
+    )
+
+    assert not np.allclose(linearization_a.value, linearization_b.value)
+    xr.testing.assert_allclose(linearization_a.jvp(tangent_a), expected_a)
+    xr.testing.assert_allclose(linearization_b.jvp(tangent_b), expected_b)
+
+    cotangent_a = xr.ones_like(linearization_a.value) * 0.7
+    expected_gradient_a = (
+        linearization_a.jacobian["surface_albedo"] * cotangent_a
+    ).sum(linearization_a.value.dims)
+    gradient_a = linearization_a.vjp(cotangent_a, parameters=("surface_albedo",))
+    xr.testing.assert_allclose(gradient_a["surface_albedo"], expected_gradient_a)
 
 
 def test_streaming_products_do_not_materialize_jacobian():

--- a/tests/engine/test_linearization.py
+++ b/tests/engine/test_linearization.py
@@ -198,6 +198,30 @@ def _raw_engine_scenario(*, calculate_derivatives: bool = True):
     return sk.Engine(config, geometry, viewing), atmosphere
 
 
+def _constituent_engine_scenario(surface, *, num_stokes: int = 1):
+    config = sk.Config()
+    config.single_scatter_source = sk.SingleScatterSource.Exact
+    config.multiple_scatter_source = sk.MultipleScatterSource.NoSource
+    config.num_stokes = num_stokes
+    geometry = sk.Geometry1D(
+        0.6,
+        0.0,
+        6_372_000.0,
+        np.arange(0.0, 30_001.0, 5_000.0),
+        sk.InterpolationMethod.LinearInterpolation,
+        sk.GeometryType.Spherical,
+    )
+    viewing = sk.ViewingGeometry()
+    viewing.add_ray(sk.GroundViewingSolar(0.6, 0.2, 0.8, 100_000.0))
+    atmosphere = sk.Atmosphere(
+        geometry, config, wavelengths_nm=np.array([300.0, 350.0, 400.0])
+    )
+    sk.climatology.us76.add_us76_standard_atmosphere(atmosphere)
+    atmosphere["rayleigh"] = sk.constituent.Rayleigh()
+    atmosphere["surface"] = surface
+    return sk.Engine(config, geometry, viewing), atmosphere
+
+
 def test_engine_linearize_matches_weighting_function_output():
     engine, atmosphere = _raw_engine_scenario()
     expected = engine.calculate_radiance(atmosphere)
@@ -206,27 +230,246 @@ def test_engine_linearize_matches_weighting_function_output():
     assert engine._engine._supports_linearization(0)
     assert not engine._engine._supports_linearization(1)
     assert not engine._engine._supports_linearization(2)
+    assert engine._engine._linearization_backend(0) == 2
+    assert engine._engine._linearization_backend(1) == 1
+    assert engine._engine._linearization_backend(2) == 1
     xr.testing.assert_allclose(lin.value, expected["radiance"])
     xr.testing.assert_allclose(lin.jacobian["extinction"], expected["wf_extinction"])
     xr.testing.assert_allclose(lin.jacobian["ssa"], expected["wf_ssa"])
     xr.testing.assert_allclose(lin.jacobian["albedo"], expected["wf_albedo"])
 
 
-def test_engine_linearization_is_fixed_at_atmosphere_state():
+@pytest.mark.parametrize(
+    "surface",
+    [
+        sk.constituent.LambertianSurface(0.3),
+        sk.constituent.LambertianSurface(
+            [0.2, 0.4], wavelengths_nm=np.array([290.0, 410.0])
+        ),
+        sk.constituent.LambertianSurface([0.2, 0.3, 0.4]),
+    ],
+)
+def test_streaming_products_cover_surface_parameterizations(surface):
+    engine, atmosphere = _constituent_engine_scenario(surface)
+    lin = engine.linearize(atmosphere)
+    name = "surface_albedo"
+
+    tangent = lin.tangent_template[[name]]
+    tangent[name].data[...] = np.linspace(0.2, 0.6, tangent[name].size).reshape(
+        tangent[name].shape
+    )
+    expected_jvp = (lin.jacobian[name] * tangent[name]).sum(lin.parameter_dims[name])
+    xr.testing.assert_allclose(lin.jvp(tangent), expected_jvp)
+
+    cotangent = xr.ones_like(lin.value) * 0.7
+    expected_vjp = (lin.jacobian[name] * cotangent).sum(lin.value.dims)
+    xr.testing.assert_allclose(lin.vjp(cotangent)[name], expected_vjp)
+
+
+def test_streaming_products_apply_polarized_output_rotation():
+    engine, atmosphere = _constituent_engine_scenario(
+        sk.constituent.LambertianSurface([0.2, 0.3, 0.4]), num_stokes=3
+    )
+    lin = engine.linearize(atmosphere)
+    tangent = lin.tangent_template[["surface_albedo"]]
+    tangent["surface_albedo"].data[:] = [0.3, -0.2, 0.5]
+    expected = (lin.jacobian["surface_albedo"] * tangent["surface_albedo"]).sum(
+        lin.parameter_dims["surface_albedo"]
+    )
+    xr.testing.assert_allclose(lin.jvp(tangent), expected)
+
+    cotangent = xr.ones_like(lin.value)
+    xr.testing.assert_allclose(
+        lin.vjp(cotangent)["surface_albedo"],
+        (lin.jacobian["surface_albedo"] * cotangent).sum(lin.value.dims),
+    )
+
+
+def test_constituent_rebuild_invalidates_linearization():
+    engine, atmosphere = _constituent_engine_scenario(
+        sk.constituent.LambertianSurface(0.3)
+    )
+    lin = engine.linearize(atmosphere)
+    revision = atmosphere.revision
+
+    engine.calculate_radiance(atmosphere)
+
+    assert atmosphere.revision == revision + 1
+    with pytest.raises(sk.StaleLinearizationError):
+        lin.jvp(lin.tangent_template[["surface_albedo"]])
+
+
+def test_assign_name_parameter_mapping_streams_products():
+    engine, atmosphere = _constituent_engine_scenario(
+        sk.constituent.LambertianSurface(0.3)
+    )
+    lin = engine.linearize(atmosphere)
+    assert "pressure_pa" in lin.parameters
+
+    tangent = lin.tangent_template[["pressure_pa"]]
+    tangent["pressure_pa"].data[:] = np.linspace(0.1, 0.7, 7)
+    xr.testing.assert_allclose(
+        lin.jvp(tangent),
+        (lin.jacobian["pressure_pa"] * tangent["pressure_pa"]).sum(
+            lin.parameter_dims["pressure_pa"]
+        ),
+    )
+
+    cotangent = xr.ones_like(lin.value) * 0.2
+    xr.testing.assert_allclose(
+        lin.vjp(cotangent)["pressure_pa"],
+        (lin.jacobian["pressure_pa"] * cotangent).sum(lin.value.dims),
+    )
+
+
+def test_scalar_surface_emission_products():
+    config = sk.Config()
+    config.single_scatter_source = sk.SingleScatterSource.NoSource
+    config.multiple_scatter_source = sk.MultipleScatterSource.NoSource
+    config.emission_source = sk.EmissionSource.Standard
+    geometry = sk.Geometry1D(
+        0.6,
+        0.0,
+        6_372_000.0,
+        np.arange(0.0, 30_001.0, 5_000.0),
+        sk.InterpolationMethod.LinearInterpolation,
+        sk.GeometryType.Spherical,
+    )
+    viewing = sk.ViewingGeometry()
+    viewing.add_ray(sk.GroundViewingSolar(0.6, 0.0, 0.8, 100_000.0))
+    wavelengths = np.array([8_000.0, 10_000.0])
+    atmosphere = sk.Atmosphere(geometry, config, wavelengths_nm=wavelengths)
+    atmosphere["manual"] = sk.constituent.Manual(
+        np.full((7, 2), 1.0e-5), np.zeros((7, 2))
+    )
+    atmosphere["surface"] = sk.constituent.SurfaceThermalEmission(290.0, 0.8)
+    lin = sk.Engine(config, geometry, viewing).linearize(atmosphere)
+
+    assert lin.parameter_dims["surface_temperature_k"] == ()
+    assert lin.parameter_dims["surface_emissivity"] == ()
+    tangent = xr.Dataset(
+        {
+            "surface_temperature_k": xr.DataArray(1.3),
+            "surface_emissivity": xr.DataArray(-0.2),
+        }
+    )
+    expected = (
+        lin.jacobian["surface_temperature_k"] * tangent["surface_temperature_k"]
+        + lin.jacobian["surface_emissivity"] * tangent["surface_emissivity"]
+    )
+    xr.testing.assert_allclose(lin.jvp(tangent), expected)
+
+    cotangent = xr.ones_like(lin.value) * 0.6
+    gradient = lin.vjp(cotangent)
+    for name in tangent:
+        xr.testing.assert_allclose(
+            gradient[name], (lin.jacobian[name] * cotangent).sum(lin.value.dims)
+        )
+
+
+def test_log_radiance_mapping_is_converted_for_linearization():
+    engine, atmosphere = _constituent_engine_scenario(
+        sk.constituent.LambertianSurface(0.3)
+    )
+    atmosphere["amf"] = sk.constituent.AirMassFactor()
+    legacy = engine.calculate_radiance(atmosphere)
+    lin = engine.linearize(atmosphere)
+
+    xr.testing.assert_allclose(
+        lin.jacobian["air_mass_factor"],
+        legacy["air_mass_factor"] * lin.value,
+    )
+    tangent = lin.tangent_template[["air_mass_factor"]]
+    tangent["air_mass_factor"].data[:] = 1
+    xr.testing.assert_allclose(
+        lin.jvp(tangent),
+        lin.jacobian["air_mass_factor"].sum("altitude"),
+    )
+
+
+def test_engine_streaming_products_match_materialized_jacobian():
     engine, atmosphere = _raw_engine_scenario()
     lin = engine.linearize(atmosphere)
-    value_at_point = lin.value.copy(deep=True)
+
+    tangent = lin.tangent_template[["extinction", "ssa", "leg_coeff_2", "albedo"]]
+    tangent["extinction"].data[:] = np.linspace(0.2, 0.8, 7)
+    tangent["ssa"].data[:] = np.linspace(-0.3, 0.1, 7)
+    tangent["leg_coeff_2"].data[:] = np.linspace(0.05, 0.2, 7)
+    tangent["albedo"].data[:] = 0.4
+    expected_jvp = (
+        (lin.jacobian["extinction"] * tangent["extinction"]).sum("altitude")
+        + (lin.jacobian["ssa"] * tangent["ssa"]).sum("altitude")
+        + (lin.jacobian["leg_coeff_2"] * tangent["leg_coeff_2"]).sum("altitude")
+        + lin.jacobian["albedo"] * tangent["albedo"]
+    )
+    xr.testing.assert_allclose(lin.jvp(tangent), expected_jvp)
+
+    cotangent = xr.ones_like(lin.value) * 1.7
+    gradient = lin.vjp(cotangent)
+    xr.testing.assert_allclose(
+        gradient["extinction"],
+        (lin.jacobian["extinction"] * cotangent).sum(lin.value.dims),
+    )
+    xr.testing.assert_allclose(
+        gradient["ssa"],
+        (lin.jacobian["ssa"] * cotangent).sum(lin.value.dims),
+    )
+    xr.testing.assert_allclose(
+        gradient["leg_coeff_2"],
+        (lin.jacobian["leg_coeff_2"] * cotangent).sum(lin.value.dims),
+    )
+    xr.testing.assert_allclose(
+        gradient["albedo"],
+        (lin.jacobian["albedo"] * cotangent).sum(("los", "stokes")),
+    )
+
+    lhs = float((lin.jvp(tangent) * cotangent).sum())
+    rhs = sum(float((tangent[name] * gradient[name]).sum()) for name in tangent)
+    np.testing.assert_allclose(lhs, rhs)
+
+
+def test_streaming_products_do_not_materialize_jacobian():
+    engine, atmosphere = _raw_engine_scenario()
+    lin = engine.linearize(atmosphere)
+    assert lin._backend._jacobian is None
 
     tangent = lin.tangent_template[["extinction"]]
     tangent["extinction"].data[:] = 1
-    product_at_point = lin.jvp(tangent).copy(deep=True)
+    lin.jvp(tangent)
+    lin.vjp(xr.ones_like(lin.value))
+
+    assert lin._backend._jacobian is None
+
+
+def test_engine_linearization_detects_changed_atmosphere():
+    engine, atmosphere = _raw_engine_scenario()
+    lin = engine.linearize(atmosphere)
+    value_at_point = lin.value.copy(deep=True)
+    jacobian_at_point = lin.jacobian.copy(deep=True)
+
+    tangent = lin.tangent_template[["extinction"]]
+    tangent["extinction"].data[:] = 1
 
     atmosphere.storage.total_extinction[:] = 0
+    atmosphere.mark_changed()
     updated_value = engine.calculate_radiance(atmosphere)["radiance"]
 
     assert float(np.abs(updated_value - value_at_point).max()) > 0
     xr.testing.assert_identical(lin.value, value_at_point)
-    xr.testing.assert_identical(lin.jvp(tangent), product_at_point)
+    xr.testing.assert_identical(lin.jacobian, jacobian_at_point)
+    with pytest.raises(sk.StaleLinearizationError):
+        lin.jvp(tangent)
+    with pytest.raises(sk.StaleLinearizationError):
+        lin.vjp(xr.ones_like(lin.value))
+
+
+def test_unmaterialized_jacobian_rejects_changed_atmosphere():
+    engine, atmosphere = _raw_engine_scenario()
+    lin = engine.linearize(atmosphere)
+
+    atmosphere.mark_changed()
+    with pytest.raises(sk.StaleLinearizationError):
+        _ = lin.jacobian
 
 
 def test_engine_linearize_requires_derivatives():


### PR DESCRIPTION
## Summary

Adds the public radiance linearization interface and generic product-backend plumbing:

- `Engine.linearize(atmosphere)` returns a reusable `Linearization`
- labeled `value`, lazy `jacobian`, `jvp()`, and `vjp()` operations
- public `LinearizationBackend` metadata through the read-only `linearization.backends` mapping
- optional `vjp(..., parameters=(...))` filtering so retrievals only compute gradients for active parameters
- C/Rust bindings for streamed radiance tangents and cotangents
- source/integrator capability queries used to select native products when available
- full-Jacobian fallback that preserves existing weighting-function behavior
- atmosphere revision tracking, stale-linearization checks, and support for retaining accepted/trial state linearisations on distinct atmospheres with one engine

This PR intentionally contains no source-specific native JVP/VJP implementation. A stacked follow-up implements native products for exact single scattering.

## Motivation and impact

Retrieval code can use the same labeled interface with either a materialized Jacobian or matrix-free products. The backend metadata lets a SciPy-facing adapter decide whether repeated products or one-time Jacobian materialization is more efficient, while filtered VJPs avoid work for inactive retrieval parameters. Existing `calculate_radiance()` and `wf_*` outputs remain backward compatible.

## Validation

- `pixi run build`
- `.pixi/envs/default/bin/python -m pytest tests/engine/test_linearization.py -q` (24 passed)
- `pixi run pre-commit`
