### PR TITLE
Implement native JVP and VJP for exact single scattering

### DIFF
--- a/asv_bench/benchmarks/limb_singlescatter.py
+++ b/asv_bench/benchmarks/limb_singlescatter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 import sasktran2 as sk
+import xarray as xr
 
 from . import _skip_slow, parameterized
 
@@ -99,3 +100,66 @@ class LimbSingleScatterWavelengthBatch:
 
     def time_limb_single_scatter_batch(self, batch_size, calc_deriv):  # noqa: ARG002
         self._engine.calculate_radiance(self._atmosphere)
+
+
+@parameterized(["batch_size"], ([1, 32],))
+class LimbSingleScatterLinearizationProducts:
+    """Track exact-single-scatter product and full-Jacobian execution."""
+
+    def setup(self, batch_size):
+        config = sk.Config()
+        config.num_threads = 1
+        config.single_scatter_source = sk.SingleScatterSource.Exact
+        config.multiple_scatter_source = sk.MultipleScatterSource.NoSource
+        config.num_singlescatter_moments = 4
+        config.wavelength_batch_size = batch_size
+
+        geometry = sk.Geometry1D(
+            cos_sza=0.5,
+            solar_azimuth=0.0,
+            earth_radius_m=6_372_000.0,
+            altitude_grid_m=np.linspace(0.0, 80_000.0, 41),
+            interpolation_method=sk.InterpolationMethod.LinearInterpolation,
+            geometry_type=sk.GeometryType.Spherical,
+        )
+        viewing = sk.ViewingGeometry()
+        for altitude_m in np.linspace(0.0, 40_000.0, 20):
+            viewing.add_ray(sk.TangentAltitudeSolar(altitude_m, 0.0, 200_000.0, 0.5))
+
+        def atmosphere():
+            result = sk.Atmosphere(
+                geometry,
+                config,
+                calculate_derivatives=True,
+                numwavel=256,
+                pressure_derivative=False,
+                temperature_derivative=False,
+                specific_humidity_derivative=False,
+            )
+            result.storage.total_extinction[:] = 1.0e-5
+            result.storage.ssa[:] = 0.8
+            result.leg_coeff.a1[0] = 1.0
+            result.leg_coeff.a1[2] = 0.3
+            return result
+
+        self._product_atmosphere = atmosphere()
+        self._product_engine = sk.Engine(config, geometry, viewing)
+        self._linearization = self._product_engine.linearize(self._product_atmosphere)
+        self._tangent = self._linearization.tangent_template[["extinction"]]
+        self._tangent["extinction"].data[:] = 1.0
+        self._cotangent = xr.ones_like(self._linearization.value)
+
+        # Full-Jacobian timing mutates an atmosphere revision while rebuilding
+        # constituent mappings. Keep it isolated from the reusable product
+        # linearization so ASV method order cannot make that object stale.
+        self._jacobian_atmosphere = atmosphere()
+        self._jacobian_engine = sk.Engine(config, geometry, viewing)
+
+    def time_jvp(self, _batch_size):
+        self._linearization.jvp(self._tangent)
+
+    def time_vjp(self, _batch_size):
+        self._linearization.vjp(self._cotangent)
+
+    def time_materialized_jacobian(self, _batch_size):
+        self._jacobian_engine.calculate_radiance(self._jacobian_atmosphere)

--- a/cpp/c_api/engine.cpp
+++ b/cpp/c_api/engine.cpp
@@ -205,18 +205,36 @@ int sk_engine_calculate_jvp(Engine* engine, Atmosphere* atmosphere,
     try {
         if (engine->_config->impl.num_stokes() == 1) {
             auto* impl = dynamic_cast<Sasktran2<1>*>(engine->impl.get());
-            impl->calculate_radiance(
+            auto& native_atmosphere =
                 *static_cast<sasktran2::atmosphere::Atmosphere<1>*>(
-                    atmosphere->impl.get()),
-                *static_cast<sasktran2::Output<1>*>(output->impl.get()));
+                    atmosphere->impl.get());
+            if (impl->supports_linearization(
+                    sasktran2::LinearizationMode::JVP)) {
+                impl->calculate_jvp(
+                    native_atmosphere,
+                    *static_cast<sasktran2::OutputJVP<1>*>(output->impl.get()));
+            } else {
+                impl->calculate_radiance(
+                    native_atmosphere,
+                    *static_cast<sasktran2::Output<1>*>(output->impl.get()));
+            }
             return 0;
         }
         if (engine->_config->impl.num_stokes() == 3) {
             auto* impl = dynamic_cast<Sasktran2<3>*>(engine->impl.get());
-            impl->calculate_radiance(
+            auto& native_atmosphere =
                 *static_cast<sasktran2::atmosphere::Atmosphere<3>*>(
-                    atmosphere->impl.get()),
-                *static_cast<sasktran2::Output<3>*>(output->impl.get()));
+                    atmosphere->impl.get());
+            if (impl->supports_linearization(
+                    sasktran2::LinearizationMode::JVP)) {
+                impl->calculate_jvp(
+                    native_atmosphere,
+                    *static_cast<sasktran2::OutputJVP<3>*>(output->impl.get()));
+            } else {
+                impl->calculate_radiance(
+                    native_atmosphere,
+                    *static_cast<sasktran2::Output<3>*>(output->impl.get()));
+            }
             return 0;
         }
         return -2;
@@ -234,17 +252,35 @@ int sk_engine_calculate_vjp(Engine* engine, Atmosphere* atmosphere,
         int result = -2;
         if (engine->_config->impl.num_stokes() == 1) {
             auto* impl = dynamic_cast<Sasktran2<1>*>(engine->impl.get());
-            impl->calculate_radiance(
+            auto& native_atmosphere =
                 *static_cast<sasktran2::atmosphere::Atmosphere<1>*>(
-                    atmosphere->impl.get()),
-                *static_cast<sasktran2::Output<1>*>(output->impl.get()));
+                    atmosphere->impl.get());
+            if (impl->supports_linearization(
+                    sasktran2::LinearizationMode::VJP)) {
+                impl->calculate_vjp(
+                    native_atmosphere,
+                    *static_cast<sasktran2::OutputVJP<1>*>(output->impl.get()));
+            } else {
+                impl->calculate_radiance(
+                    native_atmosphere,
+                    *static_cast<sasktran2::Output<1>*>(output->impl.get()));
+            }
             result = 0;
         } else if (engine->_config->impl.num_stokes() == 3) {
             auto* impl = dynamic_cast<Sasktran2<3>*>(engine->impl.get());
-            impl->calculate_radiance(
+            auto& native_atmosphere =
                 *static_cast<sasktran2::atmosphere::Atmosphere<3>*>(
-                    atmosphere->impl.get()),
-                *static_cast<sasktran2::Output<3>*>(output->impl.get()));
+                    atmosphere->impl.get());
+            if (impl->supports_linearization(
+                    sasktran2::LinearizationMode::VJP)) {
+                impl->calculate_vjp(
+                    native_atmosphere,
+                    *static_cast<sasktran2::OutputVJP<3>*>(output->impl.get()));
+            } else {
+                impl->calculate_radiance(
+                    native_atmosphere,
+                    *static_cast<sasktran2::Output<3>*>(output->impl.get()));
+            }
             result = 0;
         }
         if (result == 0) {

--- a/cpp/c_api/engine.cpp
+++ b/cpp/c_api/engine.cpp
@@ -199,95 +199,107 @@ int sk_engine_linearization_backend(Engine* engine, int mode, int* backend) {
 
 int sk_engine_calculate_jvp(Engine* engine, Atmosphere* atmosphere,
                             OutputJVP* output) {
-    if (engine == nullptr || atmosphere == nullptr || output == nullptr) {
+    if (engine == nullptr || !engine->impl || engine->_config == nullptr ||
+        atmosphere == nullptr || !atmosphere->impl || output == nullptr ||
+        !output->impl) {
         return -1;
     }
     try {
         if (engine->_config->impl.num_stokes() == 1) {
             auto* impl = dynamic_cast<Sasktran2<1>*>(engine->impl.get());
-            auto& native_atmosphere =
-                *static_cast<sasktran2::atmosphere::Atmosphere<1>*>(
+            auto* native_atmosphere =
+                dynamic_cast<sasktran2::atmosphere::Atmosphere<1>*>(
                     atmosphere->impl.get());
+            auto* native_output =
+                dynamic_cast<sasktran2::OutputJVP<1>*>(output->impl.get());
+            if (impl == nullptr || native_atmosphere == nullptr ||
+                native_output == nullptr) {
+                return -2;
+            }
             if (impl->supports_linearization(
                     sasktran2::LinearizationMode::JVP)) {
-                impl->calculate_jvp(
-                    native_atmosphere,
-                    *static_cast<sasktran2::OutputJVP<1>*>(output->impl.get()));
+                impl->calculate_jvp(*native_atmosphere, *native_output);
             } else {
-                impl->calculate_radiance(
-                    native_atmosphere,
-                    *static_cast<sasktran2::Output<1>*>(output->impl.get()));
+                impl->calculate_radiance(*native_atmosphere, *native_output);
             }
             return 0;
         }
         if (engine->_config->impl.num_stokes() == 3) {
             auto* impl = dynamic_cast<Sasktran2<3>*>(engine->impl.get());
-            auto& native_atmosphere =
-                *static_cast<sasktran2::atmosphere::Atmosphere<3>*>(
+            auto* native_atmosphere =
+                dynamic_cast<sasktran2::atmosphere::Atmosphere<3>*>(
                     atmosphere->impl.get());
+            auto* native_output =
+                dynamic_cast<sasktran2::OutputJVP<3>*>(output->impl.get());
+            if (impl == nullptr || native_atmosphere == nullptr ||
+                native_output == nullptr) {
+                return -2;
+            }
             if (impl->supports_linearization(
                     sasktran2::LinearizationMode::JVP)) {
-                impl->calculate_jvp(
-                    native_atmosphere,
-                    *static_cast<sasktran2::OutputJVP<3>*>(output->impl.get()));
+                impl->calculate_jvp(*native_atmosphere, *native_output);
             } else {
-                impl->calculate_radiance(
-                    native_atmosphere,
-                    *static_cast<sasktran2::Output<3>*>(output->impl.get()));
+                impl->calculate_radiance(*native_atmosphere, *native_output);
             }
             return 0;
         }
         return -2;
-    } catch (const std::exception&) {
+    } catch (const std::exception& error) {
+        spdlog::error("Error calculating JVP: {}", error.what());
         return -3;
     }
 }
 
 int sk_engine_calculate_vjp(Engine* engine, Atmosphere* atmosphere,
                             OutputVJP* output) {
-    if (engine == nullptr || atmosphere == nullptr || output == nullptr) {
+    if (engine == nullptr || !engine->impl || engine->_config == nullptr ||
+        atmosphere == nullptr || !atmosphere->impl || output == nullptr ||
+        !output->impl) {
         return -1;
     }
     try {
-        int result = -2;
         if (engine->_config->impl.num_stokes() == 1) {
             auto* impl = dynamic_cast<Sasktran2<1>*>(engine->impl.get());
-            auto& native_atmosphere =
-                *static_cast<sasktran2::atmosphere::Atmosphere<1>*>(
+            auto* native_atmosphere =
+                dynamic_cast<sasktran2::atmosphere::Atmosphere<1>*>(
                     atmosphere->impl.get());
+            auto* native_output =
+                dynamic_cast<sasktran2::OutputVJP<1>*>(output->impl.get());
+            if (impl == nullptr || native_atmosphere == nullptr ||
+                native_output == nullptr) {
+                return -2;
+            }
             if (impl->supports_linearization(
                     sasktran2::LinearizationMode::VJP)) {
-                impl->calculate_vjp(
-                    native_atmosphere,
-                    *static_cast<sasktran2::OutputVJP<1>*>(output->impl.get()));
+                impl->calculate_vjp(*native_atmosphere, *native_output);
             } else {
-                impl->calculate_radiance(
-                    native_atmosphere,
-                    *static_cast<sasktran2::Output<1>*>(output->impl.get()));
+                impl->calculate_radiance(*native_atmosphere, *native_output);
             }
-            result = 0;
+            native_output->finalize();
+            return 0;
         } else if (engine->_config->impl.num_stokes() == 3) {
             auto* impl = dynamic_cast<Sasktran2<3>*>(engine->impl.get());
-            auto& native_atmosphere =
-                *static_cast<sasktran2::atmosphere::Atmosphere<3>*>(
+            auto* native_atmosphere =
+                dynamic_cast<sasktran2::atmosphere::Atmosphere<3>*>(
                     atmosphere->impl.get());
+            auto* native_output =
+                dynamic_cast<sasktran2::OutputVJP<3>*>(output->impl.get());
+            if (impl == nullptr || native_atmosphere == nullptr ||
+                native_output == nullptr) {
+                return -2;
+            }
             if (impl->supports_linearization(
                     sasktran2::LinearizationMode::VJP)) {
-                impl->calculate_vjp(
-                    native_atmosphere,
-                    *static_cast<sasktran2::OutputVJP<3>*>(output->impl.get()));
+                impl->calculate_vjp(*native_atmosphere, *native_output);
             } else {
-                impl->calculate_radiance(
-                    native_atmosphere,
-                    *static_cast<sasktran2::Output<3>*>(output->impl.get()));
+                impl->calculate_radiance(*native_atmosphere, *native_output);
             }
-            result = 0;
+            native_output->finalize();
+            return 0;
         }
-        if (result == 0) {
-            result = output->finalize();
-        }
-        return result;
-    } catch (const std::exception&) {
+        return -2;
+    } catch (const std::exception& error) {
+        spdlog::error("Error calculating VJP: {}", error.what());
         return -3;
     }
 }

--- a/cpp/c_api/output.cpp
+++ b/cpp/c_api/output.cpp
@@ -2,7 +2,23 @@
 #include "sasktran2/config.h"
 #include "internal_types.h"
 #include <cstdio>
+#include <limits>
 #include <sasktran2.h>
+#include <stdexcept>
+
+namespace {
+    bool valid_product_output_memory(const double* radiance,
+                                     const double* product, int nrad,
+                                     int nstokes) {
+        if (nrad < 0 || (nstokes != 1 && nstokes != 3)) {
+            return false;
+        }
+        if (nrad > std::numeric_limits<int>::max() / nstokes) {
+            return false;
+        }
+        return nrad == 0 || (radiance != nullptr && product != nullptr);
+    }
+} // namespace
 
 OutputC::OutputC(double* radiance, int nrad, int nstokes, double* flux,
                  int nflux) {
@@ -20,6 +36,9 @@ OutputC::OutputC(double* radiance, int nrad, int nstokes, double* flux,
 }
 
 OutputJVP::OutputJVP(double* radiance, double* jvp, int nrad, int nstokes) {
+    if (!valid_product_output_memory(radiance, jvp, nrad, nstokes)) {
+        throw std::invalid_argument("Invalid JVP output memory");
+    }
     Eigen::Map<Eigen::VectorXd> radiance_map(radiance, nrad * nstokes);
     Eigen::Map<Eigen::VectorXd> jvp_map(jvp, nrad * nstokes);
     if (nstokes == 1) {
@@ -31,7 +50,8 @@ OutputJVP::OutputJVP(double* radiance, double* jvp, int nrad, int nstokes) {
 
 int OutputJVP::assign_derivative_tangent(const char* name,
                                          const double* tangent, int nparam) {
-    if (impl == nullptr || tangent == nullptr || nparam < 0) {
+    if (impl == nullptr || name == nullptr || nparam < 0 ||
+        (nparam > 0 && tangent == nullptr)) {
         return -1;
     }
     Eigen::Map<const Eigen::VectorXd> tangent_map(tangent, nparam);
@@ -48,7 +68,8 @@ int OutputJVP::assign_derivative_tangent(const char* name,
 
 int OutputJVP::assign_surface_tangent(const char* name, const double* tangent,
                                       int nparam) {
-    if (impl == nullptr || tangent == nullptr || nparam < 0) {
+    if (impl == nullptr || name == nullptr || nparam < 0 ||
+        (nparam > 0 && tangent == nullptr)) {
         return -1;
     }
     Eigen::Map<const Eigen::VectorXd> tangent_map(tangent, nparam);
@@ -65,6 +86,9 @@ int OutputJVP::assign_surface_tangent(const char* name, const double* tangent,
 
 OutputVJP::OutputVJP(double* radiance, const double* cotangent, int nrad,
                      int nstokes) {
+    if (!valid_product_output_memory(radiance, cotangent, nrad, nstokes)) {
+        throw std::invalid_argument("Invalid VJP output memory");
+    }
     Eigen::Map<Eigen::VectorXd> radiance_map(radiance, nrad * nstokes);
     Eigen::Map<const Eigen::VectorXd> cotangent_map(cotangent, nrad * nstokes);
     if (nstokes == 1) {
@@ -78,7 +102,8 @@ OutputVJP::OutputVJP(double* radiance, const double* cotangent, int nrad,
 
 int OutputVJP::assign_derivative_gradient(const char* name, double* gradient,
                                           int nparam) {
-    if (impl == nullptr || gradient == nullptr || nparam < 0) {
+    if (impl == nullptr || name == nullptr || nparam < 0 ||
+        (nparam > 0 && gradient == nullptr)) {
         return -1;
     }
     Eigen::Map<Eigen::VectorXd> gradient_map(gradient, nparam);
@@ -95,7 +120,8 @@ int OutputVJP::assign_derivative_gradient(const char* name, double* gradient,
 
 int OutputVJP::assign_surface_gradient(const char* name, double* gradient,
                                        int nparam) {
-    if (impl == nullptr || gradient == nullptr || nparam < 0) {
+    if (impl == nullptr || name == nullptr || nparam < 0 ||
+        (nparam > 0 && gradient == nullptr)) {
         return -1;
     }
     Eigen::Map<Eigen::VectorXd> gradient_map(gradient, nparam);
@@ -304,28 +330,46 @@ int sk_output_get_los_optical_depth(OutputC* output, double** od) {
 
 OutputJVP* sk_output_jvp_create(double* radiance, double* jvp, int nrad,
                                 int nstokes) {
-    return new OutputJVP(radiance, jvp, nrad, nstokes);
+    try {
+        return new OutputJVP(radiance, jvp, nrad, nstokes);
+    } catch (...) {
+        return nullptr;
+    }
 }
 
 void sk_output_jvp_destroy(OutputJVP* output) { delete output; }
 
 int sk_output_jvp_assign_derivative_tangent(OutputJVP* output, const char* name,
                                             const double* tangent, int nparam) {
-    return output == nullptr
-               ? -1
-               : output->assign_derivative_tangent(name, tangent, nparam);
+    if (output == nullptr) {
+        return -1;
+    }
+    try {
+        return output->assign_derivative_tangent(name, tangent, nparam);
+    } catch (...) {
+        return -3;
+    }
 }
 
 int sk_output_jvp_assign_surface_tangent(OutputJVP* output, const char* name,
                                          const double* tangent, int nparam) {
-    return output == nullptr
-               ? -1
-               : output->assign_surface_tangent(name, tangent, nparam);
+    if (output == nullptr) {
+        return -1;
+    }
+    try {
+        return output->assign_surface_tangent(name, tangent, nparam);
+    } catch (...) {
+        return -3;
+    }
 }
 
 OutputVJP* sk_output_vjp_create(double* radiance, const double* cotangent,
                                 int nrad, int nstokes) {
-    return new OutputVJP(radiance, cotangent, nrad, nstokes);
+    try {
+        return new OutputVJP(radiance, cotangent, nrad, nstokes);
+    } catch (...) {
+        return nullptr;
+    }
 }
 
 void sk_output_vjp_destroy(OutputVJP* output) { delete output; }
@@ -333,19 +377,36 @@ void sk_output_vjp_destroy(OutputVJP* output) { delete output; }
 int sk_output_vjp_assign_derivative_gradient(OutputVJP* output,
                                              const char* name, double* gradient,
                                              int nparam) {
-    return output == nullptr
-               ? -1
-               : output->assign_derivative_gradient(name, gradient, nparam);
+    if (output == nullptr) {
+        return -1;
+    }
+    try {
+        return output->assign_derivative_gradient(name, gradient, nparam);
+    } catch (...) {
+        return -3;
+    }
 }
 
 int sk_output_vjp_assign_surface_gradient(OutputVJP* output, const char* name,
                                           double* gradient, int nparam) {
-    return output == nullptr
-               ? -1
-               : output->assign_surface_gradient(name, gradient, nparam);
+    if (output == nullptr) {
+        return -1;
+    }
+    try {
+        return output->assign_surface_gradient(name, gradient, nparam);
+    } catch (...) {
+        return -3;
+    }
 }
 
 int sk_output_vjp_finalize(OutputVJP* output) {
-    return output == nullptr ? -1 : output->finalize();
+    if (output == nullptr) {
+        return -1;
+    }
+    try {
+        return output->finalize();
+    } catch (...) {
+        return -3;
+    }
 }
 }

--- a/cpp/include/sasktran2/engine.h
+++ b/cpp/include/sasktran2/engine.h
@@ -139,6 +139,14 @@ template <int NSTOKES> class Sasktran2 : public Sasktran2Interface {
         const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere,
         sasktran2::Output<NSTOKES>& output, bool only_initialize = false) const;
 
+    void
+    calculate_jvp(const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere,
+                  sasktran2::OutputJVP<NSTOKES>& output) const;
+
+    void
+    calculate_vjp(const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere,
+                  sasktran2::OutputVJP<NSTOKES>& output) const;
+
     int effective_wavelength_batch_size(int num_wavelengths) const;
 
     /** Reports whether the complete line-of-sight model supports a native

--- a/cpp/include/sasktran2/output.h
+++ b/cpp/include/sasktran2/output.h
@@ -343,6 +343,12 @@ namespace sasktran2 {
                     const sasktran2::WavelengthBlockDual<NSTOKES>& radiance,
                     int losidx, int threadidx) override;
 
+        void native_tangent(int wavelidx, Eigen::VectorXd& tangent) const;
+
+        void assign_native(int losidx, int wavelidx,
+                           const Eigen::Vector<double, NSTOKES>& value,
+                           const Eigen::Vector<double, NSTOKES>& jvp);
+
         void assign_flux(
             const sasktran2::Dual<double, sasktran2::dualstorage::dense, 1>&,
             int, int, int, int) override {}
@@ -385,6 +391,16 @@ namespace sasktran2 {
         void assign(const sasktran2::WavelengthBlock<>& block,
                     const sasktran2::WavelengthBlockDual<NSTOKES>& radiance,
                     int losidx, int threadidx) override;
+
+        Eigen::Vector<double, NSTOKES> native_cotangent(int losidx,
+                                                        int wavelidx) const;
+
+        void assign_native_value(int losidx, int wavelidx,
+                                 const Eigen::Vector<double, NSTOKES>& value);
+
+        void accumulate_native_gradient(
+            int wavelidx, int threadidx,
+            Eigen::Ref<const Eigen::VectorXd> native_gradient);
 
         void assign_flux(
             const sasktran2::Dual<double, sasktran2::dualstorage::dense, 1>&,

--- a/cpp/include/sasktran2/output.h
+++ b/cpp/include/sasktran2/output.h
@@ -315,6 +315,7 @@ namespace sasktran2 {
         Eigen::Map<Eigen::VectorXd> m_jvp;
         std::map<std::string, Eigen::VectorXd> m_derivative_tangents;
         std::map<std::string, Eigen::VectorXd> m_surface_tangents;
+        std::map<std::string, Eigen::VectorXd> m_native_parameter_tangents;
         std::vector<Eigen::MatrixXd> m_native_thread_storage;
         std::vector<Eigen::MatrixXd> m_mapped_thread_storage;
 
@@ -343,7 +344,8 @@ namespace sasktran2 {
                     const sasktran2::WavelengthBlockDual<NSTOKES>& radiance,
                     int losidx, int threadidx) override;
 
-        void native_tangent(int wavelidx, Eigen::VectorXd& tangent) const;
+        void native_tangent(int wavelidx,
+                            Eigen::Ref<Eigen::VectorXd> tangent) const;
 
         void assign_native(int losidx, int wavelidx,
                            const Eigen::Vector<double, NSTOKES>& value,
@@ -368,6 +370,8 @@ namespace sasktran2 {
         std::vector<std::map<std::string, Eigen::VectorXd>>
             m_thread_surface_gradients;
         std::vector<Eigen::MatrixXd> m_native_thread_storage;
+        std::vector<Eigen::MatrixXd> m_native_parameter_thread_storage;
+        std::vector<Eigen::RowVectorXd> m_surface_parameter_thread_storage;
 
         void resize();
 
@@ -401,6 +405,13 @@ namespace sasktran2 {
         void accumulate_native_gradient(
             int wavelidx, int threadidx,
             Eigen::Ref<const Eigen::VectorXd> native_gradient);
+
+        /** Applies constituent mappings once to a native gradient already
+         * reduced across every LOS in the wavelength block. */
+        void
+        accumulate_native_gradient(const sasktran2::WavelengthBlock<>& block,
+                                   int threadidx,
+                                   const Eigen::MatrixXd& native_gradient);
 
         void assign_flux(
             const sasktran2::Dual<double, sasktran2::dualstorage::dense, 1>&,

--- a/cpp/include/sasktran2/solartransmission.h
+++ b/cpp/include/sasktran2/solartransmission.h
@@ -288,6 +288,24 @@ namespace sasktran2::solartransmission {
             Eigen::Matrix<double, NSTOKES, Eigen::Dynamic, Eigen::RowMajor>&
                 phase_result) const;
 
+        void scatter_jvp(int threadidx, int losidx, int layeridx,
+                         const raytracing::GridWeightStencilView& index_weights,
+                         bool is_entrance,
+                         Eigen::Ref<const Eigen::VectorXd> native_tangent,
+                         Eigen::Vector<double, NSTOKES>& phase,
+                         Eigen::Vector<double, NSTOKES>& phase_jvp) const;
+
+        Eigen::Vector<double, NSTOKES>
+        scatter_value(int threadidx, int losidx, int layeridx,
+                      const raytracing::GridWeightStencilView& index_weights,
+                      bool is_entrance) const;
+
+        void scatter_vjp(int threadidx, int losidx, int layeridx,
+                         const raytracing::GridWeightStencilView& index_weights,
+                         bool is_entrance,
+                         const Eigen::Vector<double, NSTOKES>& phase_cotangent,
+                         Eigen::Ref<Eigen::VectorXd> native_gradient) const;
+
       private:
         template <typename Target>
         Eigen::Vector<double, NSTOKES> scatter_and_accumulate_derivative_impl(
@@ -690,6 +708,20 @@ namespace sasktran2::solartransmission {
             typename SourceTermInterface<NSTOKES>::IntegrationDirection
                 direction) const;
 
+        void endpoint_source_jvp(
+            int wavelidx, int losidx, int layeridx, int wavel_threadidx,
+            int solar_index,
+            const sasktran2::raytracing::GridWeightStencilView& weights,
+            bool is_entrance, Eigen::Ref<const Eigen::VectorXd> native_tangent,
+            sasktran2::RadianceJVP<NSTOKES>& result) const;
+
+        Eigen::Vector<double, NSTOKES> endpoint_source_vjp(
+            int wavelidx, int losidx, int layeridx, int wavel_threadidx,
+            int solar_index,
+            const sasktran2::raytracing::GridWeightStencilView& weights,
+            bool is_entrance, const Eigen::Vector<double, NSTOKES>& cotangent,
+            Eigen::Ref<Eigen::VectorXd> native_gradient) const;
+
       public:
         SingleScatterSource(
             const Geometry1D& geometry,
@@ -908,6 +940,42 @@ namespace sasktran2::solartransmission {
         bool supports_sparse_derivative_tracking() const override {
             return std::is_same_v<S, SolarTransmissionExact>;
         }
+
+        bool supports_linearization(
+            sasktran2::LinearizationMode mode) const override {
+            return mode == sasktran2::LinearizationMode::Jacobian ||
+                   std::is_same_v<S, SolarTransmissionExact>;
+        }
+
+        void end_of_ray_source_jvp(
+            int wavelidx, int losidx, int wavel_threadidx, int threadidx,
+            Eigen::Ref<const Eigen::VectorXd> native_tangent,
+            sasktran2::RadianceJVP<NSTOKES>& source) const override;
+
+        void integrated_source_jvp(
+            int wavelidx, int losidx, int layeridx, int wavel_threadidx,
+            int threadidx, const sasktran2::raytracing::TracedLayer& layer,
+            const sasktran2::raytracing::GridWeightStencilView&
+                entrance_weights,
+            const sasktran2::raytracing::GridWeightStencilView& exit_weights,
+            const sasktran2::WavelengthBlockODView& shell_od,
+            Eigen::Ref<const Eigen::VectorXd> native_tangent,
+            sasktran2::RadianceJVP<NSTOKES>& source) const override;
+
+        void end_of_ray_source_vjp(
+            int wavelidx, int losidx, int wavel_threadidx, int threadidx,
+            const Eigen::Vector<double, NSTOKES>& cotangent,
+            Eigen::Ref<Eigen::VectorXd> native_gradient) const override;
+
+        void integrated_source_vjp(
+            int wavelidx, int losidx, int layeridx, int wavel_threadidx,
+            int threadidx, const sasktran2::raytracing::TracedLayer& layer,
+            const sasktran2::raytracing::GridWeightStencilView&
+                entrance_weights,
+            const sasktran2::raytracing::GridWeightStencilView& exit_weights,
+            const sasktran2::WavelengthBlockODView& shell_od,
+            const Eigen::Vector<double, NSTOKES>& cotangent,
+            Eigen::Ref<Eigen::VectorXd> native_gradient) const override;
 
         void append_end_of_ray_active_derivatives(
             int losidx, std::vector<int>& derivative_indices) const override;

--- a/cpp/include/sasktran2/solartransmission.h
+++ b/cpp/include/sasktran2/solartransmission.h
@@ -1053,6 +1053,16 @@ namespace sasktran2::solartransmission {
         void start_of_ray_source(
             const sasktran2::WavelengthBlock<>&, int, int, int,
             sasktran2::WavelengthBlockDual<NSTOKES>&) const override {}
+
+        void start_of_ray_source_jvp(
+            int, int, int, int, Eigen::Ref<const Eigen::VectorXd>,
+            sasktran2::RadianceJVP<NSTOKES>&) const override {}
+
+        void
+        start_of_ray_source_vjp(int, int, int, int,
+                                const Eigen::Vector<double, NSTOKES>&,
+                                Eigen::Vector<double, NSTOKES>&,
+                                Eigen::Ref<Eigen::VectorXd>) const override {}
     };
 
     template <int NSTOKES>

--- a/cpp/include/sasktran2/solartransmission.h
+++ b/cpp/include/sasktran2/solartransmission.h
@@ -182,6 +182,8 @@ namespace sasktran2::solartransmission {
         std::vector<RowMajorMatrix> m_phase_batch;
         std::vector<RowMajorMatrix> m_d_phase_batch;
         int m_wavelength_batch_capacity = 0;
+        std::vector<int> m_active_wavelength_block_start;
+        std::vector<int> m_active_wavelength_block_count;
 
         std::vector<std::vector<std::vector<int>>>
             m_geometry_entrance_to_internal; /** Mapping from layer entrances to
@@ -288,7 +290,7 @@ namespace sasktran2::solartransmission {
             Eigen::Matrix<double, NSTOKES, Eigen::Dynamic, Eigen::RowMajor>&
                 phase_result) const;
 
-        void scatter_jvp(int threadidx, int losidx, int layeridx,
+        void scatter_jvp(int threadidx, int losidx, int layeridx, int wavelidx,
                          const raytracing::GridWeightStencilView& index_weights,
                          bool is_entrance,
                          Eigen::Ref<const Eigen::VectorXd> native_tangent,
@@ -296,11 +298,11 @@ namespace sasktran2::solartransmission {
                          Eigen::Vector<double, NSTOKES>& phase_jvp) const;
 
         Eigen::Vector<double, NSTOKES>
-        scatter_value(int threadidx, int losidx, int layeridx,
+        scatter_value(int threadidx, int losidx, int layeridx, int wavelidx,
                       const raytracing::GridWeightStencilView& index_weights,
                       bool is_entrance) const;
 
-        void scatter_vjp(int threadidx, int losidx, int layeridx,
+        void scatter_vjp(int threadidx, int losidx, int layeridx, int wavelidx,
                          const raytracing::GridWeightStencilView& index_weights,
                          bool is_entrance,
                          const Eigen::Vector<double, NSTOKES>& phase_cotangent,
@@ -654,6 +656,8 @@ namespace sasktran2::solartransmission {
                                              Eigen::Dynamic, Eigen::RowMajor>;
         std::vector<RowMajorMatrix> m_solar_trans_batch;
         int m_wavelength_batch_capacity = 1;
+        std::vector<int> m_active_wavelength_block_start;
+        std::vector<int> m_active_wavelength_block_count;
         std::vector<std::vector<int>> m_index_map;
 
         PhaseHandler<NSTOKES> m_phase_handler;
@@ -721,6 +725,9 @@ namespace sasktran2::solartransmission {
             const sasktran2::raytracing::GridWeightStencilView& weights,
             bool is_entrance, const Eigen::Vector<double, NSTOKES>& cotangent,
             Eigen::Ref<Eigen::VectorXd> native_gradient) const;
+
+        double solar_transmission_value(int wavelidx, int threadidx,
+                                        int solar_index) const;
 
       public:
         SingleScatterSource(
@@ -962,9 +969,13 @@ namespace sasktran2::solartransmission {
             Eigen::Ref<const Eigen::VectorXd> native_tangent,
             sasktran2::RadianceJVP<NSTOKES>& source) const override;
 
+        /** Native exact single scattering is additive at the end of the ray
+         * and within each layer, so these implementations leave the mutable
+         * cotangent unchanged. */
         void end_of_ray_source_vjp(
             int wavelidx, int losidx, int wavel_threadidx, int threadidx,
-            const Eigen::Vector<double, NSTOKES>& cotangent,
+            const Eigen::Vector<double, NSTOKES>& value_before,
+            Eigen::Vector<double, NSTOKES>& cotangent,
             Eigen::Ref<Eigen::VectorXd> native_gradient) const override;
 
         void integrated_source_vjp(
@@ -974,7 +985,8 @@ namespace sasktran2::solartransmission {
                 entrance_weights,
             const sasktran2::raytracing::GridWeightStencilView& exit_weights,
             const sasktran2::WavelengthBlockODView& shell_od,
-            const Eigen::Vector<double, NSTOKES>& cotangent,
+            const Eigen::Vector<double, NSTOKES>& value_before,
+            Eigen::Vector<double, NSTOKES>& cotangent,
             Eigen::Ref<Eigen::VectorXd> native_gradient) const override;
 
         void append_end_of_ray_active_derivatives(

--- a/cpp/include/sasktran2/source_integrator.h
+++ b/cpp/include/sasktran2/source_integrator.h
@@ -145,15 +145,25 @@ namespace sasktran2 {
         supports_linearization(sasktran2::LinearizationMode mode,
                                const std::vector<SourceTermInterface<NSTOKES>*>&
                                    source_terms) const {
-            if (mode != sasktran2::LinearizationMode::Jacobian) {
-                return false;
-            }
             return std::all_of(
                 source_terms.begin(), source_terms.end(),
                 [mode](const SourceTermInterface<NSTOKES>* source) {
                     return source->supports_linearization(mode);
                 });
         }
+
+        void integrate_jvp(
+            sasktran2::RadianceJVP<NSTOKES>& radiance,
+            const std::vector<SourceTermInterface<NSTOKES>*>& source_terms,
+            int wavelength, int rayidx, int wavel_threadidx, int threadidx,
+            Eigen::Ref<const Eigen::VectorXd> native_tangent) const;
+
+        void integrate_vjp(
+            Eigen::Vector<double, NSTOKES>& radiance,
+            const std::vector<SourceTermInterface<NSTOKES>*>& source_terms,
+            int wavelength, int rayidx, int wavel_threadidx, int threadidx,
+            const Eigen::Vector<double, NSTOKES>& cotangent,
+            Eigen::Ref<Eigen::VectorXd> native_gradient) const;
 
         /** Integrates the source terms and stores the result in radiance
          *

--- a/cpp/include/sasktran2/source_integrator.h
+++ b/cpp/include/sasktran2/source_integrator.h
@@ -50,6 +50,18 @@ namespace sasktran2 {
 
         using RowMajorMatrix = Eigen::Matrix<double, Eigen::Dynamic,
                                              Eigen::Dynamic, Eigen::RowMajor>;
+        using StokesBlock =
+            Eigen::Matrix<double, NSTOKES, Eigen::Dynamic, Eigen::RowMajor>;
+        struct VJPThreadStorage {
+            sasktran2::WavelengthBlockDual<NSTOKES> state;
+            StokesBlock cotangent;
+            Eigen::RowVectorXd od_cotangent;
+            RowMajorMatrix values_before_end;
+            RowMajorMatrix values_before_layer;
+            RowMajorMatrix values_before_interior;
+            RowMajorMatrix attenuation;
+            RowMajorMatrix values_before_start;
+        };
         std::vector<RowMajorMatrix>
             m_shell_od; /**< Optical depth for every ray, layer, and
                            wavelength. */
@@ -58,6 +70,7 @@ namespace sasktran2 {
                                   when the configured block capacity is one. */
         int m_wavelength_block_capacity = 1;
         mutable std::vector<Eigen::RowVectorXd> m_thread_attenuation{1};
+        mutable std::vector<VJPThreadStorage> m_vjp_thread_storage;
         const std::vector<sasktran2::raytracing::TracedRay>* m_traced_rays =
             nullptr; /**< Reference to the rays we are integrating */
 
@@ -85,6 +98,12 @@ namespace sasktran2 {
             const ShellODMatrix& shell_od,
             const sasktran2::WavelengthBlock<N>& batch, int rayidx,
             int wavel_threadidx, int threadidx) const;
+
+        /** Validates source/block integration requirements and returns true
+         * when at least one source requires line-of-sight layer marching. */
+        bool validate_sources_for_block(
+            const std::vector<SourceTermInterface<NSTOKES>*>& source_terms,
+            int block_size) const;
 
       public:
         /**
@@ -133,6 +152,34 @@ namespace sasktran2 {
             }
         }
 
+        /** Allocates the reverse-mode tape once per engine thread. */
+        void initialize_vjp_storage(int num_threads, int num_sources) {
+            std::size_t max_layers = 0;
+            if (m_traced_rays != nullptr) {
+                for (const auto& ray : *m_traced_rays) {
+                    max_layers = std::max(max_layers, ray.layers.size());
+                }
+            }
+            m_vjp_thread_storage.resize(num_threads);
+            for (auto& storage : m_vjp_thread_storage) {
+                storage.state.resize(m_wavelength_block_capacity, 0, true);
+                storage.cotangent.resize(NSTOKES, m_wavelength_block_capacity);
+                storage.od_cotangent.resize(m_wavelength_block_capacity);
+                storage.values_before_end.resize(num_sources * NSTOKES,
+                                                 m_wavelength_block_capacity);
+                storage.values_before_layer.resize(
+                    static_cast<int>(max_layers) * NSTOKES,
+                    m_wavelength_block_capacity);
+                storage.values_before_interior.resize(
+                    static_cast<int>(max_layers) * num_sources * NSTOKES,
+                    m_wavelength_block_capacity);
+                storage.attenuation.resize(static_cast<int>(max_layers),
+                                           m_wavelength_block_capacity);
+                storage.values_before_start.resize(num_sources * NSTOKES,
+                                                   m_wavelength_block_capacity);
+            }
+        }
+
         /** Precomputes the cumulative derivative columns that can be nonzero
          * before each layer attenuation. This is enabled only when every
          * active source can report its derivative sparsity exactly. */
@@ -164,6 +211,15 @@ namespace sasktran2 {
             int wavelength, int rayidx, int wavel_threadidx, int threadidx,
             const Eigen::Vector<double, NSTOKES>& cotangent,
             Eigen::Ref<Eigen::VectorXd> native_gradient) const;
+
+        /** Integrates a wavelength block and adds its reverse-mode native
+         * gradients to `native_gradient`. */
+        void integrate_vjp_block(
+            StokesBlock& radiance,
+            const std::vector<SourceTermInterface<NSTOKES>*>& source_terms,
+            const sasktran2::WavelengthBlock<>& block, int rayidx,
+            int wavel_threadidx, int threadidx, const StokesBlock& cotangent,
+            Eigen::MatrixXd& native_gradient) const;
 
         /** Integrates the source terms and stores the result in radiance
          *

--- a/cpp/include/sasktran2/source_interface.h
+++ b/cpp/include/sasktran2/source_interface.h
@@ -11,6 +11,18 @@
 namespace sasktran2 {
     template <int NSTOKES> class SourceIntegrator;
 
+    template <int NSTOKES> struct RadianceJVP {
+        Eigen::Vector<double, NSTOKES> value =
+            Eigen::Vector<double, NSTOKES>::Zero();
+        Eigen::Vector<double, NSTOKES> jvp =
+            Eigen::Vector<double, NSTOKES>::Zero();
+
+        void set_zero() {
+            value.setZero();
+            jvp.setZero();
+        }
+    };
+
     /** Native derivative execution modes that an engine component may
      * implement. Capability reporting is kept separate from execution so
      * specialized JVP/VJP interfaces can be added without placeholder hooks. */
@@ -226,6 +238,42 @@ template <int NSTOKES> class SourceTermInterface {
     virtual bool
     supports_linearization(sasktran2::LinearizationMode mode) const {
         return mode == sasktran2::LinearizationMode::Jacobian;
+    }
+
+    virtual void end_of_ray_source_jvp(int, int, int, int,
+                                       Eigen::Ref<const Eigen::VectorXd>,
+                                       sasktran2::RadianceJVP<NSTOKES>&) const {
+        throw std::logic_error("Native source JVP is not implemented");
+    }
+
+    virtual void
+    integrated_source_jvp(int, int, int, int, int,
+                          const sasktran2::raytracing::TracedLayer&,
+                          const sasktran2::raytracing::GridWeightStencilView&,
+                          const sasktran2::raytracing::GridWeightStencilView&,
+                          const sasktran2::WavelengthBlockODView&,
+                          Eigen::Ref<const Eigen::VectorXd>,
+                          sasktran2::RadianceJVP<NSTOKES>&) const {
+        throw std::logic_error(
+            "Native integrated source JVP is not implemented");
+    }
+
+    virtual void end_of_ray_source_vjp(int, int, int, int,
+                                       const Eigen::Vector<double, NSTOKES>&,
+                                       Eigen::Ref<Eigen::VectorXd>) const {
+        throw std::logic_error("Native source VJP is not implemented");
+    }
+
+    virtual void
+    integrated_source_vjp(int, int, int, int, int,
+                          const sasktran2::raytracing::TracedLayer&,
+                          const sasktran2::raytracing::GridWeightStencilView&,
+                          const sasktran2::raytracing::GridWeightStencilView&,
+                          const sasktran2::WavelengthBlockODView&,
+                          const Eigen::Vector<double, NSTOKES>&,
+                          Eigen::Ref<Eigen::VectorXd>) const {
+        throw std::logic_error(
+            "Native integrated source VJP is not implemented");
     }
 
     /** Returns whether this source supports the requested atmosphere

--- a/cpp/include/sasktran2/source_interface.h
+++ b/cpp/include/sasktran2/source_interface.h
@@ -258,6 +258,18 @@ template <int NSTOKES> class SourceTermInterface {
             "Native integrated source JVP is not implemented");
     }
 
+    /** Applies a source contribution evaluated after line-of-sight
+     * integration to a value/tangent pair.  Unlike end-of-ray and interior
+     * hooks, this operation may transform the radiance already accumulated by
+     * earlier sources, so the source owns both the input and output state. */
+    virtual void
+    start_of_ray_source_jvp(int, int, int, int,
+                            Eigen::Ref<const Eigen::VectorXd>,
+                            sasktran2::RadianceJVP<NSTOKES>&) const {
+        throw std::logic_error(
+            "Native start-of-ray source JVP is not implemented");
+    }
+
     virtual void end_of_ray_source_vjp(int, int, int, int,
                                        const Eigen::Vector<double, NSTOKES>&,
                                        Eigen::Ref<Eigen::VectorXd>) const {
@@ -274,6 +286,18 @@ template <int NSTOKES> class SourceTermInterface {
                           Eigen::Ref<Eigen::VectorXd>) const {
         throw std::logic_error(
             "Native integrated source VJP is not implemented");
+    }
+
+    /** Pulls a cotangent through a post-integration source contribution.
+     * `value_before` is the radiance immediately before this source was
+     * applied.  Implementations add parameter gradients to `native_gradient`
+     * and replace `cotangent` with the cotangent of `value_before`. */
+    virtual void start_of_ray_source_vjp(int, int, int, int,
+                                         const Eigen::Vector<double, NSTOKES>&,
+                                         Eigen::Vector<double, NSTOKES>&,
+                                         Eigen::Ref<Eigen::VectorXd>) const {
+        throw std::logic_error(
+            "Native start-of-ray source VJP is not implemented");
     }
 
     /** Returns whether this source supports the requested atmosphere

--- a/cpp/include/sasktran2/source_interface.h
+++ b/cpp/include/sasktran2/source_interface.h
@@ -270,20 +270,30 @@ template <int NSTOKES> class SourceTermInterface {
             "Native start-of-ray source JVP is not implemented");
     }
 
+    /** Pulls a cotangent through a source contribution evaluated at the end of
+     * the ray. `value_before` is the radiance immediately before this source
+     * was applied. Implementations add parameter gradients to
+     * `native_gradient` and replace `cotangent` with the cotangent of
+     * `value_before`. */
     virtual void end_of_ray_source_vjp(int, int, int, int,
                                        const Eigen::Vector<double, NSTOKES>&,
+                                       Eigen::Vector<double, NSTOKES>&,
                                        Eigen::Ref<Eigen::VectorXd>) const {
         throw std::logic_error("Native source VJP is not implemented");
     }
 
-    virtual void
-    integrated_source_vjp(int, int, int, int, int,
-                          const sasktran2::raytracing::TracedLayer&,
-                          const sasktran2::raytracing::GridWeightStencilView&,
-                          const sasktran2::raytracing::GridWeightStencilView&,
-                          const sasktran2::WavelengthBlockODView&,
-                          const Eigen::Vector<double, NSTOKES>&,
-                          Eigen::Ref<Eigen::VectorXd>) const {
+    /** Pulls a cotangent through a source contribution evaluated within a
+     * traced layer. `value_before` is the attenuated radiance immediately
+     * before this source was applied. Implementations add parameter gradients
+     * to `native_gradient` and replace `cotangent` with the cotangent of
+     * `value_before`. */
+    virtual void integrated_source_vjp(
+        int, int, int, int, int, const sasktran2::raytracing::TracedLayer&,
+        const sasktran2::raytracing::GridWeightStencilView&,
+        const sasktran2::raytracing::GridWeightStencilView&,
+        const sasktran2::WavelengthBlockODView&,
+        const Eigen::Vector<double, NSTOKES>&, Eigen::Vector<double, NSTOKES>&,
+        Eigen::Ref<Eigen::VectorXd>) const {
         throw std::logic_error(
             "Native integrated source VJP is not implemented");
     }

--- a/cpp/lib/engine/engine.cpp
+++ b/cpp/lib/engine/engine.cpp
@@ -536,6 +536,89 @@ void Sasktran2<NSTOKES>::calculate_radiance(
 }
 
 template <int NSTOKES>
+void Sasktran2<NSTOKES>::calculate_jvp(
+    const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere,
+    sasktran2::OutputJVP<NSTOKES>& output) const {
+    if (!supports_linearization(sasktran2::LinearizationMode::JVP)) {
+        throw std::logic_error(
+            "The configured sources do not implement a native JVP");
+    }
+    validate_input_atmosphere(atmosphere);
+    const_cast<sasktran2::atmosphere::AtmosphereGridStorageFull<NSTOKES>&>(
+        atmosphere.storage())
+        .determine_maximum_order();
+
+    m_source_integrator->initialize_thread_storage(m_config.num_threads(), 1);
+    for (auto& source : m_source_terms) {
+        source->set_wavelength_block_capacity(1);
+        source->initialize_atmosphere(atmosphere);
+    }
+    m_source_integrator->initialize_atmosphere(atmosphere);
+    output.set_wavelength_block_capacity(1);
+    output.initialize(m_config, *m_geometry, m_internal_viewing_geometry,
+                      atmosphere);
+
+    Eigen::VectorXd native_tangent(atmosphere.num_deriv());
+    for (int wavelength = 0; wavelength < atmosphere.num_wavel();
+         ++wavelength) {
+        const sasktran2::WavelengthBlock<> block{wavelength, 1};
+        for (auto& source : m_source_terms) {
+            source->calculate(block, 0);
+        }
+        output.native_tangent(wavelength, native_tangent);
+        for (int ray = 0; ray < m_internal_viewing_geometry.num_rays(); ++ray) {
+            sasktran2::RadianceJVP<NSTOKES> radiance;
+            m_source_integrator->integrate_jvp(radiance, m_los_source_terms,
+                                               wavelength, ray, 0, 0,
+                                               native_tangent);
+            output.assign_native(ray, wavelength, radiance.value, radiance.jvp);
+        }
+    }
+}
+
+template <int NSTOKES>
+void Sasktran2<NSTOKES>::calculate_vjp(
+    const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere,
+    sasktran2::OutputVJP<NSTOKES>& output) const {
+    if (!supports_linearization(sasktran2::LinearizationMode::VJP)) {
+        throw std::logic_error(
+            "The configured sources do not implement a native VJP");
+    }
+    validate_input_atmosphere(atmosphere);
+    const_cast<sasktran2::atmosphere::AtmosphereGridStorageFull<NSTOKES>&>(
+        atmosphere.storage())
+        .determine_maximum_order();
+
+    m_source_integrator->initialize_thread_storage(m_config.num_threads(), 1);
+    for (auto& source : m_source_terms) {
+        source->set_wavelength_block_capacity(1);
+        source->initialize_atmosphere(atmosphere);
+    }
+    m_source_integrator->initialize_atmosphere(atmosphere);
+    output.set_wavelength_block_capacity(1);
+    output.initialize(m_config, *m_geometry, m_internal_viewing_geometry,
+                      atmosphere);
+
+    Eigen::VectorXd native_gradient(atmosphere.num_deriv());
+    for (int wavelength = 0; wavelength < atmosphere.num_wavel();
+         ++wavelength) {
+        const sasktran2::WavelengthBlock<> block{wavelength, 1};
+        for (auto& source : m_source_terms) {
+            source->calculate(block, 0);
+        }
+        for (int ray = 0; ray < m_internal_viewing_geometry.num_rays(); ++ray) {
+            native_gradient.setZero();
+            Eigen::Vector<double, NSTOKES> radiance;
+            m_source_integrator->integrate_vjp(
+                radiance, m_los_source_terms, wavelength, ray, 0, 0,
+                output.native_cotangent(ray, wavelength), native_gradient);
+            output.assign_native_value(ray, wavelength, radiance);
+            output.accumulate_native_gradient(wavelength, 0, native_gradient);
+        }
+    }
+}
+
+template <int NSTOKES>
 int Sasktran2<NSTOKES>::effective_wavelength_batch_size(
     int num_wavelengths) const {
     const int requested_block_size = std::max(

--- a/cpp/lib/engine/engine.cpp
+++ b/cpp/lib/engine/engine.cpp
@@ -558,19 +558,34 @@ void Sasktran2<NSTOKES>::calculate_jvp(
     output.initialize(m_config, *m_geometry, m_internal_viewing_geometry,
                       atmosphere);
 
-    Eigen::VectorXd native_tangent(atmosphere.num_deriv());
+    const int num_wavelength_threads = m_config.num_wavelength_threads();
+#pragma omp parallel for num_threads(num_wavelength_threads)
     for (int wavelength = 0; wavelength < atmosphere.num_wavel();
          ++wavelength) {
+#ifdef SKTRAN_OPENMP_SUPPORT
+        const int wavelength_threadidx = omp_get_thread_num();
+#else
+        const int wavelength_threadidx = 0;
+#endif
         const sasktran2::WavelengthBlock<> block{wavelength, 1};
         for (auto& source : m_source_terms) {
-            source->calculate(block, 0);
+            source->calculate(block, wavelength_threadidx);
         }
+        Eigen::VectorXd native_tangent(atmosphere.num_deriv());
         output.native_tangent(wavelength, native_tangent);
+#pragma omp parallel for num_threads(m_config.num_source_threads())            \
+    schedule(dynamic)
         for (int ray = 0; ray < m_internal_viewing_geometry.num_rays(); ++ray) {
+#ifdef SKTRAN_OPENMP_SUPPORT
+            const int ray_threadidx =
+                omp_get_thread_num() + wavelength_threadidx;
+#else
+            const int ray_threadidx = wavelength_threadidx;
+#endif
             sasktran2::RadianceJVP<NSTOKES> radiance;
-            m_source_integrator->integrate_jvp(radiance, m_los_source_terms,
-                                               wavelength, ray, 0, 0,
-                                               native_tangent);
+            m_source_integrator->integrate_jvp(
+                radiance, m_los_source_terms, wavelength, ray,
+                wavelength_threadidx, ray_threadidx, native_tangent);
             output.assign_native(ray, wavelength, radiance.value, radiance.jvp);
         }
     }
@@ -599,21 +614,42 @@ void Sasktran2<NSTOKES>::calculate_vjp(
     output.initialize(m_config, *m_geometry, m_internal_viewing_geometry,
                       atmosphere);
 
-    Eigen::VectorXd native_gradient(atmosphere.num_deriv());
+    std::vector<Eigen::VectorXd> native_gradients(m_config.num_threads());
+    for (auto& native_gradient : native_gradients) {
+        native_gradient.resize(atmosphere.num_deriv());
+    }
+    const int num_wavelength_threads = m_config.num_wavelength_threads();
+#pragma omp parallel for num_threads(num_wavelength_threads)
     for (int wavelength = 0; wavelength < atmosphere.num_wavel();
          ++wavelength) {
+#ifdef SKTRAN_OPENMP_SUPPORT
+        const int wavelength_threadidx = omp_get_thread_num();
+#else
+        const int wavelength_threadidx = 0;
+#endif
         const sasktran2::WavelengthBlock<> block{wavelength, 1};
         for (auto& source : m_source_terms) {
-            source->calculate(block, 0);
+            source->calculate(block, wavelength_threadidx);
         }
+#pragma omp parallel for num_threads(m_config.num_source_threads())            \
+    schedule(dynamic)
         for (int ray = 0; ray < m_internal_viewing_geometry.num_rays(); ++ray) {
+#ifdef SKTRAN_OPENMP_SUPPORT
+            const int ray_threadidx =
+                omp_get_thread_num() + wavelength_threadidx;
+#else
+            const int ray_threadidx = wavelength_threadidx;
+#endif
+            auto& native_gradient = native_gradients[ray_threadidx];
             native_gradient.setZero();
             Eigen::Vector<double, NSTOKES> radiance;
             m_source_integrator->integrate_vjp(
-                radiance, m_los_source_terms, wavelength, ray, 0, 0,
+                radiance, m_los_source_terms, wavelength, ray,
+                wavelength_threadidx, ray_threadidx,
                 output.native_cotangent(ray, wavelength), native_gradient);
             output.assign_native_value(ray, wavelength, radiance);
-            output.accumulate_native_gradient(wavelength, 0, native_gradient);
+            output.accumulate_native_gradient(wavelength, ray_threadidx,
+                                              native_gradient);
         }
     }
 }

--- a/cpp/lib/engine/engine.cpp
+++ b/cpp/lib/engine/engine.cpp
@@ -539,25 +539,44 @@ template <int NSTOKES>
 void Sasktran2<NSTOKES>::calculate_jvp(
     const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere,
     sasktran2::OutputJVP<NSTOKES>& output) const {
+#ifdef SKTRAN_OPENMP_SUPPORT
+    omp_set_num_threads(m_config.num_threads());
+    Eigen::setNbThreads(m_config.num_source_threads());
+#endif
+
     if (!supports_linearization(sasktran2::LinearizationMode::JVP)) {
         throw std::logic_error(
             "The configured sources do not implement a native JVP");
     }
     validate_input_atmosphere(atmosphere);
+    if (atmosphere.num_deriv() == 0) {
+        throw std::invalid_argument(
+            "JVP calculation requires an atmosphere constructed with "
+            "calculate_derivatives=true");
+    }
     const_cast<sasktran2::atmosphere::AtmosphereGridStorageFull<NSTOKES>&>(
         atmosphere.storage())
         .determine_maximum_order();
 
+    // The native source JVP hooks currently operate on one wavelength at a
+    // time. Feeding them from batched source caches adds dispatch/cache
+    // overhead without vectorizing the product itself, so retain the scalar
+    // source path until a native block-JVP hook is available.
+    constexpr int wavelength_batch_size = 1;
     m_source_integrator->initialize_thread_storage(m_config.num_threads(), 1);
     for (auto& source : m_source_terms) {
-        source->set_wavelength_block_capacity(1);
+        source->set_wavelength_block_capacity(wavelength_batch_size);
         source->initialize_atmosphere(atmosphere);
     }
     m_source_integrator->initialize_atmosphere(atmosphere);
-    output.set_wavelength_block_capacity(1);
+    output.set_wavelength_block_capacity(wavelength_batch_size);
     output.initialize(m_config, *m_geometry, m_internal_viewing_geometry,
                       atmosphere);
 
+    std::vector<Eigen::VectorXd> native_tangents(m_config.num_threads());
+    for (auto& tangent : native_tangents) {
+        tangent.resize(atmosphere.num_deriv());
+    }
     const int num_wavelength_threads = m_config.num_wavelength_threads();
 #pragma omp parallel for num_threads(num_wavelength_threads)
     for (int wavelength = 0; wavelength < atmosphere.num_wavel();
@@ -571,7 +590,7 @@ void Sasktran2<NSTOKES>::calculate_jvp(
         for (auto& source : m_source_terms) {
             source->calculate(block, wavelength_threadidx);
         }
-        Eigen::VectorXd native_tangent(atmosphere.num_deriv());
+        auto& native_tangent = native_tangents[wavelength_threadidx];
         output.native_tangent(wavelength, native_tangent);
 #pragma omp parallel for num_threads(m_config.num_source_threads())            \
     schedule(dynamic)
@@ -595,44 +614,80 @@ template <int NSTOKES>
 void Sasktran2<NSTOKES>::calculate_vjp(
     const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere,
     sasktran2::OutputVJP<NSTOKES>& output) const {
+#ifdef SKTRAN_OPENMP_SUPPORT
+    omp_set_num_threads(m_config.num_threads());
+    Eigen::setNbThreads(m_config.num_source_threads());
+#endif
+
     if (!supports_linearization(sasktran2::LinearizationMode::VJP)) {
         throw std::logic_error(
             "The configured sources do not implement a native VJP");
     }
     validate_input_atmosphere(atmosphere);
+    if (atmosphere.num_deriv() == 0) {
+        throw std::invalid_argument(
+            "VJP calculation requires an atmosphere constructed with "
+            "calculate_derivatives=true");
+    }
     const_cast<sasktran2::atmosphere::AtmosphereGridStorageFull<NSTOKES>&>(
         atmosphere.storage())
         .determine_maximum_order();
 
-    m_source_integrator->initialize_thread_storage(m_config.num_threads(), 1);
+    const int wavelength_batch_size =
+        effective_wavelength_batch_size(atmosphere.num_wavel());
+    m_source_integrator->initialize_thread_storage(m_config.num_threads(),
+                                                   wavelength_batch_size);
+    m_source_integrator->initialize_vjp_storage(
+        m_config.num_threads(), static_cast<int>(m_los_source_terms.size()));
     for (auto& source : m_source_terms) {
-        source->set_wavelength_block_capacity(1);
+        source->set_wavelength_block_capacity(wavelength_batch_size);
         source->initialize_atmosphere(atmosphere);
     }
     m_source_integrator->initialize_atmosphere(atmosphere);
-    output.set_wavelength_block_capacity(1);
+    output.set_wavelength_block_capacity(wavelength_batch_size);
     output.initialize(m_config, *m_geometry, m_internal_viewing_geometry,
                       atmosphere);
 
-    std::vector<Eigen::VectorXd> native_gradients(m_config.num_threads());
-    for (auto& native_gradient : native_gradients) {
-        native_gradient.resize(atmosphere.num_deriv());
+    using StokesBlock =
+        Eigen::Matrix<double, NSTOKES, Eigen::Dynamic, Eigen::RowMajor>;
+    std::vector<Eigen::MatrixXd> native_gradients(m_config.num_threads());
+    std::vector<StokesBlock> radiance_storage(m_config.num_threads());
+    std::vector<StokesBlock> cotangent_storage(m_config.num_threads());
+    for (int thread = 0; thread < m_config.num_threads(); ++thread) {
+        native_gradients[thread].resize(atmosphere.num_deriv(),
+                                        wavelength_batch_size);
+        radiance_storage[thread].resize(NSTOKES, wavelength_batch_size);
+        cotangent_storage[thread].resize(NSTOKES, wavelength_batch_size);
     }
     const int num_wavelength_threads = m_config.num_wavelength_threads();
+    const int num_source_threads = m_config.num_source_threads();
+    const int num_blocks =
+        (atmosphere.num_wavel() + wavelength_batch_size - 1) /
+        wavelength_batch_size;
 #pragma omp parallel for num_threads(num_wavelength_threads)
-    for (int wavelength = 0; wavelength < atmosphere.num_wavel();
-         ++wavelength) {
+    for (int block_index = 0; block_index < num_blocks; ++block_index) {
 #ifdef SKTRAN_OPENMP_SUPPORT
         const int wavelength_threadidx = omp_get_thread_num();
 #else
         const int wavelength_threadidx = 0;
 #endif
-        const sasktran2::WavelengthBlock<> block{wavelength, 1};
+        const int start = block_index * wavelength_batch_size;
+        const sasktran2::WavelengthBlock<> block{
+            start,
+            std::min(wavelength_batch_size, atmosphere.num_wavel() - start)};
         for (auto& source : m_source_terms) {
             source->calculate(block, wavelength_threadidx);
         }
-#pragma omp parallel for num_threads(m_config.num_source_threads())            \
-    schedule(dynamic)
+        if (num_source_threads == 1) {
+            native_gradients[wavelength_threadidx]
+                .leftCols(block.count)
+                .setZero();
+        } else {
+            for (int thread = 0; thread < num_source_threads; ++thread) {
+                native_gradients[thread].leftCols(block.count).setZero();
+            }
+        }
+#pragma omp parallel for num_threads(num_source_threads) schedule(dynamic)
         for (int ray = 0; ray < m_internal_viewing_geometry.num_rays(); ++ray) {
 #ifdef SKTRAN_OPENMP_SUPPORT
             const int ray_threadidx =
@@ -640,17 +695,29 @@ void Sasktran2<NSTOKES>::calculate_vjp(
 #else
             const int ray_threadidx = wavelength_threadidx;
 #endif
-            auto& native_gradient = native_gradients[ray_threadidx];
-            native_gradient.setZero();
-            Eigen::Vector<double, NSTOKES> radiance;
-            m_source_integrator->integrate_vjp(
-                radiance, m_los_source_terms, wavelength, ray,
-                wavelength_threadidx, ray_threadidx,
-                output.native_cotangent(ray, wavelength), native_gradient);
-            output.assign_native_value(ray, wavelength, radiance);
-            output.accumulate_native_gradient(wavelength, ray_threadidx,
-                                              native_gradient);
+            auto& radiance = radiance_storage[ray_threadidx];
+            auto& cotangent = cotangent_storage[ray_threadidx];
+            for (int lane = 0; lane < block.count; ++lane) {
+                cotangent.col(lane) =
+                    output.native_cotangent(ray, block.wavelength(lane));
+            }
+            m_source_integrator->integrate_vjp_block(
+                radiance, m_los_source_terms, block, ray, wavelength_threadidx,
+                ray_threadidx, cotangent, native_gradients[ray_threadidx]);
+            for (int lane = 0; lane < block.count; ++lane) {
+                output.assign_native_value(ray, block.wavelength(lane),
+                                           radiance.col(lane));
+            }
         }
+        auto& reduced_gradient = native_gradients[wavelength_threadidx];
+        if (num_source_threads > 1) {
+            for (int thread = 1; thread < num_source_threads; ++thread) {
+                reduced_gradient.leftCols(block.count) +=
+                    native_gradients[thread].leftCols(block.count);
+            }
+        }
+        output.accumulate_native_gradient(block, wavelength_threadidx,
+                                          reduced_gradient);
     }
 }
 

--- a/cpp/lib/output/outputlinearization.cpp
+++ b/cpp/lib/output/outputlinearization.cpp
@@ -117,6 +117,106 @@ namespace sasktran2 {
     }
 
     template <int NSTOKES>
+    void OutputJVP<NSTOKES>::native_tangent(int wavelidx,
+                                            Eigen::VectorXd& tangent) const {
+        tangent.setZero(this->m_atmosphere->num_deriv());
+        const int num_geometry = this->m_ngeometry;
+        for (const auto& [name, parameter_tangent] : m_derivative_tangents) {
+            const auto& mapping =
+                this->m_atmosphere->storage().derivative_mappings_const().at(
+                    name);
+            Eigen::VectorXd native_parameter;
+            if (mapping.get_interpolator_const().has_value()) {
+                native_parameter = mapping.get_interpolator_const().value() *
+                                   parameter_tangent;
+            } else {
+                native_parameter = parameter_tangent;
+            }
+            const auto& native_mapping = mapping.native_mapping();
+            if (native_mapping.d_extinction.has_value()) {
+                tangent.head(num_geometry).array() +=
+                    native_mapping.d_extinction.value().col(wavelidx).array() *
+                    native_parameter.array();
+            }
+            if (native_mapping.d_ssa.has_value()) {
+                tangent
+                    .segment(this->m_atmosphere->ssa_deriv_start_index(),
+                             num_geometry)
+                    .array() +=
+                    native_mapping.d_ssa.value().col(wavelidx).array() *
+                    native_parameter.array();
+            }
+            if (mapping.is_scattering_derivative()) {
+                const int start = this->m_atmosphere->scat_deriv_start_index() +
+                                  mapping.get_scattering_index() * num_geometry;
+                tangent.segment(start, num_geometry).array() +=
+                    native_mapping.scat_factor.value().col(wavelidx).array() *
+                    native_parameter.array();
+            }
+            if (native_mapping.d_emission.has_value() &&
+                this->m_atmosphere->include_emission_derivatives()) {
+                tangent
+                    .segment(this->m_atmosphere->emission_deriv_start_index(),
+                             num_geometry)
+                    .array() +=
+                    native_mapping.d_emission.value().col(wavelidx).array() *
+                    native_parameter.array();
+            }
+        }
+
+        for (const auto& [name, parameter_tangent] : m_surface_tangents) {
+            const auto& mapping =
+                this->m_atmosphere->surface().derivative_mappings().at(name);
+            double parameter_direction;
+            if (mapping.get_interpolator_const().has_value()) {
+                parameter_direction =
+                    mapping.get_interpolator_const().value().row(wavelidx).dot(
+                        parameter_tangent);
+            } else {
+                parameter_direction = parameter_tangent(wavelidx);
+            }
+            const auto& native_mapping = mapping.native_surface_mapping();
+            if (native_mapping.d_brdf.has_value()) {
+                tangent
+                    .segment(this->m_atmosphere->surface_deriv_start_index(),
+                             this->m_atmosphere->surface().num_deriv())
+                    .array() +=
+                    parameter_direction * native_mapping.d_brdf.value()
+                                              .row(wavelidx)
+                                              .transpose()
+                                              .array();
+            }
+            if (native_mapping.d_emission.has_value() &&
+                this->m_atmosphere->include_emission_derivatives()) {
+                tangent(
+                    this->m_atmosphere->surface_emission_deriv_start_index()) +=
+                    parameter_direction *
+                    native_mapping.d_emission.value()(wavelidx, 0);
+            }
+        }
+    }
+
+    template <int NSTOKES>
+    void OutputJVP<NSTOKES>::assign_native(
+        int losidx, int wavelidx, const Eigen::Vector<double, NSTOKES>& value,
+        const Eigen::Vector<double, NSTOKES>& jvp) {
+        const int linear_index =
+            NSTOKES * this->m_nlos * wavelidx + NSTOKES * losidx;
+        double c = 1.0;
+        double s = 0.0;
+        if constexpr (NSTOKES >= 3) {
+            c = this->m_stokes_C[losidx];
+            s = this->m_stokes_S[losidx];
+        }
+        const auto rotated_value = rotate_stokes<NSTOKES>(value, c, s);
+        const auto rotated_jvp = rotate_stokes<NSTOKES>(jvp, c, s);
+        for (int stokes = 0; stokes < NSTOKES; ++stokes) {
+            m_radiance(linear_index + stokes) = rotated_value(stokes);
+            m_jvp(linear_index + stokes) = rotated_jvp(stokes);
+        }
+    }
+
+    template <int NSTOKES>
     template <typename Radiance>
     void OutputJVP<NSTOKES>::assign_lane(const Radiance& radiance, int losidx,
                                          int wavelidx, int threadidx) {
@@ -257,6 +357,125 @@ namespace sasktran2 {
             for (const auto& [name, gradient] : m_surface_gradients) {
                 m_thread_surface_gradients[thread][name] =
                     Eigen::VectorXd::Zero(gradient.size());
+            }
+        }
+    }
+
+    template <int NSTOKES>
+    Eigen::Vector<double, NSTOKES>
+    OutputVJP<NSTOKES>::native_cotangent(int losidx, int wavelidx) const {
+        const int linear_index =
+            NSTOKES * this->m_nlos * wavelidx + NSTOKES * losidx;
+        Eigen::Vector<double, NSTOKES> cotangent;
+        for (int stokes = 0; stokes < NSTOKES; ++stokes) {
+            cotangent(stokes) = m_cotangent(linear_index + stokes);
+        }
+        double c = 1.0;
+        double s = 0.0;
+        if constexpr (NSTOKES >= 3) {
+            c = this->m_stokes_C[losidx];
+            s = this->m_stokes_S[losidx];
+        }
+        return transpose_rotate_stokes<NSTOKES>(cotangent, c, s);
+    }
+
+    template <int NSTOKES>
+    void OutputVJP<NSTOKES>::assign_native_value(
+        int losidx, int wavelidx, const Eigen::Vector<double, NSTOKES>& value) {
+        const int linear_index =
+            NSTOKES * this->m_nlos * wavelidx + NSTOKES * losidx;
+        double c = 1.0;
+        double s = 0.0;
+        if constexpr (NSTOKES >= 3) {
+            c = this->m_stokes_C[losidx];
+            s = this->m_stokes_S[losidx];
+        }
+        const auto rotated = rotate_stokes<NSTOKES>(value, c, s);
+        for (int stokes = 0; stokes < NSTOKES; ++stokes) {
+            m_radiance(linear_index + stokes) = rotated(stokes);
+        }
+    }
+
+    template <int NSTOKES>
+    void OutputVJP<NSTOKES>::accumulate_native_gradient(
+        int wavelidx, int threadidx,
+        Eigen::Ref<const Eigen::VectorXd> native_gradient) {
+        const int num_geometry = this->m_ngeometry;
+        Eigen::VectorXd native_parameter(num_geometry);
+        for (const auto& [name, gradient] : m_derivative_gradients) {
+            const auto& mapping =
+                this->m_atmosphere->storage().derivative_mappings_const().at(
+                    name);
+            const auto& native_mapping = mapping.native_mapping();
+            native_parameter.setZero();
+            if (native_mapping.d_extinction.has_value()) {
+                native_parameter.array() +=
+                    native_mapping.d_extinction.value().col(wavelidx).array() *
+                    native_gradient.head(num_geometry).array();
+            }
+            if (native_mapping.d_ssa.has_value()) {
+                native_parameter.array() +=
+                    native_mapping.d_ssa.value().col(wavelidx).array() *
+                    native_gradient
+                        .segment(this->m_atmosphere->ssa_deriv_start_index(),
+                                 num_geometry)
+                        .array();
+            }
+            if (mapping.is_scattering_derivative()) {
+                const int start = this->m_atmosphere->scat_deriv_start_index() +
+                                  mapping.get_scattering_index() * num_geometry;
+                native_parameter.array() +=
+                    native_mapping.scat_factor.value().col(wavelidx).array() *
+                    native_gradient.segment(start, num_geometry).array();
+            }
+            if (native_mapping.d_emission.has_value() &&
+                this->m_atmosphere->include_emission_derivatives()) {
+                native_parameter.array() +=
+                    native_mapping.d_emission.value().col(wavelidx).array() *
+                    native_gradient
+                        .segment(
+                            this->m_atmosphere->emission_deriv_start_index(),
+                            num_geometry)
+                        .array();
+            }
+            auto& target = m_thread_derivative_gradients[threadidx].at(name);
+            if (mapping.get_interpolator_const().has_value()) {
+                target.noalias() +=
+                    mapping.get_interpolator_const().value().transpose() *
+                    native_parameter;
+            } else {
+                target += native_parameter;
+            }
+        }
+
+        for (const auto& [name, gradient] : m_surface_gradients) {
+            const auto& mapping =
+                this->m_atmosphere->surface().derivative_mappings().at(name);
+            const auto& native_mapping = mapping.native_surface_mapping();
+            double native_parameter_gradient = 0.0;
+            if (native_mapping.d_brdf.has_value()) {
+                native_parameter_gradient +=
+                    native_mapping.d_brdf.value().row(wavelidx).dot(
+                        native_gradient.segment(
+                            this->m_atmosphere->surface_deriv_start_index(),
+                            this->m_atmosphere->surface().num_deriv()));
+            }
+            if (native_mapping.d_emission.has_value() &&
+                this->m_atmosphere->include_emission_derivatives()) {
+                native_parameter_gradient +=
+                    native_mapping.d_emission.value()(wavelidx, 0) *
+                    native_gradient(this->m_atmosphere
+                                        ->surface_emission_deriv_start_index());
+            }
+            auto& target = m_thread_surface_gradients[threadidx].at(name);
+            if (mapping.get_interpolator_const().has_value()) {
+                target.noalias() += mapping.get_interpolator_const()
+                                        .value()
+                                        .row(wavelidx)
+                                        .transpose() *
+                                    native_parameter_gradient;
+            } else {
+                target(wavelidx) += native_parameter_gradient;
             }
         }
     }

--- a/cpp/lib/output/outputlinearization.cpp
+++ b/cpp/lib/output/outputlinearization.cpp
@@ -100,10 +100,126 @@ namespace sasktran2 {
             }
             return result;
         }
+
+        template <int NSTOKES, typename ParameterMap>
+        void validate_volume_parameter_sizes(
+            const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere,
+            const ParameterMap& parameters, const std::string& quantity) {
+            const auto& mappings =
+                atmosphere.storage().derivative_mappings_const();
+            const int num_geometry =
+                atmosphere.storage().total_extinction.rows();
+            for (const auto& [name, parameter] : parameters) {
+                const auto mapping = mappings.find(name);
+                if (mapping == mappings.end()) {
+                    throw std::invalid_argument(
+                        "Unknown volume derivative mapping '" + name + "'");
+                }
+
+                int expected_size = num_geometry;
+                if (mapping->second.get_interpolator_const().has_value()) {
+                    const auto& interpolator =
+                        mapping->second.get_interpolator_const().value();
+                    if (interpolator.rows() != num_geometry) {
+                        throw std::invalid_argument(
+                            "Volume derivative mapping '" + name +
+                            "' has an interpolator with " +
+                            std::to_string(interpolator.rows()) +
+                            " rows; expected " + std::to_string(num_geometry));
+                    }
+                    expected_size = interpolator.cols();
+                }
+                if (parameter.size() != expected_size) {
+                    throw std::invalid_argument(
+                        "Volume " + quantity + " for mapping '" + name +
+                        "' has size " + std::to_string(parameter.size()) +
+                        "; expected " + std::to_string(expected_size));
+                }
+            }
+        }
+
+        template <int NSTOKES, typename ParameterMap>
+        void validate_surface_parameter_sizes(
+            const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere,
+            const ParameterMap& parameters, const std::string& quantity) {
+            const auto& mappings = atmosphere.surface().derivative_mappings();
+            const int num_wavelengths = atmosphere.num_wavel();
+            for (const auto& [name, parameter] : parameters) {
+                const auto mapping = mappings.find(name);
+                if (mapping == mappings.end()) {
+                    throw std::invalid_argument(
+                        "Unknown surface derivative mapping '" + name + "'");
+                }
+
+                int expected_size = num_wavelengths;
+                if (mapping->second.get_interpolator_const().has_value()) {
+                    const auto& interpolator =
+                        mapping->second.get_interpolator_const().value();
+                    if (interpolator.rows() != num_wavelengths) {
+                        throw std::invalid_argument(
+                            "Surface derivative mapping '" + name +
+                            "' has an interpolator with " +
+                            std::to_string(interpolator.rows()) +
+                            " rows; expected " +
+                            std::to_string(num_wavelengths));
+                    }
+                    expected_size = interpolator.cols();
+                }
+                if (parameter.size() != expected_size) {
+                    throw std::invalid_argument(
+                        "Surface " + quantity + " for mapping '" + name +
+                        "' has size " + std::to_string(parameter.size()) +
+                        "; expected " + std::to_string(expected_size));
+                }
+            }
+        }
+
+        template <typename Vector>
+        void validate_product_output_buffer(const Vector& buffer,
+                                            Eigen::Index expected_size,
+                                            const std::string& quantity) {
+            if (buffer.size() != expected_size ||
+                (expected_size > 0 && buffer.data() == nullptr)) {
+                throw std::invalid_argument(quantity + " buffer has size " +
+                                            std::to_string(buffer.size()) +
+                                            "; expected " +
+                                            std::to_string(expected_size));
+            }
+        }
     } // namespace
 
     template <int NSTOKES> void OutputJVP<NSTOKES>::resize() {
+        const Eigen::Index expected_size =
+            static_cast<Eigen::Index>(NSTOKES) *
+            static_cast<Eigen::Index>(this->m_nlos) *
+            static_cast<Eigen::Index>(this->m_nwavel);
+        validate_product_output_buffer(m_radiance, expected_size,
+                                       "JVP radiance");
+        validate_product_output_buffer(m_jvp, expected_size, "JVP product");
+        if (this->m_atmosphere->num_deriv() == 0) {
+            throw std::invalid_argument(
+                "JVP calculation requires an atmosphere constructed with "
+                "calculate_derivatives=true");
+        }
+        validate_volume_parameter_sizes(*this->m_atmosphere,
+                                        m_derivative_tangents, "JVP tangent");
+        validate_surface_parameter_sizes(*this->m_atmosphere,
+                                         m_surface_tangents, "JVP tangent");
+
         m_jvp.setZero();
+        m_native_parameter_tangents.clear();
+        for (const auto& [name, parameter_tangent] : m_derivative_tangents) {
+            const auto& mapping =
+                this->m_atmosphere->storage().derivative_mappings_const().at(
+                    name);
+            if (mapping.get_interpolator_const().has_value()) {
+                m_native_parameter_tangents[name] =
+                    mapping.get_interpolator_const().value() *
+                    parameter_tangent;
+            } else {
+                m_native_parameter_tangents[name] = parameter_tangent;
+            }
+        }
         m_native_thread_storage.resize(this->m_config->num_threads());
         m_mapped_thread_storage.resize(this->m_config->num_threads());
         int max_output = 1;
@@ -117,21 +233,20 @@ namespace sasktran2 {
     }
 
     template <int NSTOKES>
-    void OutputJVP<NSTOKES>::native_tangent(int wavelidx,
-                                            Eigen::VectorXd& tangent) const {
-        tangent.setZero(this->m_atmosphere->num_deriv());
+    void OutputJVP<NSTOKES>::native_tangent(
+        int wavelidx, Eigen::Ref<Eigen::VectorXd> tangent) const {
+        if (tangent.size() != this->m_atmosphere->num_deriv()) {
+            throw std::invalid_argument(
+                "Native JVP tangent has incorrect size");
+        }
+        tangent.setZero();
         const int num_geometry = this->m_ngeometry;
-        for (const auto& [name, parameter_tangent] : m_derivative_tangents) {
+        for (const auto& [name, unused] : m_derivative_tangents) {
+            (void)unused;
             const auto& mapping =
                 this->m_atmosphere->storage().derivative_mappings_const().at(
                     name);
-            Eigen::VectorXd native_parameter;
-            if (mapping.get_interpolator_const().has_value()) {
-                native_parameter = mapping.get_interpolator_const().value() *
-                                   parameter_tangent;
-            } else {
-                native_parameter = parameter_tangent;
-            }
+            const auto& native_parameter = m_native_parameter_tangents.at(name);
             const auto& native_mapping = mapping.native_mapping();
             if (native_mapping.d_extinction.has_value()) {
                 tangent.head(num_geometry).array() +=
@@ -338,10 +453,30 @@ namespace sasktran2 {
     }
 
     template <int NSTOKES> void OutputVJP<NSTOKES>::resize() {
+        const Eigen::Index expected_size =
+            static_cast<Eigen::Index>(NSTOKES) *
+            static_cast<Eigen::Index>(this->m_nlos) *
+            static_cast<Eigen::Index>(this->m_nwavel);
+        validate_product_output_buffer(m_radiance, expected_size,
+                                       "VJP radiance");
+        validate_product_output_buffer(m_cotangent, expected_size,
+                                       "VJP cotangent");
+        if (this->m_atmosphere->num_deriv() == 0) {
+            throw std::invalid_argument(
+                "VJP calculation requires an atmosphere constructed with "
+                "calculate_derivatives=true");
+        }
+        validate_volume_parameter_sizes(*this->m_atmosphere,
+                                        m_derivative_gradients, "VJP gradient");
+        validate_surface_parameter_sizes(*this->m_atmosphere,
+                                         m_surface_gradients, "VJP gradient");
+
         const int num_threads = this->m_config->num_threads();
         m_native_thread_storage.resize(num_threads);
         m_thread_derivative_gradients.resize(num_threads);
         m_thread_surface_gradients.resize(num_threads);
+        m_native_parameter_thread_storage.resize(num_threads);
+        m_surface_parameter_thread_storage.resize(num_threads);
         for (auto& [name, gradient] : m_derivative_gradients) {
             gradient.setZero();
         }
@@ -350,6 +485,10 @@ namespace sasktran2 {
         }
         for (int thread = 0; thread < num_threads; ++thread) {
             m_native_thread_storage[thread].resize(NSTOKES, this->m_ngeometry);
+            m_native_parameter_thread_storage[thread].resize(
+                this->m_ngeometry, this->m_wavelength_block_capacity);
+            m_surface_parameter_thread_storage[thread].resize(
+                this->m_wavelength_block_capacity);
             for (const auto& [name, gradient] : m_derivative_gradients) {
                 m_thread_derivative_gradients[thread][name] =
                     Eigen::VectorXd::Zero(gradient.size());
@@ -400,8 +539,28 @@ namespace sasktran2 {
     void OutputVJP<NSTOKES>::accumulate_native_gradient(
         int wavelidx, int threadidx,
         Eigen::Ref<const Eigen::VectorXd> native_gradient) {
+        Eigen::MatrixXd gradient_block(native_gradient.size(), 1);
+        gradient_block.col(0) = native_gradient;
+        accumulate_native_gradient(sasktran2::WavelengthBlock<>{wavelidx, 1},
+                                   threadidx, gradient_block);
+    }
+
+    template <int NSTOKES>
+    void OutputVJP<NSTOKES>::accumulate_native_gradient(
+        const sasktran2::WavelengthBlock<>& block, int threadidx,
+        const Eigen::MatrixXd& native_gradient) {
+        if (threadidx < 0 ||
+            threadidx >= m_native_parameter_thread_storage.size() ||
+            block.count < 1 ||
+            block.count > this->m_wavelength_block_capacity ||
+            native_gradient.rows() != this->m_atmosphere->num_deriv() ||
+            native_gradient.cols() < block.count) {
+            throw std::invalid_argument(
+                "Invalid native VJP gradient wavelength block");
+        }
         const int num_geometry = this->m_ngeometry;
-        Eigen::VectorXd native_parameter(num_geometry);
+        auto native_parameter =
+            m_native_parameter_thread_storage[threadidx].leftCols(block.count);
         for (const auto& [name, gradient] : m_derivative_gradients) {
             const auto& mapping =
                 this->m_atmosphere->storage().derivative_mappings_const().at(
@@ -410,41 +569,50 @@ namespace sasktran2 {
             native_parameter.setZero();
             if (native_mapping.d_extinction.has_value()) {
                 native_parameter.array() +=
-                    native_mapping.d_extinction.value().col(wavelidx).array() *
-                    native_gradient.head(num_geometry).array();
+                    native_mapping.d_extinction.value()
+                        .middleCols(block.start, block.count)
+                        .array() *
+                    native_gradient.block(0, 0, num_geometry, block.count)
+                        .array();
             }
             if (native_mapping.d_ssa.has_value()) {
                 native_parameter.array() +=
-                    native_mapping.d_ssa.value().col(wavelidx).array() *
+                    native_mapping.d_ssa.value()
+                        .middleCols(block.start, block.count)
+                        .array() *
                     native_gradient
-                        .segment(this->m_atmosphere->ssa_deriv_start_index(),
-                                 num_geometry)
+                        .block(this->m_atmosphere->ssa_deriv_start_index(), 0,
+                               num_geometry, block.count)
                         .array();
             }
             if (mapping.is_scattering_derivative()) {
                 const int start = this->m_atmosphere->scat_deriv_start_index() +
                                   mapping.get_scattering_index() * num_geometry;
                 native_parameter.array() +=
-                    native_mapping.scat_factor.value().col(wavelidx).array() *
-                    native_gradient.segment(start, num_geometry).array();
+                    native_mapping.scat_factor.value()
+                        .middleCols(block.start, block.count)
+                        .array() *
+                    native_gradient.block(start, 0, num_geometry, block.count)
+                        .array();
             }
             if (native_mapping.d_emission.has_value() &&
                 this->m_atmosphere->include_emission_derivatives()) {
                 native_parameter.array() +=
-                    native_mapping.d_emission.value().col(wavelidx).array() *
+                    native_mapping.d_emission.value()
+                        .middleCols(block.start, block.count)
+                        .array() *
                     native_gradient
-                        .segment(
-                            this->m_atmosphere->emission_deriv_start_index(),
-                            num_geometry)
+                        .block(this->m_atmosphere->emission_deriv_start_index(),
+                               0, num_geometry, block.count)
                         .array();
             }
             auto& target = m_thread_derivative_gradients[threadidx].at(name);
             if (mapping.get_interpolator_const().has_value()) {
                 target.noalias() +=
                     mapping.get_interpolator_const().value().transpose() *
-                    native_parameter;
+                    native_parameter.rowwise().sum();
             } else {
-                target += native_parameter;
+                target += native_parameter.rowwise().sum();
             }
         }
 
@@ -452,30 +620,43 @@ namespace sasktran2 {
             const auto& mapping =
                 this->m_atmosphere->surface().derivative_mappings().at(name);
             const auto& native_mapping = mapping.native_surface_mapping();
-            double native_parameter_gradient = 0.0;
+            auto native_parameter_gradient =
+                m_surface_parameter_thread_storage[threadidx].head(block.count);
+            native_parameter_gradient.setZero();
             if (native_mapping.d_brdf.has_value()) {
-                native_parameter_gradient +=
-                    native_mapping.d_brdf.value().row(wavelidx).dot(
-                        native_gradient.segment(
-                            this->m_atmosphere->surface_deriv_start_index(),
-                            this->m_atmosphere->surface().num_deriv()));
+                const int num_surface_derivatives =
+                    this->m_atmosphere->surface().num_deriv();
+                for (int lane = 0; lane < block.count; ++lane) {
+                    native_parameter_gradient(lane) +=
+                        native_mapping.d_brdf.value()
+                            .row(block.wavelength(lane))
+                            .dot(native_gradient.col(lane).segment(
+                                this->m_atmosphere->surface_deriv_start_index(),
+                                num_surface_derivatives));
+                }
             }
             if (native_mapping.d_emission.has_value() &&
                 this->m_atmosphere->include_emission_derivatives()) {
-                native_parameter_gradient +=
-                    native_mapping.d_emission.value()(wavelidx, 0) *
-                    native_gradient(this->m_atmosphere
-                                        ->surface_emission_deriv_start_index());
+                for (int lane = 0; lane < block.count; ++lane) {
+                    native_parameter_gradient(lane) +=
+                        native_mapping.d_emission.value()(
+                            block.wavelength(lane), 0) *
+                        native_gradient(
+                            this->m_atmosphere
+                                ->surface_emission_deriv_start_index(),
+                            lane);
+                }
             }
             auto& target = m_thread_surface_gradients[threadidx].at(name);
             if (mapping.get_interpolator_const().has_value()) {
                 target.noalias() += mapping.get_interpolator_const()
                                         .value()
-                                        .row(wavelidx)
+                                        .middleRows(block.start, block.count)
                                         .transpose() *
                                     native_parameter_gradient;
             } else {
-                target(wavelidx) += native_parameter_gradient;
+                target.segment(block.start, block.count) +=
+                    native_parameter_gradient.transpose();
             }
         }
     }

--- a/cpp/lib/phasefunction/phasehandler.cpp
+++ b/cpp/lib/phasefunction/phasehandler.cpp
@@ -644,6 +644,131 @@ namespace sasktran2::solartransmission {
     }
 
     template <int NSTOKES>
+    Eigen::Vector<double, NSTOKES> PhaseHandler<NSTOKES>::scatter_value(
+        int threadidx, int losidx, int layeridx,
+        const raytracing::GridWeightStencilView& index_weights,
+        bool is_entrance) const {
+        Eigen::Vector<double, NSTOKES> phase =
+            Eigen::Vector<double, NSTOKES>::Zero();
+        const auto& internal_indices =
+            is_entrance ? m_geometry_entrance_to_internal[losidx][layeridx]
+                        : m_geometry_exit_to_internal[losidx][layeridx];
+
+        const auto accumulate_phase = [&](int internal_index, double weight) {
+            phase(0) += m_phase(0, internal_index, threadidx) * weight;
+            if constexpr (NSTOKES == 3) {
+                const auto& scatter_angle =
+                    m_scatter_angles[m_internal_to_cos_scatter[internal_index]];
+                const double polarized =
+                    m_phase(1, internal_index, threadidx) * weight;
+                phase(1) -= scatter_angle[1] * polarized;
+                phase(2) -= scatter_angle[2] * polarized;
+            }
+        };
+
+        if (index_weights.size() == 2 && (index_weights[0].second == 0.0 ||
+                                          index_weights[1].second == 0.0)) {
+            accumulate_phase(internal_indices[0], 1.0);
+        } else {
+            int internal_offset = 0;
+            for (std::size_t index = 0; index < index_weights.size(); ++index) {
+                const auto weight = index_weights[index];
+                if (weight.second == 0.0) {
+                    continue;
+                }
+                accumulate_phase(internal_indices[internal_offset++],
+                                 weight.second);
+            }
+        }
+
+        return phase;
+    }
+
+    template <int NSTOKES>
+    void PhaseHandler<NSTOKES>::scatter_jvp(
+        int threadidx, int losidx, int layeridx,
+        const raytracing::GridWeightStencilView& index_weights,
+        bool is_entrance, Eigen::Ref<const Eigen::VectorXd> native_tangent,
+        Eigen::Vector<double, NSTOKES>& phase,
+        Eigen::Vector<double, NSTOKES>& phase_jvp) const {
+        phase = scatter_value(threadidx, losidx, layeridx, index_weights,
+                              is_entrance);
+        phase_jvp.setZero();
+        const auto& internal_indices =
+            is_entrance ? m_geometry_entrance_to_internal[losidx][layeridx]
+                        : m_geometry_exit_to_internal[losidx][layeridx];
+
+        for (int derivative = 0;
+             derivative < m_atmosphere->num_scattering_deriv_groups();
+             ++derivative) {
+            int internal_offset = 0;
+            const int derivative_start =
+                m_atmosphere->scat_deriv_start_index() +
+                derivative * m_geometry.size();
+            for (std::size_t index = 0; index < index_weights.size(); ++index) {
+                const auto weight = index_weights[index];
+                if (weight.second == 0.0) {
+                    continue;
+                }
+                const int internal_index = internal_indices[internal_offset++];
+                const double direction =
+                    native_tangent(derivative_start + weight.first) *
+                    weight.second;
+                phase_jvp(0) += direction * m_d_phase(0, internal_index,
+                                                      derivative, threadidx);
+                if constexpr (NSTOKES == 3) {
+                    const auto& scatter_angle = m_scatter_angles
+                        [m_internal_to_cos_scatter[internal_index]];
+                    const double polarized =
+                        direction *
+                        m_d_phase(1, internal_index, derivative, threadidx);
+                    phase_jvp(1) -= scatter_angle[1] * polarized;
+                    phase_jvp(2) -= scatter_angle[2] * polarized;
+                }
+            }
+        }
+    }
+
+    template <int NSTOKES>
+    void PhaseHandler<NSTOKES>::scatter_vjp(
+        int threadidx, int losidx, int layeridx,
+        const raytracing::GridWeightStencilView& index_weights,
+        bool is_entrance, const Eigen::Vector<double, NSTOKES>& phase_cotangent,
+        Eigen::Ref<Eigen::VectorXd> native_gradient) const {
+        const auto& internal_indices =
+            is_entrance ? m_geometry_entrance_to_internal[losidx][layeridx]
+                        : m_geometry_exit_to_internal[losidx][layeridx];
+        for (int derivative = 0;
+             derivative < m_atmosphere->num_scattering_deriv_groups();
+             ++derivative) {
+            int internal_offset = 0;
+            const int derivative_start =
+                m_atmosphere->scat_deriv_start_index() +
+                derivative * m_geometry.size();
+            for (std::size_t index = 0; index < index_weights.size(); ++index) {
+                const auto weight = index_weights[index];
+                if (weight.second == 0.0) {
+                    continue;
+                }
+                const int internal_index = internal_indices[internal_offset++];
+                double derivative_value =
+                    phase_cotangent(0) *
+                    m_d_phase(0, internal_index, derivative, threadidx);
+                if constexpr (NSTOKES == 3) {
+                    const auto& scatter_angle = m_scatter_angles
+                        [m_internal_to_cos_scatter[internal_index]];
+                    derivative_value +=
+                        (-scatter_angle[1] * phase_cotangent(1) -
+                         scatter_angle[2] * phase_cotangent(2)) *
+                        m_d_phase(1, internal_index, derivative, threadidx);
+                }
+                native_gradient(derivative_start + weight.first) +=
+                    weight.second * derivative_value;
+            }
+        }
+    }
+
+    template <int NSTOKES>
     template <int N>
     void PhaseHandler<NSTOKES>::scatter_and_accumulate_derivative_block(
         int threadidx, int losidx, int layeridx,

--- a/cpp/lib/phasefunction/phasehandler.cpp
+++ b/cpp/lib/phasefunction/phasehandler.cpp
@@ -317,6 +317,10 @@ namespace sasktran2::solartransmission {
 
         m_phase_batch.resize(m_config->num_wavelength_threads());
         m_d_phase_batch.resize(m_config->num_wavelength_threads());
+        m_active_wavelength_block_start.assign(
+            m_config->num_wavelength_threads(), 0);
+        m_active_wavelength_block_count.assign(
+            m_config->num_wavelength_threads(), 0);
         for (int threadidx = 0; threadidx < m_config->num_wavelength_threads();
              ++threadidx) {
             m_phase_batch[threadidx].resize(num_phase_components * num_internal,
@@ -339,6 +343,8 @@ namespace sasktran2::solartransmission {
             throw std::invalid_argument(
                 "Wavelength batch exceeds phase storage capacity");
         }
+        m_active_wavelength_block_start[threadidx] = batch.start;
+        m_active_wavelength_block_count[threadidx] = batch.count;
 
         auto& phase = m_phase_batch[threadidx];
         auto& d_phase = m_d_phase_batch[threadidx];
@@ -645,7 +651,7 @@ namespace sasktran2::solartransmission {
 
     template <int NSTOKES>
     Eigen::Vector<double, NSTOKES> PhaseHandler<NSTOKES>::scatter_value(
-        int threadidx, int losidx, int layeridx,
+        int threadidx, int losidx, int layeridx, int wavelidx,
         const raytracing::GridWeightStencilView& index_weights,
         bool is_entrance) const {
         Eigen::Vector<double, NSTOKES> phase =
@@ -654,13 +660,32 @@ namespace sasktran2::solartransmission {
             is_entrance ? m_geometry_entrance_to_internal[losidx][layeridx]
                         : m_geometry_exit_to_internal[losidx][layeridx];
 
+        const int batch_lane =
+            m_wavelength_batch_capacity > 1
+                ? wavelidx - m_active_wavelength_block_start.at(threadidx)
+                : 0;
+        if (m_wavelength_batch_capacity > 1 &&
+            (batch_lane < 0 ||
+             batch_lane >= m_active_wavelength_block_count.at(threadidx))) {
+            throw std::out_of_range(
+                "Phase wavelength is outside the active block");
+        }
+        const int num_internal =
+            static_cast<int>(m_internal_to_geometry.size());
+        const auto phase_value = [&](int component, int internal_index) {
+            if (m_wavelength_batch_capacity > 1) {
+                return m_phase_batch[threadidx](
+                    component * num_internal + internal_index, batch_lane);
+            }
+            return m_phase(component, internal_index, threadidx);
+        };
         const auto accumulate_phase = [&](int internal_index, double weight) {
-            phase(0) += m_phase(0, internal_index, threadidx) * weight;
+            phase(0) += phase_value(0, internal_index) * weight;
             if constexpr (NSTOKES == 3) {
                 const auto& scatter_angle =
                     m_scatter_angles[m_internal_to_cos_scatter[internal_index]];
                 const double polarized =
-                    m_phase(1, internal_index, threadidx) * weight;
+                    phase_value(1, internal_index) * weight;
                 phase(1) -= scatter_angle[1] * polarized;
                 phase(2) -= scatter_angle[2] * polarized;
             }
@@ -686,17 +711,42 @@ namespace sasktran2::solartransmission {
 
     template <int NSTOKES>
     void PhaseHandler<NSTOKES>::scatter_jvp(
-        int threadidx, int losidx, int layeridx,
+        int threadidx, int losidx, int layeridx, int wavelidx,
         const raytracing::GridWeightStencilView& index_weights,
         bool is_entrance, Eigen::Ref<const Eigen::VectorXd> native_tangent,
         Eigen::Vector<double, NSTOKES>& phase,
         Eigen::Vector<double, NSTOKES>& phase_jvp) const {
-        phase = scatter_value(threadidx, losidx, layeridx, index_weights,
-                              is_entrance);
+        phase = scatter_value(threadidx, losidx, layeridx, wavelidx,
+                              index_weights, is_entrance);
         phase_jvp.setZero();
         const auto& internal_indices =
             is_entrance ? m_geometry_entrance_to_internal[losidx][layeridx]
                         : m_geometry_exit_to_internal[losidx][layeridx];
+
+        const int batch_lane =
+            m_wavelength_batch_capacity > 1
+                ? wavelidx - m_active_wavelength_block_start.at(threadidx)
+                : 0;
+        if (m_wavelength_batch_capacity > 1 &&
+            (batch_lane < 0 ||
+             batch_lane >= m_active_wavelength_block_count.at(threadidx))) {
+            throw std::out_of_range(
+                "Phase wavelength is outside the active block");
+        }
+        const int num_internal =
+            static_cast<int>(m_internal_to_geometry.size());
+        const int num_phase_components = NSTOKES == 1 ? 1 : 2;
+        const auto derivative_value = [&](int derivative, int component,
+                                          int internal_index) {
+            if (m_wavelength_batch_capacity > 1) {
+                const int row =
+                    (derivative * num_phase_components + component) *
+                        num_internal +
+                    internal_index;
+                return m_d_phase_batch[threadidx](row, batch_lane);
+            }
+            return m_d_phase(component, internal_index, derivative, threadidx);
+        };
 
         for (int derivative = 0;
              derivative < m_atmosphere->num_scattering_deriv_groups();
@@ -714,14 +764,14 @@ namespace sasktran2::solartransmission {
                 const double direction =
                     native_tangent(derivative_start + weight.first) *
                     weight.second;
-                phase_jvp(0) += direction * m_d_phase(0, internal_index,
-                                                      derivative, threadidx);
+                phase_jvp(0) +=
+                    direction * derivative_value(derivative, 0, internal_index);
                 if constexpr (NSTOKES == 3) {
                     const auto& scatter_angle = m_scatter_angles
                         [m_internal_to_cos_scatter[internal_index]];
                     const double polarized =
                         direction *
-                        m_d_phase(1, internal_index, derivative, threadidx);
+                        derivative_value(derivative, 1, internal_index);
                     phase_jvp(1) -= scatter_angle[1] * polarized;
                     phase_jvp(2) -= scatter_angle[2] * polarized;
                 }
@@ -731,13 +781,37 @@ namespace sasktran2::solartransmission {
 
     template <int NSTOKES>
     void PhaseHandler<NSTOKES>::scatter_vjp(
-        int threadidx, int losidx, int layeridx,
+        int threadidx, int losidx, int layeridx, int wavelidx,
         const raytracing::GridWeightStencilView& index_weights,
         bool is_entrance, const Eigen::Vector<double, NSTOKES>& phase_cotangent,
         Eigen::Ref<Eigen::VectorXd> native_gradient) const {
         const auto& internal_indices =
             is_entrance ? m_geometry_entrance_to_internal[losidx][layeridx]
                         : m_geometry_exit_to_internal[losidx][layeridx];
+        const int batch_lane =
+            m_wavelength_batch_capacity > 1
+                ? wavelidx - m_active_wavelength_block_start.at(threadidx)
+                : 0;
+        if (m_wavelength_batch_capacity > 1 &&
+            (batch_lane < 0 ||
+             batch_lane >= m_active_wavelength_block_count.at(threadidx))) {
+            throw std::out_of_range(
+                "Phase wavelength is outside the active block");
+        }
+        const int num_internal =
+            static_cast<int>(m_internal_to_geometry.size());
+        const int num_phase_components = NSTOKES == 1 ? 1 : 2;
+        const auto derivative_phase = [&](int derivative, int component,
+                                          int internal_index) {
+            if (m_wavelength_batch_capacity > 1) {
+                const int row =
+                    (derivative * num_phase_components + component) *
+                        num_internal +
+                    internal_index;
+                return m_d_phase_batch[threadidx](row, batch_lane);
+            }
+            return m_d_phase(component, internal_index, derivative, threadidx);
+        };
         for (int derivative = 0;
              derivative < m_atmosphere->num_scattering_deriv_groups();
              ++derivative) {
@@ -753,14 +827,14 @@ namespace sasktran2::solartransmission {
                 const int internal_index = internal_indices[internal_offset++];
                 double derivative_value =
                     phase_cotangent(0) *
-                    m_d_phase(0, internal_index, derivative, threadidx);
+                    derivative_phase(derivative, 0, internal_index);
                 if constexpr (NSTOKES == 3) {
                     const auto& scatter_angle = m_scatter_angles
                         [m_internal_to_cos_scatter[internal_index]];
                     derivative_value +=
                         (-scatter_angle[1] * phase_cotangent(1) -
                          scatter_angle[2] * phase_cotangent(2)) *
-                        m_d_phase(1, internal_index, derivative, threadidx);
+                        derivative_phase(derivative, 1, internal_index);
                 }
                 native_gradient(derivative_start + weight.first) +=
                     weight.second * derivative_value;

--- a/cpp/lib/solar/singlescattersource.cpp
+++ b/cpp/lib/solar/singlescattersource.cpp
@@ -171,6 +171,238 @@ namespace sasktran2::solartransmission {
     }
 
     template <typename S, int NSTOKES>
+    void SingleScatterSource<S, NSTOKES>::endpoint_source_jvp(
+        int wavelidx, int losidx, int layeridx, int wavel_threadidx,
+        int solar_index,
+        const sasktran2::raytracing::GridWeightStencilView& weights,
+        bool is_entrance, Eigen::Ref<const Eigen::VectorXd> native_tangent,
+        sasktran2::RadianceJVP<NSTOKES>& result) const {
+        if constexpr (!std::is_same_v<S, SolarTransmissionExact>) {
+            throw std::logic_error(
+                "Native JVP requires exact solar transmission");
+        } else {
+            const auto& storage = m_atmosphere->storage();
+            double extinction = 0.0;
+            double ssa = 0.0;
+            double extinction_jvp = 0.0;
+            double ssa_jvp = 0.0;
+            for (std::size_t index = 0; index < weights.size(); ++index) {
+                const auto weight = weights[index];
+                if (weight.second == 0.0) {
+                    continue;
+                }
+                extinction += storage.total_extinction(weight.first, wavelidx) *
+                              weight.second;
+                ssa += storage.ssa(weight.first, wavelidx) * weight.second;
+                extinction_jvp += native_tangent(weight.first) * weight.second;
+                ssa_jvp +=
+                    native_tangent(m_atmosphere->ssa_deriv_start_index() +
+                                   weight.first) *
+                    weight.second;
+            }
+
+            const double solar_trans =
+                m_solar_trans[wavel_threadidx](solar_index);
+            double solar_od_jvp = 0.0;
+            for (Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator
+                     derivative(m_geometry_sparse, solar_index);
+                 derivative; ++derivative) {
+                solar_od_jvp +=
+                    derivative.value() * native_tangent(derivative.index());
+            }
+            const double solar_trans_jvp = -solar_trans * solar_od_jvp;
+
+            Eigen::Vector<double, NSTOKES> phase;
+            Eigen::Vector<double, NSTOKES> phase_jvp;
+            m_phase_handler.scatter_jvp(wavel_threadidx, losidx, layeridx,
+                                        weights, is_entrance, native_tangent,
+                                        phase, phase_jvp);
+
+            const double scale = 1.0 / (EIGEN_PI * 4);
+            const double amplitude = extinction * ssa * solar_trans * scale;
+            const double amplitude_jvp =
+                scale * (extinction_jvp * ssa * solar_trans +
+                         extinction * ssa_jvp * solar_trans +
+                         extinction * ssa * solar_trans_jvp);
+            result.value = amplitude * phase;
+            result.jvp = amplitude_jvp * phase + amplitude * phase_jvp;
+        }
+    }
+
+    template <typename S, int NSTOKES>
+    Eigen::Vector<double, NSTOKES>
+    SingleScatterSource<S, NSTOKES>::endpoint_source_vjp(
+        int wavelidx, int losidx, int layeridx, int wavel_threadidx,
+        int solar_index,
+        const sasktran2::raytracing::GridWeightStencilView& weights,
+        bool is_entrance, const Eigen::Vector<double, NSTOKES>& cotangent,
+        Eigen::Ref<Eigen::VectorXd> native_gradient) const {
+        if constexpr (!std::is_same_v<S, SolarTransmissionExact>) {
+            throw std::logic_error(
+                "Native VJP requires exact solar transmission");
+        } else {
+            const auto& storage = m_atmosphere->storage();
+            double extinction = 0.0;
+            double ssa = 0.0;
+            for (std::size_t index = 0; index < weights.size(); ++index) {
+                const auto weight = weights[index];
+                if (weight.second == 0.0) {
+                    continue;
+                }
+                extinction += storage.total_extinction(weight.first, wavelidx) *
+                              weight.second;
+                ssa += storage.ssa(weight.first, wavelidx) * weight.second;
+            }
+
+            const double solar_trans =
+                m_solar_trans[wavel_threadidx](solar_index);
+            const Eigen::Vector<double, NSTOKES> phase =
+                m_phase_handler.scatter_value(wavel_threadidx, losidx, layeridx,
+                                              weights, is_entrance);
+
+            const double scale = 1.0 / (EIGEN_PI * 4);
+            const double amplitude = extinction * ssa * solar_trans * scale;
+            const double amplitude_cotangent = cotangent.dot(phase);
+            const double extinction_cotangent =
+                amplitude_cotangent * ssa * solar_trans * scale;
+            const double ssa_cotangent =
+                amplitude_cotangent * extinction * solar_trans * scale;
+            const double solar_trans_cotangent =
+                amplitude_cotangent * extinction * ssa * scale;
+
+            for (std::size_t index = 0; index < weights.size(); ++index) {
+                const auto weight = weights[index];
+                if (weight.second == 0.0) {
+                    continue;
+                }
+                native_gradient(weight.first) +=
+                    weight.second * extinction_cotangent;
+                native_gradient(m_atmosphere->ssa_deriv_start_index() +
+                                weight.first) += weight.second * ssa_cotangent;
+            }
+            for (Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator
+                     derivative(m_geometry_sparse, solar_index);
+                 derivative; ++derivative) {
+                native_gradient(derivative.index()) -=
+                    derivative.value() * solar_trans * solar_trans_cotangent;
+            }
+            m_phase_handler.scatter_vjp(wavel_threadidx, losidx, layeridx,
+                                        weights, is_entrance,
+                                        amplitude * cotangent, native_gradient);
+            return amplitude * phase;
+        }
+    }
+
+    template <typename S, int NSTOKES>
+    void SingleScatterSource<S, NSTOKES>::end_of_ray_source_jvp(
+        int wavelidx, int losidx, int wavel_threadidx, int threadidx,
+        Eigen::Ref<const Eigen::VectorXd> native_tangent,
+        sasktran2::RadianceJVP<NSTOKES>& source) const {
+        (void)threadidx;
+        if constexpr (!std::is_same_v<S, SolarTransmissionExact>) {
+            throw std::logic_error(
+                "Native JVP requires exact solar transmission");
+        } else {
+            if (!m_los_ground_is_hit.at(losidx)) {
+                return;
+            }
+            const auto& first_layer = m_los_end_layers.at(losidx);
+            const double mu_in = first_layer.exit.cos_zenith_angle(
+                m_geometry.coordinates().sun_unit());
+            if (mu_in <= 0.0) {
+                return;
+            }
+            const double mu_out = -first_layer.exit.cos_zenith_angle(
+                first_layer.average_look_away);
+            const double phi_diff = first_layer.saz_exit;
+            const int solar_index = m_index_map[losidx][0];
+            const double solar_trans =
+                m_solar_trans[wavel_threadidx](solar_index);
+            double solar_od_jvp = 0.0;
+            if (m_config->wf_precision() !=
+                sasktran2::Config::WeightingFunctionPrecision::limited) {
+                for (Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator
+                         derivative(m_geometry_sparse, solar_index);
+                     derivative; ++derivative) {
+                    solar_od_jvp +=
+                        derivative.value() * native_tangent(derivative.index());
+                }
+            }
+            const double solar_trans_jvp = -solar_trans * solar_od_jvp;
+            const auto brdf =
+                m_atmosphere->surface().brdf(wavelidx, mu_in, mu_out, phi_diff);
+            Eigen::Matrix<double, NSTOKES, NSTOKES> brdf_jvp =
+                Eigen::Matrix<double, NSTOKES, NSTOKES>::Zero();
+            for (int derivative = 0;
+                 derivative < m_atmosphere->surface().num_deriv();
+                 ++derivative) {
+                brdf_jvp +=
+                    native_tangent(m_atmosphere->surface_deriv_start_index() +
+                                   derivative) *
+                    m_atmosphere->surface().d_brdf(wavelidx, mu_in, mu_out,
+                                                   phi_diff, derivative);
+            }
+            source.value +=
+                solar_trans * mu_in * brdf(Eigen::placeholders::all, 0);
+            source.jvp +=
+                mu_in * (solar_trans_jvp * brdf(Eigen::placeholders::all, 0) +
+                         solar_trans * brdf_jvp(Eigen::placeholders::all, 0));
+        }
+    }
+
+    template <typename S, int NSTOKES>
+    void SingleScatterSource<S, NSTOKES>::end_of_ray_source_vjp(
+        int wavelidx, int losidx, int wavel_threadidx, int threadidx,
+        const Eigen::Vector<double, NSTOKES>& cotangent,
+        Eigen::Ref<Eigen::VectorXd> native_gradient) const {
+        (void)threadidx;
+        if constexpr (!std::is_same_v<S, SolarTransmissionExact>) {
+            throw std::logic_error(
+                "Native VJP requires exact solar transmission");
+        } else {
+            if (!m_los_ground_is_hit.at(losidx)) {
+                return;
+            }
+            const auto& first_layer = m_los_end_layers.at(losidx);
+            const double mu_in = first_layer.exit.cos_zenith_angle(
+                m_geometry.coordinates().sun_unit());
+            if (mu_in <= 0.0) {
+                return;
+            }
+            const double mu_out = -first_layer.exit.cos_zenith_angle(
+                first_layer.average_look_away);
+            const double phi_diff = first_layer.saz_exit;
+            const int solar_index = m_index_map[losidx][0];
+            const double solar_trans =
+                m_solar_trans[wavel_threadidx](solar_index);
+            const auto brdf =
+                m_atmosphere->surface().brdf(wavelidx, mu_in, mu_out, phi_diff);
+            const double solar_trans_cotangent =
+                mu_in * cotangent.dot(brdf(Eigen::placeholders::all, 0));
+            if (m_config->wf_precision() !=
+                sasktran2::Config::WeightingFunctionPrecision::limited) {
+                for (Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator
+                         derivative(m_geometry_sparse, solar_index);
+                     derivative; ++derivative) {
+                    native_gradient(derivative.index()) -=
+                        derivative.value() * solar_trans *
+                        solar_trans_cotangent;
+                }
+            }
+            for (int derivative = 0;
+                 derivative < m_atmosphere->surface().num_deriv();
+                 ++derivative) {
+                const auto brdf_derivative = m_atmosphere->surface().d_brdf(
+                    wavelidx, mu_in, mu_out, phi_diff, derivative);
+                native_gradient(m_atmosphere->surface_deriv_start_index() +
+                                derivative) +=
+                    solar_trans * mu_in *
+                    cotangent.dot(brdf_derivative(Eigen::placeholders::all, 0));
+            }
+        }
+    }
+
+    template <typename S, int NSTOKES>
     void SingleScatterSource<S, NSTOKES>::end_of_ray_source_single(
         int wavelidx, int losidx, int wavel_threadidx, int threadidx,
         sasktran2::WavelengthBlockLaneDualView<NSTOKES, 1>& source) const {
@@ -770,6 +1002,145 @@ namespace sasktran2::solartransmission {
         integrated_source_constant(wavelidx, losidx, layeridx, wavel_threadidx,
                                    threadidx, layer, entrance_weights,
                                    exit_weights, shell_od, source, direction);
+    }
+
+    template <typename S, int NSTOKES>
+    void SingleScatterSource<S, NSTOKES>::integrated_source_jvp(
+        int wavelidx, int losidx, int layeridx, int wavel_threadidx,
+        int threadidx, const sasktran2::raytracing::TracedLayer& layer,
+        const sasktran2::raytracing::GridWeightStencilView& entrance_weights,
+        const sasktran2::raytracing::GridWeightStencilView& exit_weights,
+        const sasktran2::WavelengthBlockODView& shell_od,
+        Eigen::Ref<const Eigen::VectorXd> native_tangent,
+        sasktran2::RadianceJVP<NSTOKES>& source) const {
+        (void)threadidx;
+        if constexpr (!std::is_same_v<S, SolarTransmissionExact>) {
+            throw std::logic_error(
+                "Native JVP requires exact solar transmission");
+        } else {
+            if (layer.layer_distance < MINIMUM_SHELL_SIZE_M) {
+                return;
+            }
+            const int exit_index = m_index_map[losidx][layeridx];
+            const int entrance_index = exit_index + 1;
+            const auto* start_weights = &entrance_weights;
+            const auto* end_weights = &exit_weights;
+            bool start_is_entrance = true;
+            bool end_is_entrance = false;
+            const bool use_lower_interpolation =
+                m_geometry_1d != nullptr &&
+                m_geometry_1d->altitude_grid().interpolation_method() ==
+                    grids::interpolation::lower;
+            if (use_lower_interpolation) {
+                if (layer.r_exit > layer.r_entrance) {
+                    end_weights = &entrance_weights;
+                    end_is_entrance = true;
+                } else {
+                    start_weights = &exit_weights;
+                    start_is_entrance = false;
+                }
+            }
+
+            sasktran2::RadianceJVP<NSTOKES> start;
+            sasktran2::RadianceJVP<NSTOKES> end;
+            endpoint_source_jvp(wavelidx, losidx, layeridx, wavel_threadidx,
+                                entrance_index, *start_weights,
+                                start_is_entrance, native_tangent, start);
+            endpoint_source_jvp(wavelidx, losidx, layeridx, wavel_threadidx,
+                                exit_index, *end_weights, end_is_entrance,
+                                native_tangent, end);
+
+            const double od = shell_od.od(0);
+            double factor;
+            double factor_derivative;
+            if (std::abs(od) < 1e-12) {
+                factor = 1.0;
+                factor_derivative = -0.5;
+            } else {
+                factor = -std::expm1(-od) / od;
+                factor_derivative = 1 / od - factor * (1 + 1 / od);
+            }
+            double od_jvp = 0.0;
+            for (auto derivative = shell_od.derivative_iterator(); derivative;
+                 ++derivative) {
+                od_jvp +=
+                    derivative.value() * native_tangent(derivative.index());
+            }
+            const auto endpoint_value = start.value * layer.od_quad_start +
+                                        end.value * layer.od_quad_end;
+            const auto endpoint_jvp =
+                start.jvp * layer.od_quad_start + end.jvp * layer.od_quad_end;
+            source.value += factor * endpoint_value;
+            source.jvp += factor * endpoint_jvp +
+                          factor_derivative * od_jvp * endpoint_value;
+        }
+    }
+
+    template <typename S, int NSTOKES>
+    void SingleScatterSource<S, NSTOKES>::integrated_source_vjp(
+        int wavelidx, int losidx, int layeridx, int wavel_threadidx,
+        int threadidx, const sasktran2::raytracing::TracedLayer& layer,
+        const sasktran2::raytracing::GridWeightStencilView& entrance_weights,
+        const sasktran2::raytracing::GridWeightStencilView& exit_weights,
+        const sasktran2::WavelengthBlockODView& shell_od,
+        const Eigen::Vector<double, NSTOKES>& cotangent,
+        Eigen::Ref<Eigen::VectorXd> native_gradient) const {
+        (void)threadidx;
+        if constexpr (!std::is_same_v<S, SolarTransmissionExact>) {
+            throw std::logic_error(
+                "Native VJP requires exact solar transmission");
+        } else {
+            if (layer.layer_distance < MINIMUM_SHELL_SIZE_M) {
+                return;
+            }
+            const int exit_index = m_index_map[losidx][layeridx];
+            const int entrance_index = exit_index + 1;
+            const auto* start_weights = &entrance_weights;
+            const auto* end_weights = &exit_weights;
+            bool start_is_entrance = true;
+            bool end_is_entrance = false;
+            const bool use_lower_interpolation =
+                m_geometry_1d != nullptr &&
+                m_geometry_1d->altitude_grid().interpolation_method() ==
+                    grids::interpolation::lower;
+            if (use_lower_interpolation) {
+                if (layer.r_exit > layer.r_entrance) {
+                    end_weights = &entrance_weights;
+                    end_is_entrance = true;
+                } else {
+                    start_weights = &exit_weights;
+                    start_is_entrance = false;
+                }
+            }
+
+            const double od = shell_od.od(0);
+            double factor;
+            double factor_derivative;
+            if (std::abs(od) < 1e-12) {
+                factor = 1.0;
+                factor_derivative = -0.5;
+            } else {
+                factor = -std::expm1(-od) / od;
+                factor_derivative = 1 / od - factor * (1 + 1 / od);
+            }
+            const auto start_value = endpoint_source_vjp(
+                wavelidx, losidx, layeridx, wavel_threadidx, entrance_index,
+                *start_weights, start_is_entrance,
+                factor * layer.od_quad_start * cotangent, native_gradient);
+            const auto end_value = endpoint_source_vjp(
+                wavelidx, losidx, layeridx, wavel_threadidx, exit_index,
+                *end_weights, end_is_entrance,
+                factor * layer.od_quad_end * cotangent, native_gradient);
+            const double od_cotangent =
+                factor_derivative *
+                cotangent.dot(start_value * layer.od_quad_start +
+                              end_value * layer.od_quad_end);
+            for (auto derivative = shell_od.derivative_iterator(); derivative;
+                 ++derivative) {
+                native_gradient(derivative.index()) +=
+                    derivative.value() * od_cotangent;
+            }
+        }
     }
 
     template <typename S, int NSTOKES>

--- a/cpp/lib/solar/singlescattersource.cpp
+++ b/cpp/lib/solar/singlescattersource.cpp
@@ -1066,13 +1066,24 @@ namespace sasktran2::solartransmission {
                 od_jvp +=
                     derivative.value() * native_tangent(derivative.index());
             }
-            const auto endpoint_value = start.value * layer.od_quad_start +
-                                        end.value * layer.od_quad_end;
+            // Match the established source-value quadrature exactly.  The
+            // optical-depth endpoint coefficients are not source blending
+            // weights for lower interpolation: one is the full path length
+            // and the other is zero, while the source remains the average of
+            // its endpoint values.
+            const auto endpoint_value =
+                (start.value * layer.od_quad_start_fraction +
+                 end.value * layer.od_quad_end_fraction) *
+                layer.layer_distance;
+            const auto optical_depth_endpoint_value =
+                start.value * layer.od_quad_start +
+                end.value * layer.od_quad_end;
             const auto endpoint_jvp =
                 start.jvp * layer.od_quad_start + end.jvp * layer.od_quad_end;
             source.value += factor * endpoint_value;
-            source.jvp += factor * endpoint_jvp +
-                          factor_derivative * od_jvp * endpoint_value;
+            source.jvp +=
+                factor * endpoint_jvp +
+                factor_derivative * od_jvp * optical_depth_endpoint_value;
         }
     }
 

--- a/cpp/lib/solar/singlescattersource.cpp
+++ b/cpp/lib/solar/singlescattersource.cpp
@@ -51,6 +51,10 @@ namespace sasktran2::solartransmission {
         // Set up storage for each thread
         // m_solar_trans.resize(config.num_threads());
         m_solar_trans.resize(config.num_wavelength_threads());
+        m_active_wavelength_block_start.assign(config.num_wavelength_threads(),
+                                               0);
+        m_active_wavelength_block_count.assign(config.num_wavelength_threads(),
+                                               0);
 
         m_start_source_cache.resize(config.num_threads());
         m_end_source_cache.resize(config.num_threads());
@@ -60,6 +64,8 @@ namespace sasktran2::solartransmission {
     void SingleScatterSource<S, NSTOKES>::calculate_single(int wavelidx,
                                                            int threadidx) {
         ZoneScopedN("Single Scatter Source Calculation");
+        m_active_wavelength_block_start[threadidx] = wavelidx;
+        m_active_wavelength_block_count[threadidx] = 1;
         // Don't have to do anything here
         m_phase_handler.calculate(wavelidx, threadidx);
 
@@ -142,6 +148,8 @@ namespace sasktran2::solartransmission {
                     "Wavelength batch exceeds single scatter storage "
                     "capacity");
             }
+            m_active_wavelength_block_start[threadidx] = batch.start;
+            m_active_wavelength_block_count[threadidx] = batch.count;
 
             m_phase_handler.calculate_block(batch, threadidx);
             auto solar_trans =
@@ -168,6 +176,21 @@ namespace sasktran2::solartransmission {
                 }
             }
         }
+    }
+
+    template <typename S, int NSTOKES>
+    double SingleScatterSource<S, NSTOKES>::solar_transmission_value(
+        int wavelidx, int threadidx, int solar_index) const {
+        if (m_wavelength_batch_capacity == 1) {
+            return m_solar_trans.at(threadidx)(solar_index);
+        }
+        const int lane =
+            wavelidx - m_active_wavelength_block_start.at(threadidx);
+        if (lane < 0 || lane >= m_active_wavelength_block_count.at(threadidx)) {
+            throw std::out_of_range(
+                "Single-scatter wavelength is outside the active block");
+        }
+        return m_solar_trans_batch.at(threadidx)(solar_index, lane);
     }
 
     template <typename S, int NSTOKES>
@@ -201,8 +224,8 @@ namespace sasktran2::solartransmission {
                     weight.second;
             }
 
-            const double solar_trans =
-                m_solar_trans[wavel_threadidx](solar_index);
+            const double solar_trans = solar_transmission_value(
+                wavelidx, wavel_threadidx, solar_index);
             double solar_od_jvp = 0.0;
             for (Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator
                      derivative(m_geometry_sparse, solar_index);
@@ -215,8 +238,8 @@ namespace sasktran2::solartransmission {
             Eigen::Vector<double, NSTOKES> phase;
             Eigen::Vector<double, NSTOKES> phase_jvp;
             m_phase_handler.scatter_jvp(wavel_threadidx, losidx, layeridx,
-                                        weights, is_entrance, native_tangent,
-                                        phase, phase_jvp);
+                                        wavelidx, weights, is_entrance,
+                                        native_tangent, phase, phase_jvp);
 
             const double scale = 1.0 / (EIGEN_PI * 4);
             const double amplitude = extinction * ssa * solar_trans * scale;
@@ -254,11 +277,11 @@ namespace sasktran2::solartransmission {
                 ssa += storage.ssa(weight.first, wavelidx) * weight.second;
             }
 
-            const double solar_trans =
-                m_solar_trans[wavel_threadidx](solar_index);
+            const double solar_trans = solar_transmission_value(
+                wavelidx, wavel_threadidx, solar_index);
             const Eigen::Vector<double, NSTOKES> phase =
                 m_phase_handler.scatter_value(wavel_threadidx, losidx, layeridx,
-                                              weights, is_entrance);
+                                              wavelidx, weights, is_entrance);
 
             const double scale = 1.0 / (EIGEN_PI * 4);
             const double amplitude = extinction * ssa * solar_trans * scale;
@@ -287,7 +310,7 @@ namespace sasktran2::solartransmission {
                     derivative.value() * solar_trans * solar_trans_cotangent;
             }
             m_phase_handler.scatter_vjp(wavel_threadidx, losidx, layeridx,
-                                        weights, is_entrance,
+                                        wavelidx, weights, is_entrance,
                                         amplitude * cotangent, native_gradient);
             return amplitude * phase;
         }
@@ -316,8 +339,8 @@ namespace sasktran2::solartransmission {
                 first_layer.average_look_away);
             const double phi_diff = first_layer.saz_exit;
             const int solar_index = m_index_map[losidx][0];
-            const double solar_trans =
-                m_solar_trans[wavel_threadidx](solar_index);
+            const double solar_trans = solar_transmission_value(
+                wavelidx, wavel_threadidx, solar_index);
             double solar_od_jvp = 0.0;
             if (m_config->wf_precision() !=
                 sasktran2::Config::WeightingFunctionPrecision::limited) {
@@ -353,7 +376,8 @@ namespace sasktran2::solartransmission {
     template <typename S, int NSTOKES>
     void SingleScatterSource<S, NSTOKES>::end_of_ray_source_vjp(
         int wavelidx, int losidx, int wavel_threadidx, int threadidx,
-        const Eigen::Vector<double, NSTOKES>& cotangent,
+        const Eigen::Vector<double, NSTOKES>&,
+        Eigen::Vector<double, NSTOKES>& cotangent,
         Eigen::Ref<Eigen::VectorXd> native_gradient) const {
         (void)threadidx;
         if constexpr (!std::is_same_v<S, SolarTransmissionExact>) {
@@ -373,8 +397,8 @@ namespace sasktran2::solartransmission {
                 first_layer.average_look_away);
             const double phi_diff = first_layer.saz_exit;
             const int solar_index = m_index_map[losidx][0];
-            const double solar_trans =
-                m_solar_trans[wavel_threadidx](solar_index);
+            const double solar_trans = solar_transmission_value(
+                wavelidx, wavel_threadidx, solar_index);
             const auto brdf =
                 m_atmosphere->surface().brdf(wavelidx, mu_in, mu_out, phi_diff);
             const double solar_trans_cotangent =
@@ -1094,7 +1118,8 @@ namespace sasktran2::solartransmission {
         const sasktran2::raytracing::GridWeightStencilView& entrance_weights,
         const sasktran2::raytracing::GridWeightStencilView& exit_weights,
         const sasktran2::WavelengthBlockODView& shell_od,
-        const Eigen::Vector<double, NSTOKES>& cotangent,
+        const Eigen::Vector<double, NSTOKES>&,
+        Eigen::Vector<double, NSTOKES>& cotangent,
         Eigen::Ref<Eigen::VectorXd> native_gradient) const {
         (void)threadidx;
         if constexpr (!std::is_same_v<S, SolarTransmissionExact>) {

--- a/cpp/lib/sourceintegrator/sourceintegrator.cpp
+++ b/cpp/lib/sourceintegrator/sourceintegrator.cpp
@@ -170,6 +170,136 @@ namespace sasktran2 {
     }
 
     template <int NSTOKES>
+    void SourceIntegrator<NSTOKES>::integrate_jvp(
+        sasktran2::RadianceJVP<NSTOKES>& radiance,
+        const std::vector<SourceTermInterface<NSTOKES>*>& source_terms,
+        int wavelength, int rayidx, int wavel_threadidx, int threadidx,
+        Eigen::Ref<const Eigen::VectorXd> native_tangent) const {
+        if (m_wavelength_block_capacity != 1 || m_scalar_shell_od.empty()) {
+            throw std::logic_error(
+                "Native JVP requires scalar source-integrator storage");
+        }
+        radiance.set_zero();
+        for (const auto* source : source_terms) {
+            source->end_of_ray_source_jvp(wavelength, rayidx, wavel_threadidx,
+                                          threadidx, native_tangent, radiance);
+        }
+
+        const auto& ray = (*m_traced_rays)[rayidx];
+        const auto& od_matrix = m_traced_ray_od_matrix[rayidx];
+        for (int layeridx = 0; layeridx < ray.layers.size(); ++layeridx) {
+            const double od = m_scalar_shell_od[rayidx](layeridx, wavelength);
+            const double attenuation = std::exp(-od);
+            const sasktran2::WavelengthBlockODView shell_od(
+                &od, &attenuation, 1, od_matrix, layeridx);
+            double od_jvp = 0.0;
+            for (auto derivative = shell_od.derivative_iterator(); derivative;
+                 ++derivative) {
+                od_jvp +=
+                    derivative.value() * native_tangent(derivative.index());
+            }
+            radiance.jvp =
+                attenuation * (radiance.jvp - od_jvp * radiance.value);
+            radiance.value *= attenuation;
+
+            const auto& layer = ray.layers[layeridx];
+            const auto entrance_weights = ray.entrance_weights(layeridx);
+            const auto exit_weights = ray.exit_weights(layeridx);
+            for (const auto* source : source_terms) {
+                if (source->has_interior_source()) {
+                    source->integrated_source_jvp(
+                        wavelength, rayidx, layeridx, wavel_threadidx,
+                        threadidx, layer, entrance_weights, exit_weights,
+                        shell_od, native_tangent, radiance);
+                }
+            }
+        }
+    }
+
+    template <int NSTOKES>
+    void SourceIntegrator<NSTOKES>::integrate_vjp(
+        Eigen::Vector<double, NSTOKES>& radiance,
+        const std::vector<SourceTermInterface<NSTOKES>*>& source_terms,
+        int wavelength, int rayidx, int wavel_threadidx, int threadidx,
+        const Eigen::Vector<double, NSTOKES>& cotangent,
+        Eigen::Ref<Eigen::VectorXd> native_gradient) const {
+        if (m_wavelength_block_capacity != 1 || m_scalar_shell_od.empty()) {
+            throw std::logic_error(
+                "Native VJP requires scalar source-integrator storage");
+        }
+        const auto& ray = (*m_traced_rays)[rayidx];
+        const auto& od_matrix = m_traced_ray_od_matrix[rayidx];
+        const Eigen::VectorXd zero_tangent =
+            Eigen::VectorXd::Zero(m_atmosphere->num_deriv());
+        sasktran2::RadianceJVP<NSTOKES> state;
+        for (const auto* source : source_terms) {
+            source->end_of_ray_source_jvp(wavelength, rayidx, wavel_threadidx,
+                                          threadidx, zero_tangent, state);
+        }
+
+        std::vector<Eigen::Vector<double, NSTOKES>> values_before_layer(
+            ray.layers.size());
+        std::vector<double> attenuation(ray.layers.size());
+        for (int layeridx = 0; layeridx < ray.layers.size(); ++layeridx) {
+            values_before_layer[layeridx] = state.value;
+            const double od = m_scalar_shell_od[rayidx](layeridx, wavelength);
+            attenuation[layeridx] = std::exp(-od);
+            const sasktran2::WavelengthBlockODView shell_od(
+                &od, &attenuation[layeridx], 1, od_matrix, layeridx);
+            state.value *= attenuation[layeridx];
+
+            const auto& layer = ray.layers[layeridx];
+            const auto entrance_weights = ray.entrance_weights(layeridx);
+            const auto exit_weights = ray.exit_weights(layeridx);
+            for (const auto* source : source_terms) {
+                if (source->has_interior_source()) {
+                    source->integrated_source_jvp(
+                        wavelength, rayidx, layeridx, wavel_threadidx,
+                        threadidx, layer, entrance_weights, exit_weights,
+                        shell_od, zero_tangent, state);
+                }
+            }
+        }
+        radiance = state.value;
+
+        Eigen::Vector<double, NSTOKES> state_cotangent = cotangent;
+        for (int layeridx = static_cast<int>(ray.layers.size()) - 1;
+             layeridx >= 0; --layeridx) {
+            const double od = m_scalar_shell_od[rayidx](layeridx, wavelength);
+            const sasktran2::WavelengthBlockODView shell_od(
+                &od, &attenuation[layeridx], 1, od_matrix, layeridx);
+            const auto& layer = ray.layers[layeridx];
+            const auto entrance_weights = ray.entrance_weights(layeridx);
+            const auto exit_weights = ray.exit_weights(layeridx);
+            for (const auto* source : source_terms) {
+                if (source->has_interior_source()) {
+                    source->integrated_source_vjp(
+                        wavelength, rayidx, layeridx, wavel_threadidx,
+                        threadidx, layer, entrance_weights, exit_weights,
+                        shell_od, state_cotangent, native_gradient);
+                }
+            }
+
+            const double attenuation_cotangent =
+                state_cotangent.dot(values_before_layer[layeridx]);
+            const double od_cotangent =
+                -attenuation[layeridx] * attenuation_cotangent;
+            for (auto derivative = shell_od.derivative_iterator(); derivative;
+                 ++derivative) {
+                native_gradient(derivative.index()) +=
+                    derivative.value() * od_cotangent;
+            }
+            state_cotangent *= attenuation[layeridx];
+        }
+
+        for (const auto* source : source_terms) {
+            source->end_of_ray_source_vjp(wavelength, rayidx, wavel_threadidx,
+                                          threadidx, state_cotangent,
+                                          native_gradient);
+        }
+    }
+
+    template <int NSTOKES>
     template <int N>
     void SourceIntegrator<NSTOKES>::integrate_block(
         sasktran2::WavelengthBlockDual<NSTOKES>& radiance,

--- a/cpp/lib/sourceintegrator/sourceintegrator.cpp
+++ b/cpp/lib/sourceintegrator/sourceintegrator.cpp
@@ -214,6 +214,11 @@ namespace sasktran2 {
                 }
             }
         }
+        for (const auto* source : source_terms) {
+            source->start_of_ray_source_jvp(wavelength, rayidx, wavel_threadidx,
+                                            threadidx, native_tangent,
+                                            radiance);
+        }
     }
 
     template <int NSTOKES>
@@ -229,40 +234,56 @@ namespace sasktran2 {
         }
         const auto& ray = (*m_traced_rays)[rayidx];
         const auto& od_matrix = m_traced_ray_od_matrix[rayidx];
-        const Eigen::VectorXd zero_tangent =
-            Eigen::VectorXd::Zero(m_atmosphere->num_deriv());
-        sasktran2::RadianceJVP<NSTOKES> state;
+        const sasktran2::WavelengthBlock<1> block{wavelength, 1};
+        sasktran2::WavelengthBlockDual<NSTOKES> state;
+        state.resize(1, 0, true);
         for (const auto* source : source_terms) {
-            source->end_of_ray_source_jvp(wavelength, rayidx, wavel_threadidx,
-                                          threadidx, zero_tangent, state);
+            source->end_of_ray_source(block.dynamic(), rayidx, wavel_threadidx,
+                                      threadidx, state);
         }
 
         std::vector<Eigen::Vector<double, NSTOKES>> values_before_layer(
             ray.layers.size());
         std::vector<double> attenuation(ray.layers.size());
         for (int layeridx = 0; layeridx < ray.layers.size(); ++layeridx) {
-            values_before_layer[layeridx] = state.value;
+            values_before_layer[layeridx] = state.value.col(0);
             const double od = m_scalar_shell_od[rayidx](layeridx, wavelength);
             attenuation[layeridx] = std::exp(-od);
             const sasktran2::WavelengthBlockODView shell_od(
                 &od, &attenuation[layeridx], 1, od_matrix, layeridx);
-            state.value *= attenuation[layeridx];
+            state.value.col(0) *= attenuation[layeridx];
 
             const auto& layer = ray.layers[layeridx];
             const auto entrance_weights = ray.entrance_weights(layeridx);
             const auto exit_weights = ray.exit_weights(layeridx);
             for (const auto* source : source_terms) {
                 if (source->has_interior_source()) {
-                    source->integrated_source_jvp(
-                        wavelength, rayidx, layeridx, wavel_threadidx,
-                        threadidx, layer, entrance_weights, exit_weights,
-                        shell_od, zero_tangent, state);
+                    source->dispatch_integrated_source(
+                        block, rayidx, layeridx, wavel_threadidx, threadidx,
+                        layer, entrance_weights, exit_weights, shell_od, state,
+                        SourceTermInterface<
+                            NSTOKES>::IntegrationDirection::backward);
                 }
             }
         }
-        radiance = state.value;
+
+        std::vector<Eigen::Vector<double, NSTOKES>> values_before_start;
+        values_before_start.reserve(source_terms.size());
+        for (const auto* source : source_terms) {
+            values_before_start.push_back(state.value.col(0));
+            source->start_of_ray_source(block.dynamic(), rayidx,
+                                        wavel_threadidx, threadidx, state);
+        }
+        radiance = state.value.col(0);
 
         Eigen::Vector<double, NSTOKES> state_cotangent = cotangent;
+        for (int source_index = static_cast<int>(source_terms.size()) - 1;
+             source_index >= 0; --source_index) {
+            source_terms[source_index]->start_of_ray_source_vjp(
+                wavelength, rayidx, wavel_threadidx, threadidx,
+                values_before_start[source_index], state_cotangent,
+                native_gradient);
+        }
         for (int layeridx = static_cast<int>(ray.layers.size()) - 1;
              layeridx >= 0; --layeridx) {
             const double od = m_scalar_shell_od[rayidx](layeridx, wavelength);

--- a/cpp/lib/sourceintegrator/sourceintegrator.cpp
+++ b/cpp/lib/sourceintegrator/sourceintegrator.cpp
@@ -158,6 +158,36 @@ namespace sasktran2 {
     }
 
     template <int NSTOKES>
+    bool SourceIntegrator<NSTOKES>::validate_sources_for_block(
+        const std::vector<SourceTermInterface<NSTOKES>*>& source_terms,
+        int block_size) const {
+        if (block_size < 1) {
+            throw std::invalid_argument(
+                "Source integration wavelength block must be positive");
+        }
+
+        bool have_to_integrate = false;
+        for (const auto* source : source_terms) {
+            if (source->maximum_wavelength_block_size() < block_size) {
+                throw std::invalid_argument(
+                    "Source does not support the requested wavelength block "
+                    "size");
+            }
+            if (source->requires_integration()) {
+                have_to_integrate = true;
+                if (source->has_interior_source() &&
+                    !source->supports_geometry_dimension(
+                        m_num_geometry_dimensions)) {
+                    throw std::invalid_argument(
+                        "Interior source integration is not supported for "
+                        "the configured atmosphere dimensionality");
+                }
+            }
+        }
+        return have_to_integrate;
+    }
+
+    template <int NSTOKES>
     void SourceIntegrator<NSTOKES>::integrate(
         sasktran2::WavelengthBlockDual<NSTOKES>& radiance,
         const std::vector<SourceTermInterface<NSTOKES>*>& source_terms,
@@ -175,42 +205,45 @@ namespace sasktran2 {
         const std::vector<SourceTermInterface<NSTOKES>*>& source_terms,
         int wavelength, int rayidx, int wavel_threadidx, int threadidx,
         Eigen::Ref<const Eigen::VectorXd> native_tangent) const {
-        if (m_wavelength_block_capacity != 1 || m_scalar_shell_od.empty()) {
-            throw std::logic_error(
-                "Native JVP requires scalar source-integrator storage");
-        }
+        const bool have_to_integrate =
+            validate_sources_for_block(source_terms, 1);
         radiance.set_zero();
         for (const auto* source : source_terms) {
             source->end_of_ray_source_jvp(wavelength, rayidx, wavel_threadidx,
                                           threadidx, native_tangent, radiance);
         }
 
-        const auto& ray = (*m_traced_rays)[rayidx];
-        const auto& od_matrix = m_traced_ray_od_matrix[rayidx];
-        for (int layeridx = 0; layeridx < ray.layers.size(); ++layeridx) {
-            const double od = m_scalar_shell_od[rayidx](layeridx, wavelength);
-            const double attenuation = std::exp(-od);
-            const sasktran2::WavelengthBlockODView shell_od(
-                &od, &attenuation, 1, od_matrix, layeridx);
-            double od_jvp = 0.0;
-            for (auto derivative = shell_od.derivative_iterator(); derivative;
-                 ++derivative) {
-                od_jvp +=
-                    derivative.value() * native_tangent(derivative.index());
-            }
-            radiance.jvp =
-                attenuation * (radiance.jvp - od_jvp * radiance.value);
-            radiance.value *= attenuation;
+        if (have_to_integrate) {
+            const auto& ray = (*m_traced_rays)[rayidx];
+            const auto& od_matrix = m_traced_ray_od_matrix[rayidx];
+            for (int layeridx = 0; layeridx < ray.layers.size(); ++layeridx) {
+                const double od =
+                    m_wavelength_block_capacity == 1
+                        ? m_scalar_shell_od[rayidx](layeridx, wavelength)
+                        : m_shell_od[rayidx](layeridx, wavelength);
+                const double attenuation = std::exp(-od);
+                const sasktran2::WavelengthBlockODView shell_od(
+                    &od, &attenuation, 1, od_matrix, layeridx);
+                double od_jvp = 0.0;
+                for (auto derivative = shell_od.derivative_iterator();
+                     derivative; ++derivative) {
+                    od_jvp +=
+                        derivative.value() * native_tangent(derivative.index());
+                }
+                radiance.jvp =
+                    attenuation * (radiance.jvp - od_jvp * radiance.value);
+                radiance.value *= attenuation;
 
-            const auto& layer = ray.layers[layeridx];
-            const auto entrance_weights = ray.entrance_weights(layeridx);
-            const auto exit_weights = ray.exit_weights(layeridx);
-            for (const auto* source : source_terms) {
-                if (source->has_interior_source()) {
-                    source->integrated_source_jvp(
-                        wavelength, rayidx, layeridx, wavel_threadidx,
-                        threadidx, layer, entrance_weights, exit_weights,
-                        shell_od, native_tangent, radiance);
+                const auto& layer = ray.layers[layeridx];
+                const auto entrance_weights = ray.entrance_weights(layeridx);
+                const auto exit_weights = ray.exit_weights(layeridx);
+                for (const auto* source : source_terms) {
+                    if (source->has_interior_source()) {
+                        source->integrated_source_jvp(
+                            wavelength, rayidx, layeridx, wavel_threadidx,
+                            threadidx, layer, entrance_weights, exit_weights,
+                            shell_od, native_tangent, radiance);
+                    }
                 }
             }
         }
@@ -228,95 +261,203 @@ namespace sasktran2 {
         int wavelength, int rayidx, int wavel_threadidx, int threadidx,
         const Eigen::Vector<double, NSTOKES>& cotangent,
         Eigen::Ref<Eigen::VectorXd> native_gradient) const {
-        if (m_wavelength_block_capacity != 1 || m_scalar_shell_od.empty()) {
-            throw std::logic_error(
-                "Native VJP requires scalar source-integrator storage");
+        StokesBlock radiance_block(NSTOKES, 1);
+        StokesBlock cotangent_block(NSTOKES, 1);
+        Eigen::MatrixXd gradient_block =
+            Eigen::MatrixXd::Zero(native_gradient.size(), 1);
+        cotangent_block.col(0) = cotangent;
+        integrate_vjp_block(radiance_block, source_terms,
+                            sasktran2::WavelengthBlock<>{wavelength, 1}, rayidx,
+                            wavel_threadidx, threadidx, cotangent_block,
+                            gradient_block);
+        radiance = radiance_block.col(0);
+        native_gradient += gradient_block.col(0);
+    }
+
+    template <int NSTOKES>
+    void SourceIntegrator<NSTOKES>::integrate_vjp_block(
+        StokesBlock& radiance,
+        const std::vector<SourceTermInterface<NSTOKES>*>& source_terms,
+        const sasktran2::WavelengthBlock<>& block, int rayidx,
+        int wavel_threadidx, int threadidx, const StokesBlock& cotangent,
+        Eigen::MatrixXd& native_gradient) const {
+        if (threadidx < 0 || threadidx >= m_vjp_thread_storage.size()) {
+            throw std::invalid_argument(
+                "VJP thread scratch is not initialized");
         }
+        if (block.count < 1 || block.count > m_wavelength_block_capacity ||
+            radiance.cols() < block.count || cotangent.cols() < block.count ||
+            native_gradient.cols() < block.count) {
+            throw std::invalid_argument("Invalid native VJP wavelength block");
+        }
+        const bool have_to_integrate =
+            validate_sources_for_block(source_terms, block.count);
+
         const auto& ray = (*m_traced_rays)[rayidx];
         const auto& od_matrix = m_traced_ray_od_matrix[rayidx];
-        const sasktran2::WavelengthBlock<1> block{wavelength, 1};
-        sasktran2::WavelengthBlockDual<NSTOKES> state;
-        state.resize(1, 0, true);
-        for (const auto* source : source_terms) {
-            source->end_of_ray_source(block.dynamic(), rayidx, wavel_threadidx,
-                                      threadidx, state);
+        auto& scratch = m_vjp_thread_storage[threadidx];
+        auto& state = scratch.state;
+        const int num_sources = static_cast<int>(source_terms.size());
+        if (scratch.values_before_end.rows() < num_sources * NSTOKES ||
+            scratch.values_before_start.rows() < num_sources * NSTOKES ||
+            (have_to_integrate &&
+             scratch.values_before_interior.rows() <
+                 static_cast<int>(ray.layers.size()) * num_sources * NSTOKES)) {
+            throw std::invalid_argument(
+                "VJP source tape is not initialized for the active sources");
+        }
+        state.set_zero(block.count);
+        for (int source_index = 0; source_index < num_sources; ++source_index) {
+            scratch.values_before_end.block(source_index * NSTOKES, 0, NSTOKES,
+                                            block.count) =
+                state.value.leftCols(block.count);
+            source_terms[source_index]->end_of_ray_source(
+                block, rayidx, wavel_threadidx, threadidx, state);
         }
 
-        std::vector<Eigen::Vector<double, NSTOKES>> values_before_layer(
-            ray.layers.size());
-        std::vector<double> attenuation(ray.layers.size());
-        for (int layeridx = 0; layeridx < ray.layers.size(); ++layeridx) {
-            values_before_layer[layeridx] = state.value.col(0);
-            const double od = m_scalar_shell_od[rayidx](layeridx, wavelength);
-            attenuation[layeridx] = std::exp(-od);
-            const sasktran2::WavelengthBlockODView shell_od(
-                &od, &attenuation[layeridx], 1, od_matrix, layeridx);
-            state.value.col(0) *= attenuation[layeridx];
+        if (have_to_integrate) {
+            for (int layeridx = 0; layeridx < ray.layers.size(); ++layeridx) {
+                scratch.values_before_layer.block(layeridx * NSTOKES, 0,
+                                                  NSTOKES, block.count) =
+                    state.value.leftCols(block.count);
+                const double* od =
+                    m_wavelength_block_capacity == 1
+                        ? &m_scalar_shell_od[rayidx](layeridx, block.start)
+                        : &m_shell_od[rayidx](layeridx, block.start);
+                auto attenuation =
+                    scratch.attenuation.row(layeridx).head(block.count);
+                attenuation.array() =
+                    -Eigen::Map<const Eigen::RowVectorXd>(od, block.count)
+                         .array();
+                attenuation = attenuation.array().exp();
+                const sasktran2::WavelengthBlockODView shell_od(
+                    od, attenuation.data(), block.count, od_matrix, layeridx);
+                state.value.leftCols(block.count).array().rowwise() *=
+                    attenuation.array();
 
-            const auto& layer = ray.layers[layeridx];
-            const auto entrance_weights = ray.entrance_weights(layeridx);
-            const auto exit_weights = ray.exit_weights(layeridx);
-            for (const auto* source : source_terms) {
-                if (source->has_interior_source()) {
-                    source->dispatch_integrated_source(
-                        block, rayidx, layeridx, wavel_threadidx, threadidx,
-                        layer, entrance_weights, exit_weights, shell_od, state,
-                        SourceTermInterface<
-                            NSTOKES>::IntegrationDirection::backward);
+                const auto& layer = ray.layers[layeridx];
+                const auto entrance_weights = ray.entrance_weights(layeridx);
+                const auto exit_weights = ray.exit_weights(layeridx);
+                for (int source_index = 0; source_index < num_sources;
+                     ++source_index) {
+                    const auto* source = source_terms[source_index];
+                    if (source->has_interior_source()) {
+                        const int tape_row =
+                            (layeridx * num_sources + source_index) * NSTOKES;
+                        scratch.values_before_interior.block(
+                            tape_row, 0, NSTOKES, block.count) =
+                            state.value.leftCols(block.count);
+                        source->dispatch_integrated_source(
+                            block, rayidx, layeridx, wavel_threadidx, threadidx,
+                            layer, entrance_weights, exit_weights, shell_od,
+                            state,
+                            SourceTermInterface<
+                                NSTOKES>::IntegrationDirection::backward);
+                    }
                 }
             }
         }
 
-        std::vector<Eigen::Vector<double, NSTOKES>> values_before_start;
-        values_before_start.reserve(source_terms.size());
-        for (const auto* source : source_terms) {
-            values_before_start.push_back(state.value.col(0));
-            source->start_of_ray_source(block.dynamic(), rayidx,
-                                        wavel_threadidx, threadidx, state);
+        for (int source_index = 0; source_index < num_sources; ++source_index) {
+            scratch.values_before_start.block(source_index * NSTOKES, 0,
+                                              NSTOKES, block.count) =
+                state.value.leftCols(block.count);
+            source_terms[source_index]->start_of_ray_source(
+                block, rayidx, wavel_threadidx, threadidx, state);
         }
-        radiance = state.value.col(0);
+        radiance.leftCols(block.count) = state.value.leftCols(block.count);
 
-        Eigen::Vector<double, NSTOKES> state_cotangent = cotangent;
-        for (int source_index = static_cast<int>(source_terms.size()) - 1;
-             source_index >= 0; --source_index) {
-            source_terms[source_index]->start_of_ray_source_vjp(
-                wavelength, rayidx, wavel_threadidx, threadidx,
-                values_before_start[source_index], state_cotangent,
-                native_gradient);
+        auto state_cotangent = scratch.cotangent.leftCols(block.count);
+        state_cotangent = cotangent.leftCols(block.count);
+        for (int source_index = num_sources - 1; source_index >= 0;
+             --source_index) {
+            for (int lane = 0; lane < block.count; ++lane) {
+                const Eigen::Vector<double, NSTOKES> value_before =
+                    scratch.values_before_start.block(source_index * NSTOKES,
+                                                      lane, NSTOKES, 1);
+                Eigen::Vector<double, NSTOKES> lane_cotangent =
+                    state_cotangent.col(lane);
+                auto lane_gradient = native_gradient.col(lane);
+                source_terms[source_index]->start_of_ray_source_vjp(
+                    block.wavelength(lane), rayidx, wavel_threadidx, threadidx,
+                    value_before, lane_cotangent, lane_gradient);
+                state_cotangent.col(lane) = lane_cotangent;
+            }
         }
-        for (int layeridx = static_cast<int>(ray.layers.size()) - 1;
-             layeridx >= 0; --layeridx) {
-            const double od = m_scalar_shell_od[rayidx](layeridx, wavelength);
-            const sasktran2::WavelengthBlockODView shell_od(
-                &od, &attenuation[layeridx], 1, od_matrix, layeridx);
-            const auto& layer = ray.layers[layeridx];
-            const auto entrance_weights = ray.entrance_weights(layeridx);
-            const auto exit_weights = ray.exit_weights(layeridx);
-            for (const auto* source : source_terms) {
-                if (source->has_interior_source()) {
-                    source->integrated_source_vjp(
-                        wavelength, rayidx, layeridx, wavel_threadidx,
-                        threadidx, layer, entrance_weights, exit_weights,
-                        shell_od, state_cotangent, native_gradient);
+        if (have_to_integrate) {
+            for (int layeridx = static_cast<int>(ray.layers.size()) - 1;
+                 layeridx >= 0; --layeridx) {
+                const double* od =
+                    m_wavelength_block_capacity == 1
+                        ? &m_scalar_shell_od[rayidx](layeridx, block.start)
+                        : &m_shell_od[rayidx](layeridx, block.start);
+                const double* attenuation = &scratch.attenuation(layeridx, 0);
+                const auto& layer = ray.layers[layeridx];
+                const auto entrance_weights = ray.entrance_weights(layeridx);
+                const auto exit_weights = ray.exit_weights(layeridx);
+                for (int source_index = num_sources - 1; source_index >= 0;
+                     --source_index) {
+                    const auto* source = source_terms[source_index];
+                    if (!source->has_interior_source()) {
+                        continue;
+                    }
+                    const int tape_row =
+                        (layeridx * num_sources + source_index) * NSTOKES;
+                    for (int lane = 0; lane < block.count; ++lane) {
+                        const sasktran2::WavelengthBlockODView shell_od(
+                            od + lane, attenuation + lane, 1, od_matrix,
+                            layeridx);
+                        const Eigen::Vector<double, NSTOKES> value_before =
+                            scratch.values_before_interior.block(tape_row, lane,
+                                                                 NSTOKES, 1);
+                        Eigen::Vector<double, NSTOKES> lane_cotangent =
+                            state_cotangent.col(lane);
+                        auto lane_gradient = native_gradient.col(lane);
+                        source->integrated_source_vjp(
+                            block.wavelength(lane), rayidx, layeridx,
+                            wavel_threadidx, threadidx, layer, entrance_weights,
+                            exit_weights, shell_od, value_before,
+                            lane_cotangent, lane_gradient);
+                        state_cotangent.col(lane) = lane_cotangent;
+                    }
                 }
-            }
 
-            const double attenuation_cotangent =
-                state_cotangent.dot(values_before_layer[layeridx]);
-            const double od_cotangent =
-                -attenuation[layeridx] * attenuation_cotangent;
-            for (auto derivative = shell_od.derivative_iterator(); derivative;
-                 ++derivative) {
-                native_gradient(derivative.index()) +=
-                    derivative.value() * od_cotangent;
+                const auto value_before = scratch.values_before_layer.block(
+                    layeridx * NSTOKES, 0, NSTOKES, block.count);
+                auto od_cotangent = scratch.od_cotangent.head(block.count);
+                od_cotangent.array() =
+                    -scratch.attenuation.row(layeridx)
+                         .head(block.count)
+                         .array() *
+                    (state_cotangent.array() * value_before.array())
+                        .colwise()
+                        .sum();
+                for (Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator
+                         derivative(od_matrix, layeridx);
+                     derivative; ++derivative) {
+                    native_gradient.row(derivative.index())
+                        .head(block.count)
+                        .array() += derivative.value() * od_cotangent.array();
+                }
+                state_cotangent.array().rowwise() *=
+                    scratch.attenuation.row(layeridx).head(block.count).array();
             }
-            state_cotangent *= attenuation[layeridx];
         }
 
-        for (const auto* source : source_terms) {
-            source->end_of_ray_source_vjp(wavelength, rayidx, wavel_threadidx,
-                                          threadidx, state_cotangent,
-                                          native_gradient);
+        for (int source_index = num_sources - 1; source_index >= 0;
+             --source_index) {
+            for (int lane = 0; lane < block.count; ++lane) {
+                const Eigen::Vector<double, NSTOKES> value_before =
+                    scratch.values_before_end.block(source_index * NSTOKES,
+                                                    lane, NSTOKES, 1);
+                Eigen::Vector<double, NSTOKES> lane_cotangent =
+                    state_cotangent.col(lane);
+                auto lane_gradient = native_gradient.col(lane);
+                source_terms[source_index]->end_of_ray_source_vjp(
+                    block.wavelength(lane), rayidx, wavel_threadidx, threadidx,
+                    value_before, lane_cotangent, lane_gradient);
+                state_cotangent.col(lane) = lane_cotangent;
+            }
         }
     }
 
@@ -332,24 +473,8 @@ namespace sasktran2 {
                 "Wavelength block does not fit the radiance storage");
         }
 
-        bool have_to_integrate = false;
-        for (const auto* source : source_terms) {
-            if (source->maximum_wavelength_block_size() < block.count) {
-                throw std::invalid_argument(
-                    "Source does not support the requested wavelength block "
-                    "size");
-            }
-            if (source->requires_integration()) {
-                have_to_integrate = true;
-                if (source->has_interior_source() &&
-                    !source->supports_geometry_dimension(
-                        m_num_geometry_dimensions)) {
-                    throw std::invalid_argument(
-                        "Interior source integration is not supported for "
-                        "the configured atmosphere dimensionality");
-                }
-            }
-        }
+        const bool have_to_integrate =
+            validate_sources_for_block(source_terms, block.count);
 
         const auto dynamic_block = block.dynamic();
         for (const auto* source : source_terms) {

--- a/cpp/lib/tests/output/test_output_batch.cpp
+++ b/cpp/lib/tests/output/test_output_batch.cpp
@@ -75,3 +75,191 @@ TEST_CASE("Batched native C++ outputs match scalar assignment",
             .at("constituent")
             .isApprox(scalar_mapped.derivatives().at("constituent"), 1e-12));
 }
+
+TEST_CASE("Native product outputs validate registered parameter sizes",
+          "[sasktran2][output][linearization]") {
+    constexpr int nwavel = 2;
+    sasktran2::Coordinates coordinates(0.6, 0.2, 6372000,
+                                       sasktran2::geometrytype::spherical);
+    Eigen::VectorXd altitude_values(3);
+    altitude_values << 0.0, 10000.0, 20000.0;
+    sasktran2::grids::AltitudeGrid altitude_grid(
+        std::move(altitude_values), sasktran2::grids::gridspacing::constant,
+        sasktran2::grids::outofbounds::extend,
+        sasktran2::grids::interpolation::linear);
+    sasktran2::Geometry1D geometry(std::move(coordinates),
+                                   std::move(altitude_grid));
+    sasktran2::Config config;
+    sasktran2::viewinggeometry::InternalViewingGeometry viewing;
+    sasktran2::atmosphere::Atmosphere<1> atmosphere(nwavel, geometry, config,
+                                                    true);
+    atmosphere.storage()
+        .get_derivative_mapping("volume")
+        .allocate_extinction_derivatives();
+    atmosphere.surface()
+        .get_derivative_mapping("surface")
+        .allocate_brdf_derivatives();
+
+    SECTION("JVP volume tangent") {
+        Eigen::VectorXd radiance(0);
+        Eigen::VectorXd directional(0);
+        Eigen::Map<Eigen::VectorXd> radiance_map(radiance.data(), 0);
+        Eigen::Map<Eigen::VectorXd> directional_map(directional.data(), 0);
+        sasktran2::OutputJVP<1> output(radiance_map, directional_map);
+        const Eigen::VectorXd tangent =
+            Eigen::VectorXd::Zero(geometry.size() - 1);
+        output.set_derivative_tangent("volume", tangent);
+        REQUIRE_THROWS_AS(
+            output.initialize(config, geometry, viewing, atmosphere),
+            std::invalid_argument);
+    }
+
+    SECTION("JVP surface tangent") {
+        Eigen::VectorXd radiance(0);
+        Eigen::VectorXd directional(0);
+        Eigen::Map<Eigen::VectorXd> radiance_map(radiance.data(), 0);
+        Eigen::Map<Eigen::VectorXd> directional_map(directional.data(), 0);
+        sasktran2::OutputJVP<1> output(radiance_map, directional_map);
+        const Eigen::VectorXd tangent = Eigen::VectorXd::Zero(nwavel - 1);
+        output.set_surface_tangent("surface", tangent);
+        REQUIRE_THROWS_AS(
+            output.initialize(config, geometry, viewing, atmosphere),
+            std::invalid_argument);
+    }
+
+    SECTION("unknown JVP mapping") {
+        Eigen::VectorXd radiance(0);
+        Eigen::VectorXd directional(0);
+        Eigen::Map<Eigen::VectorXd> radiance_map(radiance.data(), 0);
+        Eigen::Map<Eigen::VectorXd> directional_map(directional.data(), 0);
+        sasktran2::OutputJVP<1> output(radiance_map, directional_map);
+        const Eigen::VectorXd tangent = Eigen::VectorXd::Zero(geometry.size());
+        output.set_derivative_tangent("unknown", tangent);
+        REQUIRE_THROWS_AS(
+            output.initialize(config, geometry, viewing, atmosphere),
+            std::invalid_argument);
+    }
+
+    SECTION("VJP volume gradient") {
+        Eigen::VectorXd radiance(0);
+        Eigen::VectorXd cotangent(0);
+        Eigen::VectorXd gradient = Eigen::VectorXd::Zero(geometry.size() - 1);
+        Eigen::Map<Eigen::VectorXd> radiance_map(radiance.data(), 0);
+        Eigen::Map<const Eigen::VectorXd> cotangent_map(cotangent.data(), 0);
+        Eigen::Map<Eigen::VectorXd> gradient_map(gradient.data(),
+                                                 gradient.size());
+        sasktran2::OutputVJP<1> output(radiance_map, cotangent_map);
+        output.set_derivative_gradient_memory("volume", gradient_map);
+        REQUIRE_THROWS_AS(
+            output.initialize(config, geometry, viewing, atmosphere),
+            std::invalid_argument);
+    }
+
+    SECTION("VJP surface gradient") {
+        Eigen::VectorXd radiance(0);
+        Eigen::VectorXd cotangent(0);
+        Eigen::VectorXd gradient = Eigen::VectorXd::Zero(nwavel - 1);
+        Eigen::Map<Eigen::VectorXd> radiance_map(radiance.data(), 0);
+        Eigen::Map<const Eigen::VectorXd> cotangent_map(cotangent.data(), 0);
+        Eigen::Map<Eigen::VectorXd> gradient_map(gradient.data(),
+                                                 gradient.size());
+        sasktran2::OutputVJP<1> output(radiance_map, cotangent_map);
+        output.set_surface_gradient_memory("surface", gradient_map);
+        REQUIRE_THROWS_AS(
+            output.initialize(config, geometry, viewing, atmosphere),
+            std::invalid_argument);
+    }
+
+    SECTION("JVP radiance buffer extent") {
+        sasktran2::viewinggeometry::InternalViewingGeometry one_ray_viewing;
+        one_ray_viewing.traced_rays.emplace_back();
+        Eigen::VectorXd radiance = Eigen::VectorXd::Zero(nwavel - 1);
+        Eigen::VectorXd directional = Eigen::VectorXd::Zero(nwavel);
+        Eigen::Map<Eigen::VectorXd> radiance_map(radiance.data(),
+                                                 radiance.size());
+        Eigen::Map<Eigen::VectorXd> directional_map(directional.data(),
+                                                    directional.size());
+        sasktran2::OutputJVP<1> output(radiance_map, directional_map);
+        REQUIRE_THROWS_AS(
+            output.initialize(config, geometry, one_ray_viewing, atmosphere),
+            std::invalid_argument);
+    }
+
+    SECTION("JVP product buffer extent") {
+        sasktran2::viewinggeometry::InternalViewingGeometry one_ray_viewing;
+        one_ray_viewing.traced_rays.emplace_back();
+        Eigen::VectorXd radiance = Eigen::VectorXd::Zero(nwavel);
+        Eigen::VectorXd directional = Eigen::VectorXd::Zero(nwavel - 1);
+        Eigen::Map<Eigen::VectorXd> radiance_map(radiance.data(),
+                                                 radiance.size());
+        Eigen::Map<Eigen::VectorXd> directional_map(directional.data(),
+                                                    directional.size());
+        sasktran2::OutputJVP<1> output(radiance_map, directional_map);
+        REQUIRE_THROWS_AS(
+            output.initialize(config, geometry, one_ray_viewing, atmosphere),
+            std::invalid_argument);
+    }
+
+    SECTION("VJP radiance buffer extent") {
+        sasktran2::viewinggeometry::InternalViewingGeometry one_ray_viewing;
+        one_ray_viewing.traced_rays.emplace_back();
+        Eigen::VectorXd radiance = Eigen::VectorXd::Zero(nwavel - 1);
+        Eigen::VectorXd cotangent = Eigen::VectorXd::Zero(nwavel);
+        Eigen::Map<Eigen::VectorXd> radiance_map(radiance.data(),
+                                                 radiance.size());
+        Eigen::Map<const Eigen::VectorXd> cotangent_map(cotangent.data(),
+                                                        cotangent.size());
+        sasktran2::OutputVJP<1> output(radiance_map, cotangent_map);
+        REQUIRE_THROWS_AS(
+            output.initialize(config, geometry, one_ray_viewing, atmosphere),
+            std::invalid_argument);
+    }
+
+    SECTION("VJP cotangent buffer extent") {
+        sasktran2::viewinggeometry::InternalViewingGeometry one_ray_viewing;
+        one_ray_viewing.traced_rays.emplace_back();
+        Eigen::VectorXd radiance = Eigen::VectorXd::Zero(nwavel);
+        Eigen::VectorXd cotangent = Eigen::VectorXd::Zero(nwavel - 1);
+        Eigen::Map<Eigen::VectorXd> radiance_map(radiance.data(),
+                                                 radiance.size());
+        Eigen::Map<const Eigen::VectorXd> cotangent_map(cotangent.data(),
+                                                        cotangent.size());
+        sasktran2::OutputVJP<1> output(radiance_map, cotangent_map);
+        REQUIRE_THROWS_AS(
+            output.initialize(config, geometry, one_ray_viewing, atmosphere),
+            std::invalid_argument);
+    }
+}
+
+TEST_CASE("Native product outputs reject derivative-free atmospheres",
+          "[sasktran2][output][linearization]") {
+    sasktran2::Coordinates coordinates(0.6, 0.2, 6372000,
+                                       sasktran2::geometrytype::spherical);
+    Eigen::VectorXd altitude_values(3);
+    altitude_values << 0.0, 10000.0, 20000.0;
+    sasktran2::grids::AltitudeGrid altitude_grid(
+        std::move(altitude_values), sasktran2::grids::gridspacing::constant,
+        sasktran2::grids::outofbounds::extend,
+        sasktran2::grids::interpolation::linear);
+    sasktran2::Geometry1D geometry(std::move(coordinates),
+                                   std::move(altitude_grid));
+    sasktran2::Config config;
+    sasktran2::viewinggeometry::InternalViewingGeometry viewing;
+    sasktran2::atmosphere::Atmosphere<1> atmosphere(1, geometry, config, false);
+
+    Eigen::VectorXd radiance(0);
+    Eigen::VectorXd product(0);
+    Eigen::Map<Eigen::VectorXd> radiance_map(radiance.data(), 0);
+    Eigen::Map<Eigen::VectorXd> product_map(product.data(), 0);
+    Eigen::Map<const Eigen::VectorXd> cotangent_map(product.data(), 0);
+
+    sasktran2::OutputJVP<1> jvp_output(radiance_map, product_map);
+    REQUIRE_THROWS_AS(
+        jvp_output.initialize(config, geometry, viewing, atmosphere),
+        std::invalid_argument);
+
+    sasktran2::OutputVJP<1> vjp_output(radiance_map, cotangent_map);
+    REQUIRE_THROWS_AS(
+        vjp_output.initialize(config, geometry, viewing, atmosphere),
+        std::invalid_argument);
+}

--- a/cpp/lib/tests/sourceintegrator/test_occultation2d.cpp
+++ b/cpp/lib/tests/sourceintegrator/test_occultation2d.cpp
@@ -206,6 +206,90 @@ TEST_CASE("SourceIntegrator reports native linearization capabilities",
         sasktran2::LinearizationMode::Jacobian, unsupported_sources));
 }
 
+TEST_CASE("SourceIntegrator differentiates start-of-ray source transforms",
+          "[sourceintegrator][linearization]") {
+    class NativeTransformSource : public InteriorTestSource {
+      public:
+        bool has_interior_source() const override { return false; }
+
+        bool
+        supports_linearization(sasktran2::LinearizationMode) const override {
+            return true;
+        }
+
+        void end_of_ray_source(
+            const sasktran2::WavelengthBlock<>&, int, int, int,
+            sasktran2::WavelengthBlockDual<1>& source) const override {
+            source.value(0, 0) += 2.0;
+        }
+
+        void end_of_ray_source_jvp(
+            int, int, int, int,
+            Eigen::Ref<const Eigen::VectorXd> native_tangent,
+            sasktran2::RadianceJVP<1>& source) const override {
+            source.value[0] += 2.0;
+            source.jvp[0] += native_tangent[0];
+        }
+
+        void end_of_ray_source_vjp(
+            int, int, int, int, const Eigen::Vector<double, 1>& cotangent,
+            Eigen::Ref<Eigen::VectorXd> native_gradient) const override {
+            native_gradient[0] += cotangent[0];
+        }
+
+        void start_of_ray_source(
+            const sasktran2::WavelengthBlock<>&, int, int, int,
+            sasktran2::WavelengthBlockDual<1>& source) const override {
+            source.value(0, 0) = 3.0 * source.value(0, 0) + 4.0;
+        }
+
+        void start_of_ray_source_jvp(
+            int, int, int, int,
+            Eigen::Ref<const Eigen::VectorXd> native_tangent,
+            sasktran2::RadianceJVP<1>& source) const override {
+            const double value_before = source.value[0];
+            source.value[0] = 3.0 * value_before + 4.0;
+            source.jvp[0] =
+                3.0 * source.jvp[0] + native_tangent[1] * value_before;
+        }
+
+        void start_of_ray_source_vjp(
+            int, int, int, int, const Eigen::Vector<double, 1>& value_before,
+            Eigen::Vector<double, 1>& cotangent,
+            Eigen::Ref<Eigen::VectorXd> native_gradient) const override {
+            native_gradient[1] += cotangent[0] * value_before[0];
+            cotangent *= 3.0;
+        }
+    };
+
+    const auto geometry = geometry2d();
+    sasktran2::Config config;
+    sasktran2::atmosphere::Atmosphere<1> atmosphere(1, geometry, config, true);
+    std::vector<sasktran2::raytracing::TracedRay> rays(1);
+    sasktran2::SourceIntegrator<1> integrator(true);
+    integrator.initialize_geometry(rays, geometry);
+    integrator.initialize_thread_storage(1, 1);
+    integrator.initialize_atmosphere(atmosphere);
+
+    NativeTransformSource source;
+    std::vector<SourceTermInterface<1>*> sources = {&source};
+    Eigen::VectorXd tangent = Eigen::VectorXd::Zero(atmosphere.num_deriv());
+    tangent[0] = 5.0;
+    tangent[1] = 7.0;
+    sasktran2::RadianceJVP<1> jvp;
+    integrator.integrate_jvp(jvp, sources, 0, 0, 0, 0, tangent);
+    REQUIRE(jvp.value[0] == Catch::Approx(10.0));
+    REQUIRE(jvp.jvp[0] == Catch::Approx(29.0));
+
+    Eigen::VectorXd gradient = Eigen::VectorXd::Zero(atmosphere.num_deriv());
+    Eigen::Vector<double, 1> value;
+    integrator.integrate_vjp(value, sources, 0, 0, 0, 0,
+                             Eigen::Vector<double, 1>::Ones(), gradient);
+    REQUIRE(value[0] == Catch::Approx(10.0));
+    REQUIRE(gradient[0] == Catch::Approx(3.0));
+    REQUIRE(gradient[1] == Catch::Approx(2.0));
+}
+
 TEST_CASE("SourceIntegrator applies 2D occultation transmission and native "
           "derivatives",
           "[sourceintegrator][occultation][geometry2d]") {

--- a/cpp/lib/tests/sourceintegrator/test_occultation2d.cpp
+++ b/cpp/lib/tests/sourceintegrator/test_occultation2d.cpp
@@ -157,6 +157,14 @@ TEST_CASE("Atmosphere allocates flattened storage from Geometry2D",
 
 TEST_CASE("SourceIntegrator reports native linearization capabilities",
           "[sourceintegrator][linearization]") {
+    class NativeProductSource : public InteriorTestSource {
+      public:
+        bool
+        supports_linearization(sasktran2::LinearizationMode) const override {
+            return true;
+        }
+    };
+
     class NoJacobianSource : public InteriorTestSource {
       public:
         bool
@@ -174,6 +182,22 @@ TEST_CASE("SourceIntegrator reports native linearization capabilities",
         sasktran2::LinearizationMode::JVP, default_sources));
     REQUIRE_FALSE(integrator.supports_linearization(
         sasktran2::LinearizationMode::VJP, default_sources));
+
+    NativeProductSource native_source;
+    std::vector<SourceTermInterface<1>*> native_sources = {&native_source};
+    REQUIRE(integrator.supports_linearization(
+        sasktran2::LinearizationMode::Jacobian, native_sources));
+    REQUIRE(integrator.supports_linearization(sasktran2::LinearizationMode::JVP,
+                                              native_sources));
+    REQUIRE(integrator.supports_linearization(sasktran2::LinearizationMode::VJP,
+                                              native_sources));
+
+    std::vector<SourceTermInterface<1>*> mixed_sources = {&native_source,
+                                                          &default_source};
+    REQUIRE_FALSE(integrator.supports_linearization(
+        sasktran2::LinearizationMode::JVP, mixed_sources));
+    REQUIRE_FALSE(integrator.supports_linearization(
+        sasktran2::LinearizationMode::VJP, mixed_sources));
 
     NoJacobianSource unsupported_source;
     std::vector<SourceTermInterface<1>*> unsupported_sources = {

--- a/cpp/lib/tests/sourceintegrator/test_occultation2d.cpp
+++ b/cpp/lib/tests/sourceintegrator/test_occultation2d.cpp
@@ -206,10 +206,179 @@ TEST_CASE("SourceIntegrator reports native linearization capabilities",
         sasktran2::LinearizationMode::Jacobian, unsupported_sources));
 }
 
-TEST_CASE("SourceIntegrator differentiates start-of-ray source transforms",
+TEST_CASE("SourceIntegrator reverses every source transform",
           "[sourceintegrator][linearization]") {
     class NativeTransformSource : public InteriorTestSource {
+      private:
+        int m_derivative_start;
+        double m_end_factor;
+        double m_interior_factor;
+        double m_start_factor;
+        double m_end_offset;
+        double m_interior_offset;
+        double m_start_offset;
+
       public:
+        NativeTransformSource(int derivative_start, double end_factor,
+                              double interior_factor, double start_factor,
+                              double end_offset, double interior_offset,
+                              double start_offset)
+            : m_derivative_start(derivative_start), m_end_factor(end_factor),
+              m_interior_factor(interior_factor), m_start_factor(start_factor),
+              m_end_offset(end_offset), m_interior_offset(interior_offset),
+              m_start_offset(start_offset) {}
+
+        bool
+        supports_linearization(sasktran2::LinearizationMode) const override {
+            return true;
+        }
+
+        bool supports_geometry_dimension(int) const override { return true; }
+
+        void end_of_ray_source(
+            const sasktran2::WavelengthBlock<>&, int, int, int,
+            sasktran2::WavelengthBlockDual<1>& source) const override {
+            source.value(0, 0) =
+                m_end_factor * source.value(0, 0) + m_end_offset;
+        }
+
+        void end_of_ray_source_jvp(
+            int, int, int, int,
+            Eigen::Ref<const Eigen::VectorXd> native_tangent,
+            sasktran2::RadianceJVP<1>& source) const override {
+            source.value[0] = m_end_factor * source.value[0] + m_end_offset;
+            source.jvp[0] = m_end_factor * source.jvp[0] +
+                            native_tangent[m_derivative_start];
+        }
+
+        void end_of_ray_source_vjp(
+            int, int, int, int, const Eigen::Vector<double, 1>&,
+            Eigen::Vector<double, 1>& cotangent,
+            Eigen::Ref<Eigen::VectorXd> native_gradient) const override {
+            native_gradient[m_derivative_start] += cotangent[0];
+            cotangent *= m_end_factor;
+        }
+
+        void
+        integrated_source(const sasktran2::WavelengthBlock<>&, int, int, int,
+                          int, const sasktran2::raytracing::TracedLayer&,
+                          const sasktran2::raytracing::GridWeightStencilView&,
+                          const sasktran2::raytracing::GridWeightStencilView&,
+                          const sasktran2::WavelengthBlockODView&,
+                          sasktran2::WavelengthBlockDual<1>& source,
+                          IntegrationDirection) const override {
+            source.value(0, 0) =
+                m_interior_factor * source.value(0, 0) + m_interior_offset;
+        }
+
+        void integrated_source_jvp(
+            int, int, int, int, int, const sasktran2::raytracing::TracedLayer&,
+            const sasktran2::raytracing::GridWeightStencilView&,
+            const sasktran2::raytracing::GridWeightStencilView&,
+            const sasktran2::WavelengthBlockODView&,
+            Eigen::Ref<const Eigen::VectorXd> native_tangent,
+            sasktran2::RadianceJVP<1>& source) const override {
+            const double value_before = source.value[0];
+            source.value[0] =
+                m_interior_factor * value_before + m_interior_offset;
+            source.jvp[0] =
+                m_interior_factor * source.jvp[0] +
+                native_tangent[m_derivative_start + 1] * value_before;
+        }
+
+        void integrated_source_vjp(
+            int, int, int, int, int, const sasktran2::raytracing::TracedLayer&,
+            const sasktran2::raytracing::GridWeightStencilView&,
+            const sasktran2::raytracing::GridWeightStencilView&,
+            const sasktran2::WavelengthBlockODView&,
+            const Eigen::Vector<double, 1>& value_before,
+            Eigen::Vector<double, 1>& cotangent,
+            Eigen::Ref<Eigen::VectorXd> native_gradient) const override {
+            native_gradient[m_derivative_start + 1] +=
+                cotangent[0] * value_before[0];
+            cotangent *= m_interior_factor;
+        }
+
+        void start_of_ray_source(
+            const sasktran2::WavelengthBlock<>&, int, int, int,
+            sasktran2::WavelengthBlockDual<1>& source) const override {
+            source.value(0, 0) =
+                m_start_factor * source.value(0, 0) + m_start_offset;
+        }
+
+        void start_of_ray_source_jvp(
+            int, int, int, int,
+            Eigen::Ref<const Eigen::VectorXd> native_tangent,
+            sasktran2::RadianceJVP<1>& source) const override {
+            const double value_before = source.value[0];
+            source.value[0] = m_start_factor * value_before + m_start_offset;
+            source.jvp[0] =
+                m_start_factor * source.jvp[0] +
+                native_tangent[m_derivative_start + 2] * value_before;
+        }
+
+        void start_of_ray_source_vjp(
+            int, int, int, int, const Eigen::Vector<double, 1>& value_before,
+            Eigen::Vector<double, 1>& cotangent,
+            Eigen::Ref<Eigen::VectorXd> native_gradient) const override {
+            native_gradient[m_derivative_start + 2] +=
+                cotangent[0] * value_before[0];
+            cotangent *= m_start_factor;
+        }
+    };
+
+    const auto geometry = geometry2d();
+    sasktran2::Config config;
+    sasktran2::atmosphere::Atmosphere<1> atmosphere(1, geometry, config, true);
+    atmosphere.storage().total_extinction.setZero();
+    std::vector<sasktran2::raytracing::TracedRay> rays(1);
+    add_layer(rays[0], geometry, 0, 0, {1.0, 1.0, 1.0, 1.0});
+    sasktran2::SourceIntegrator<1> integrator(true);
+    integrator.initialize_geometry(rays, geometry);
+    integrator.initialize_thread_storage(1, 1);
+    integrator.initialize_vjp_storage(1, 2);
+    integrator.initialize_atmosphere(atmosphere);
+
+    const int source_a_derivative = atmosphere.ssa_deriv_start_index();
+    const int source_b_derivative = source_a_derivative + 3;
+    NativeTransformSource source_a(source_a_derivative, 2.0, 3.0, 5.0, 2.0, 4.0,
+                                   6.0);
+    NativeTransformSource source_b(source_b_derivative, 7.0, 11.0, 13.0, 17.0,
+                                   19.0, 23.0);
+    std::vector<SourceTermInterface<1>*> sources = {&source_a, &source_b};
+    Eigen::VectorXd tangent = Eigen::VectorXd::Zero(atmosphere.num_deriv());
+    tangent.segment<3>(source_a_derivative) << 2.0, 3.0, 5.0;
+    tangent.segment<3>(source_b_derivative) << 7.0, 11.0, 13.0;
+    sasktran2::RadianceJVP<1> jvp;
+    integrator.integrate_jvp(jvp, sources, 0, 0, 0, 0, tangent);
+    REQUIRE(jvp.value[0] == Catch::Approx(70691.0));
+    REQUIRE(jvp.jvp[0] == Catch::Approx(322153.0));
+
+    Eigen::VectorXd gradient = Eigen::VectorXd::Zero(atmosphere.num_deriv());
+    Eigen::Vector<double, 1> value;
+    integrator.integrate_vjp(value, sources, 0, 0, 0, 0,
+                             Eigen::Vector<double, 1>::Ones(), gradient);
+    REQUIRE(value[0] == Catch::Approx(70691.0));
+    REQUIRE(gradient[source_a_derivative] == Catch::Approx(15015.0));
+    REQUIRE(gradient[source_a_derivative + 1] == Catch::Approx(22165.0));
+    REQUIRE(gradient[source_a_derivative + 2] == Catch::Approx(14118.0));
+    REQUIRE(gradient[source_b_derivative] == Catch::Approx(2145.0));
+    REQUIRE(gradient[source_b_derivative + 1] == Catch::Approx(6305.0));
+    REQUIRE(gradient[source_b_derivative + 2] == Catch::Approx(5436.0));
+    REQUIRE(tangent.dot(gradient) == Catch::Approx(jvp.jvp[0]));
+}
+
+TEST_CASE("Native products skip LOS layers for direct sources",
+          "[sourceintegrator][linearization]") {
+    class NativeDirectSource : public InteriorTestSource {
+      private:
+        int m_derivative_start;
+
+      public:
+        explicit NativeDirectSource(int derivative_start)
+            : m_derivative_start(derivative_start) {}
+
+        bool requires_integration() const override { return false; }
         bool has_interior_source() const override { return false; }
 
         bool
@@ -220,21 +389,23 @@ TEST_CASE("SourceIntegrator differentiates start-of-ray source transforms",
         void end_of_ray_source(
             const sasktran2::WavelengthBlock<>&, int, int, int,
             sasktran2::WavelengthBlockDual<1>& source) const override {
-            source.value(0, 0) += 2.0;
+            source.value(0, 0) = 2.0;
         }
 
         void end_of_ray_source_jvp(
             int, int, int, int,
             Eigen::Ref<const Eigen::VectorXd> native_tangent,
             sasktran2::RadianceJVP<1>& source) const override {
-            source.value[0] += 2.0;
-            source.jvp[0] += native_tangent[0];
+            source.value[0] = 2.0;
+            source.jvp[0] = native_tangent[m_derivative_start];
         }
 
         void end_of_ray_source_vjp(
-            int, int, int, int, const Eigen::Vector<double, 1>& cotangent,
+            int, int, int, int, const Eigen::Vector<double, 1>&,
+            Eigen::Vector<double, 1>& cotangent,
             Eigen::Ref<Eigen::VectorXd> native_gradient) const override {
-            native_gradient[0] += cotangent[0];
+            native_gradient[m_derivative_start] += cotangent[0];
+            cotangent.setZero();
         }
 
         void start_of_ray_source(
@@ -250,14 +421,16 @@ TEST_CASE("SourceIntegrator differentiates start-of-ray source transforms",
             const double value_before = source.value[0];
             source.value[0] = 3.0 * value_before + 4.0;
             source.jvp[0] =
-                3.0 * source.jvp[0] + native_tangent[1] * value_before;
+                3.0 * source.jvp[0] +
+                native_tangent[m_derivative_start + 1] * value_before;
         }
 
         void start_of_ray_source_vjp(
             int, int, int, int, const Eigen::Vector<double, 1>& value_before,
             Eigen::Vector<double, 1>& cotangent,
             Eigen::Ref<Eigen::VectorXd> native_gradient) const override {
-            native_gradient[1] += cotangent[0] * value_before[0];
+            native_gradient[m_derivative_start + 1] +=
+                cotangent[0] * value_before[0];
             cotangent *= 3.0;
         }
     };
@@ -265,17 +438,22 @@ TEST_CASE("SourceIntegrator differentiates start-of-ray source transforms",
     const auto geometry = geometry2d();
     sasktran2::Config config;
     sasktran2::atmosphere::Atmosphere<1> atmosphere(1, geometry, config, true);
+    atmosphere.storage().total_extinction.setConstant(0.25);
     std::vector<sasktran2::raytracing::TracedRay> rays(1);
+    add_layer(rays[0], geometry, 0, 0, {1.0, 1.0, 1.0, 1.0});
+
     sasktran2::SourceIntegrator<1> integrator(true);
     integrator.initialize_geometry(rays, geometry);
     integrator.initialize_thread_storage(1, 1);
+    integrator.initialize_vjp_storage(1, 1);
     integrator.initialize_atmosphere(atmosphere);
 
-    NativeTransformSource source;
+    NativeDirectSource source(0);
     std::vector<SourceTermInterface<1>*> sources = {&source};
     Eigen::VectorXd tangent = Eigen::VectorXd::Zero(atmosphere.num_deriv());
     tangent[0] = 5.0;
     tangent[1] = 7.0;
+
     sasktran2::RadianceJVP<1> jvp;
     integrator.integrate_jvp(jvp, sources, 0, 0, 0, 0, tangent);
     REQUIRE(jvp.value[0] == Catch::Approx(10.0));
@@ -288,6 +466,7 @@ TEST_CASE("SourceIntegrator differentiates start-of-ray source transforms",
     REQUIRE(value[0] == Catch::Approx(10.0));
     REQUIRE(gradient[0] == Catch::Approx(3.0));
     REQUIRE(gradient[1] == Catch::Approx(2.0));
+    REQUIRE(tangent.dot(gradient) == Catch::Approx(jvp.jvp[0]));
 }
 
 TEST_CASE("SourceIntegrator applies 2D occultation transmission and native "

--- a/docs/sphinx/source/components/source_terms/singlescatter.md
+++ b/docs/sphinx/source/components/source_terms/singlescatter.md
@@ -44,6 +44,7 @@ config.single_scatter_source = sk.SingleScatterSource.NoSource
 ## Additonal Notes
 
  - All available single scatter sources are perfectly linearized, capable of producing weighting functions to machine precision
+ - The exact source has native JVP and VJP implementations; the table source currently uses the Jacobian-row contraction backend
  - All single scatter sources support polarized calculations (`nstokes=3`)
 
 ## Relevant Configuration Options

--- a/docs/sphinx/source/weighting_functions.md
+++ b/docs/sphinx/source/weighting_functions.md
@@ -90,11 +90,27 @@ The same derivatives are available as a local linear model of the radiance:
     # Propagate a scalar objective's radiance sensitivity back to every input.
     parameter_gradients = linearization.vjp(radiance_sensitivity)
 
+    # Retrievals can request only their active parameters. Unrequested
+    # derivative mappings are then excluded from the VJP calculation.
+    retrieval_gradients = linearization.vjp(
+        radiance_sensitivity,
+        parameters=("ozone_vmr",),
+    )
+
 The `linearization.value` property is the radiance at the linearization point.
 JVP and VJP operations contract the native derivative rows as they are produced,
-so they do not allocate the complete mapped Jacobian. Accessing
-`linearization.jacobian` materializes and caches one labeled block per semantic
-parameter (for example, `ozone_vmr` rather than `wf_ozone_vmr`). The
+so they do not allocate the complete mapped Jacobian.
+
+The read-only `linearization.backends` mapping reports whether each product
+uses a `LinearizationBackend.Native`, `StreamingJacobian`, or
+`MaterializedJacobian` implementation. A streaming-Jacobian product avoids
+allocating the complete mapped Jacobian, but repeats the full derivative
+propagation for every call. Iterative solvers may therefore prefer a native
+product backend, or explicitly materialize the Jacobian once when only a
+streaming backend is available.
+
+Accessing `linearization.jacobian` materializes and caches one labeled block per
+semantic parameter (for example, `ozone_vmr` rather than `wf_ozone_vmr`). The
 `tangent_template` property describes the shape, dimensions, and coordinates of
 every parameter without materializing the Jacobian. Flux and diagnostic outputs
 are not part of this interface.
@@ -107,6 +123,13 @@ after the modification. Once the revision changes, new JVPs, VJPs, and a
 first-time Jacobian materialization raise `StaleLinearizationError`; already
 cached `value` and `jacobian` objects remain readable. Create a new
 linearization to evaluate derivatives at the changed state.
+
+Trust-region solvers may need to evaluate a trial atmosphere while retaining
+the linearization at the currently accepted state. Use two distinct
+`Atmosphere` instances for these states. Linearisations backed by distinct
+atmospheres can coexist and be evaluated sequentially with the same `Engine`;
+rebuilding one atmosphere does not invalidate a linearization backed by the
+other. Concurrent calls on a shared engine are not supported.
 
 Weighting functions configured in log-radiance space are converted back to
 radiance derivatives by this interface, so `jvp`, `vjp`, and `jacobian` always

--- a/docs/sphinx/source/weighting_functions.md
+++ b/docs/sphinx/source/weighting_functions.md
@@ -98,8 +98,13 @@ The same derivatives are available as a local linear model of the radiance:
     )
 
 The `linearization.value` property is the radiance at the linearization point.
-JVP and VJP operations contract the native derivative rows as they are produced,
-so they do not allocate the complete mapped Jacobian.
+JVP and VJP operations use the most specialized backend supported by every
+active line-of-sight source. The exact single-scatter source propagates a
+direction or cotangent directly through its source and line-of-sight
+integration, applying the existing constituent derivative mappings only at the
+atmosphere boundary. Source combinations without a specialized product backend
+contract native Jacobian rows as they are produced. Neither path allocates the
+complete mapped Jacobian.
 
 The read-only `linearization.backends` mapping reports whether each product
 uses a `LinearizationBackend.Native`, `StreamingJacobian`, or

--- a/docs/sphinx/source/weighting_functions.md
+++ b/docs/sphinx/source/weighting_functions.md
@@ -114,6 +114,12 @@ propagation for every call. Iterative solvers may therefore prefer a native
 product backend, or explicitly materialize the Jacobian once when only a
 streaming backend is available.
 
+Native JVP and VJP execution currently uses the C++ product driver. It uses
+OpenMP when that support is available, even when `ThreadingLib.Rayon` is
+selected; builds without OpenMP execute native products serially. Rayon-native
+product scheduling can be added independently without changing the
+`Linearization` interface.
+
 Accessing `linearization.jacobian` materializes and caches one labeled block per
 semantic parameter (for example, `ozone_vmr` rather than `wf_ozone_vmr`). The
 `tangent_template` property describes the shape, dimensions, and coordinates of

--- a/rust/sasktran2-rs/src/bindings/engine.rs
+++ b/rust/sasktran2-rs/src/bindings/engine.rs
@@ -442,12 +442,12 @@ mod tests {
                 .unwrap()
         );
         assert!(
-            !engine
+            engine
                 .supports_linearization(LinearizationMode::Jvp)
                 .unwrap()
         );
         assert!(
-            !engine
+            engine
                 .supports_linearization(LinearizationMode::Vjp)
                 .unwrap()
         );
@@ -461,13 +461,13 @@ mod tests {
             engine
                 .linearization_backend(LinearizationMode::Jvp)
                 .unwrap(),
-            LinearizationBackend::StreamingJacobian
+            LinearizationBackend::Native
         );
         assert_eq!(
             engine
                 .linearization_backend(LinearizationMode::Vjp)
                 .unwrap(),
-            LinearizationBackend::StreamingJacobian
+            LinearizationBackend::Native
         );
     }
 

--- a/rust/sasktran2-rs/src/bindings/engine.rs
+++ b/rust/sasktran2-rs/src/bindings/engine.rs
@@ -330,11 +330,12 @@ impl<'a> Engine<'a> {
         surface_tangents: &HashMap<String, Array1<f64>>,
     ) -> Result<JvpOutput> {
         crate::threading::set_num_threads(self.config.num_threads()?)?;
-        let mut output = JvpOutput::new(
+        let mut output = JvpOutput::try_new(
             atmosphere.num_wavel(),
             self.viewing_geometry.num_rays()?,
             self.config.num_stokes()?,
-        );
+        )
+        .map_err(anyhow::Error::msg)?;
         for (name, tangent) in derivative_tangents {
             output
                 .with_derivative_tangent(name, tangent)
@@ -374,7 +375,7 @@ impl<'a> Engine<'a> {
                 expected
             ));
         }
-        let mut output = VjpOutput::new(cotangent);
+        let mut output = VjpOutput::try_new(cotangent).map_err(anyhow::Error::msg)?;
         for (name, size) in derivative_sizes {
             output
                 .with_derivative_gradient(name, *size)
@@ -412,6 +413,7 @@ mod tests {
     use super::super::geometry::InterpolationMethod;
 
     use super::*;
+    use ndarray::ShapeBuilder;
 
     #[test]
     fn test_engine() {
@@ -468,6 +470,241 @@ mod tests {
                 .linearization_backend(LinearizationMode::Vjp)
                 .unwrap(),
             LinearizationBackend::Native
+        );
+    }
+
+    #[test]
+    fn test_native_products_reject_derivative_free_atmosphere() {
+        let config = Config::new();
+        let geometry = Geometry1D::new(
+            0.5,
+            0.0,
+            6_371_000.0,
+            vec![0.0, 10_000.0, 20_000.0],
+            InterpolationMethod::Linear,
+            GeometryType::Spherical,
+        );
+        let mut viewing_geometry = ViewingGeometry::new();
+        viewing_geometry.add_ground_viewing_solar(0.5, 0.0, 100_000.0, 0.5);
+        let engine = Engine::new(&config, &geometry, &viewing_geometry).unwrap();
+        let atmosphere = Atmosphere::new(1, 3, 3, false, false, Stokes::Stokes1, None);
+
+        let derivative_tangents: HashMap<String, Array1<f64>> = HashMap::new();
+        let surface_tangents: HashMap<String, Array1<f64>> = HashMap::new();
+        assert!(
+            engine
+                .calculate_jvp(&atmosphere, &derivative_tangents, &surface_tangents)
+                .is_err()
+        );
+
+        let cotangent = Array3::zeros((1, 1, 1));
+        let derivative_sizes: HashMap<String, usize> = HashMap::new();
+        let surface_sizes: HashMap<String, usize> = HashMap::new();
+        assert!(
+            engine
+                .calculate_vjp(&atmosphere, &cotangent, &derivative_sizes, &surface_sizes)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_native_products_reject_incorrect_parameter_size() {
+        let config = Config::new();
+        let geometry = Geometry1D::new(
+            0.5,
+            0.0,
+            6_371_000.0,
+            vec![0.0, 10_000.0, 20_000.0],
+            InterpolationMethod::Linear,
+            GeometryType::Spherical,
+        );
+        let mut viewing_geometry = ViewingGeometry::new();
+        viewing_geometry.add_ground_viewing_solar(0.5, 0.0, 100_000.0, 0.5);
+        let engine = Engine::new(&config, &geometry, &viewing_geometry).unwrap();
+        let mut atmosphere = Atmosphere::new(
+            1,
+            3,
+            config.num_singlescatter_moments().unwrap(),
+            true,
+            false,
+            Stokes::Stokes1,
+            None,
+        );
+        atmosphere.storage.total_extinction.fill(1e-5);
+        atmosphere.storage.ssa.fill(0.9);
+        for location in 0..atmosphere.num_location() {
+            atmosphere.storage.leg_coeff[[0, location, 0]] = 1.0;
+        }
+        atmosphere
+            .storage
+            .get_derivative_mapping("volume")
+            .unwrap()
+            .d_extinction()
+            .fill(1.0);
+
+        let derivative_tangents = HashMap::from([(
+            "volume".to_string(),
+            Array1::zeros(atmosphere.num_location() - 1),
+        )]);
+        let surface_tangents: HashMap<String, Array1<f64>> = HashMap::new();
+        assert!(
+            engine
+                .calculate_jvp(&atmosphere, &derivative_tangents, &surface_tangents)
+                .is_err()
+        );
+
+        let cotangent = Array3::ones((1, 1, 1));
+        let derivative_sizes =
+            HashMap::from([("volume".to_string(), atmosphere.num_location() - 1)]);
+        let surface_sizes: HashMap<String, usize> = HashMap::new();
+        assert!(
+            engine
+                .calculate_vjp(&atmosphere, &cotangent, &derivative_sizes, &surface_sizes)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_native_products_accept_nonstandard_ndarray_layouts() {
+        let config = Config::new();
+        let geometry = Geometry1D::new(
+            0.5,
+            0.0,
+            6_371_000.0,
+            vec![0.0, 10_000.0, 20_000.0],
+            InterpolationMethod::Linear,
+            GeometryType::Spherical,
+        );
+        let mut viewing_geometry = ViewingGeometry::new();
+        viewing_geometry.add_ground_viewing_solar(0.5, 0.1, 100_000.0, 0.5);
+        viewing_geometry.add_tangent_altitude_solar(5_000.0, -0.2, 100_000.0, 0.5);
+        let engine = Engine::new(&config, &geometry, &viewing_geometry).unwrap();
+        let mut atmosphere = Atmosphere::new(
+            2,
+            3,
+            config.num_singlescatter_moments().unwrap(),
+            true,
+            false,
+            Stokes::Stokes1,
+            None,
+        );
+        atmosphere.storage.total_extinction.fill(1e-5);
+        atmosphere.storage.ssa.fill(0.9);
+        for wavelength in 0..atmosphere.num_wavel() {
+            for location in 0..atmosphere.num_location() {
+                atmosphere.storage.leg_coeff[[0, location, wavelength]] = 1.0;
+            }
+        }
+        let mapping = atmosphere.storage.get_derivative_mapping("volume").unwrap();
+        for ((location, wavelength), value) in mapping.d_extinction().indexed_iter_mut() {
+            *value = 0.5 + location as f64 + 0.25 * wavelength as f64;
+        }
+
+        let standard_tangent = ndarray::array![1.0, 2.0, 4.0];
+        let strided_tangent = ndarray::array![4.0, 2.0, 1.0].slice_move(ndarray::s![..;-1]);
+        assert_eq!(standard_tangent, strided_tangent);
+        assert!(!strided_tangent.is_standard_layout());
+
+        let no_surface_tangents: HashMap<String, Array1<f64>> = HashMap::new();
+        let standard_jvp = engine
+            .calculate_jvp(
+                &atmosphere,
+                &HashMap::from([("volume".to_string(), standard_tangent)]),
+                &no_surface_tangents,
+            )
+            .unwrap();
+        let strided_jvp = engine
+            .calculate_jvp(
+                &atmosphere,
+                &HashMap::from([("volume".to_string(), strided_tangent)]),
+                &no_surface_tangents,
+            )
+            .unwrap();
+        assert!(standard_jvp.jvp.iter().any(|value| value.abs() > 1e-15));
+        for (standard, strided) in standard_jvp.jvp.iter().zip(strided_jvp.jvp.iter()) {
+            assert!((standard - strided).abs() <= 1e-12 * (1.0 + standard.abs()));
+        }
+
+        let standard_cotangent = Array3::from_shape_fn((2, 2, 1), |(wavelength, los, _)| {
+            1.0 + 2.0 * wavelength as f64 + 0.5 * los as f64
+        });
+        let mut fortran_cotangent = Array3::zeros((2, 2, 1).f());
+        for ((wavelength, los, stokes), value) in fortran_cotangent.indexed_iter_mut() {
+            *value = standard_cotangent[[wavelength, los, stokes]];
+        }
+        assert_eq!(standard_cotangent, fortran_cotangent);
+        assert!(!fortran_cotangent.is_standard_layout());
+
+        let derivative_sizes = HashMap::from([("volume".to_string(), 3)]);
+        let no_surface_sizes: HashMap<String, usize> = HashMap::new();
+        let standard_vjp = engine
+            .calculate_vjp(
+                &atmosphere,
+                &standard_cotangent,
+                &derivative_sizes,
+                &no_surface_sizes,
+            )
+            .unwrap();
+        let fortran_vjp = engine
+            .calculate_vjp(
+                &atmosphere,
+                &fortran_cotangent,
+                &derivative_sizes,
+                &no_surface_sizes,
+            )
+            .unwrap();
+        let standard_gradient = &standard_vjp.derivative_gradients["volume"];
+        let fortran_gradient = &fortran_vjp.derivative_gradients["volume"];
+        assert!(standard_gradient.iter().any(|value| value.abs() > 1e-15));
+        for (standard, fortran) in standard_gradient.iter().zip(fortran_gradient.iter()) {
+            assert!((standard - fortran).abs() <= 1e-12 * (1.0 + standard.abs()));
+        }
+    }
+
+    #[test]
+    fn test_native_product_engine_rejects_stokes_mismatches() {
+        let config = Config::new();
+        let geometry = Geometry1D::new(
+            0.5,
+            0.0,
+            6_371_000.0,
+            vec![0.0, 10_000.0, 20_000.0],
+            InterpolationMethod::Linear,
+            GeometryType::Spherical,
+        );
+        let mut viewing_geometry = ViewingGeometry::new();
+        viewing_geometry.add_ground_viewing_solar(0.5, 0.0, 100_000.0, 0.5);
+        let engine = Engine::new(&config, &geometry, &viewing_geometry).unwrap();
+        let atmosphere = Atmosphere::new(1, 3, 3, true, false, Stokes::Stokes1, None);
+
+        let jvp = JvpOutput::try_new(1, 1, 3).unwrap();
+        assert_eq!(
+            unsafe {
+                ffi::sk_engine_calculate_jvp(engine.engine, atmosphere.atmosphere, jvp.output)
+            },
+            -2
+        );
+
+        let cotangent = Array3::ones((1, 1, 3));
+        let vjp = VjpOutput::try_new(&cotangent).unwrap();
+        assert_eq!(
+            unsafe {
+                ffi::sk_engine_calculate_vjp(engine.engine, atmosphere.atmosphere, vjp.output)
+            },
+            -2
+        );
+
+        let atmosphere_stokes3 = Atmosphere::new(1, 3, 3, true, false, Stokes::Stokes3, None);
+        let jvp_stokes1 = JvpOutput::try_new(1, 1, 1).unwrap();
+        assert_eq!(
+            unsafe {
+                ffi::sk_engine_calculate_jvp(
+                    engine.engine,
+                    atmosphere_stokes3.atmosphere,
+                    jvp_stokes1.output,
+                )
+            },
+            -2
         );
     }
 

--- a/rust/sasktran2-rs/src/bindings/output.rs
+++ b/rust/sasktran2-rs/src/bindings/output.rs
@@ -12,21 +12,41 @@ pub struct JvpOutput {
 
 impl JvpOutput {
     pub fn new(num_wavel: usize, num_los: usize, num_stokes: usize) -> Self {
+        Self::try_new(num_wavel, num_los, num_stokes).expect("Failed to create native JVP output")
+    }
+
+    pub fn try_new(num_wavel: usize, num_los: usize, num_stokes: usize) -> Result<Self, String> {
+        let num_radiance = num_wavel
+            .checked_mul(num_los)
+            .ok_or_else(|| "JVP output dimensions overflow usize".to_string())?;
+        let num_values = num_radiance
+            .checked_mul(num_stokes)
+            .ok_or_else(|| "JVP output dimensions overflow usize".to_string())?;
+        i32::try_from(num_values)
+            .map_err(|_| "JVP output size exceeds the C API limit".to_string())?;
+        let num_radiance_c = i32::try_from(num_radiance)
+            .map_err(|_| "JVP output dimensions exceed the C API limit".to_string())?;
+        let num_stokes_c = i32::try_from(num_stokes)
+            .map_err(|_| "JVP Stokes dimension exceeds the C API limit".to_string())?;
+
         let mut radiance = Array3::<f64>::zeros((num_wavel, num_los, num_stokes));
         let mut jvp = Array3::<f64>::zeros((num_wavel, num_los, num_stokes));
         let output = unsafe {
             ffi::sk_output_jvp_create(
                 radiance.as_mut_ptr(),
                 jvp.as_mut_ptr(),
-                (num_wavel * num_los) as i32,
-                num_stokes as i32,
+                num_radiance_c,
+                num_stokes_c,
             )
         };
-        Self {
+        if output.is_null() {
+            return Err("Failed to create native JVP output".to_string());
+        }
+        Ok(Self {
             output,
             radiance,
             jvp,
-        }
+        })
     }
 
     pub fn with_derivative_tangent(
@@ -35,12 +55,17 @@ impl JvpOutput {
         tangent: &Array1<f64>,
     ) -> Result<(), String> {
         let name = CString::new(name).map_err(|err| err.to_string())?;
+        let nparam = i32::try_from(tangent.len())
+            .map_err(|_| "JVP tangent size exceeds the C API limit".to_string())?;
+        // The C API accepts a pointer to a dense vector and has no stride
+        // argument. Keep the temporary alive until C++ has copied the tangent.
+        let tangent = tangent.as_standard_layout();
         let result = unsafe {
             ffi::sk_output_jvp_assign_derivative_tangent(
                 self.output,
                 name.as_ptr(),
                 tangent.as_ptr(),
-                tangent.len() as i32,
+                nparam,
             )
         };
         if result == 0 {
@@ -56,12 +81,15 @@ impl JvpOutput {
         tangent: &Array1<f64>,
     ) -> Result<(), String> {
         let name = CString::new(name).map_err(|err| err.to_string())?;
+        let nparam = i32::try_from(tangent.len())
+            .map_err(|_| "Surface JVP tangent size exceeds the C API limit".to_string())?;
+        let tangent = tangent.as_standard_layout();
         let result = unsafe {
             ffi::sk_output_jvp_assign_surface_tangent(
                 self.output,
                 name.as_ptr(),
                 tangent.as_ptr(),
-                tangent.len() as i32,
+                nparam,
             )
         };
         if result == 0 {
@@ -88,29 +116,52 @@ pub struct VjpOutput {
 
 impl VjpOutput {
     pub fn new(cotangent: &Array3<f64>) -> Self {
-        // The C++ output holds a non-owning map for the duration of its
-        // lifetime, so keep an owned cotangent alongside it.
-        let cotangent = cotangent.to_owned();
+        Self::try_new(cotangent).expect("Failed to create native VJP output")
+    }
+
+    pub fn try_new(cotangent: &Array3<f64>) -> Result<Self, String> {
         let (num_wavel, num_los, num_stokes) = cotangent.dim();
+        let num_radiance = num_wavel
+            .checked_mul(num_los)
+            .ok_or_else(|| "VJP output dimensions overflow usize".to_string())?;
+        let num_values = num_radiance
+            .checked_mul(num_stokes)
+            .ok_or_else(|| "VJP output dimensions overflow usize".to_string())?;
+        i32::try_from(num_values)
+            .map_err(|_| "VJP output size exceeds the C API limit".to_string())?;
+        let num_radiance_c = i32::try_from(num_radiance)
+            .map_err(|_| "VJP output dimensions exceed the C API limit".to_string())?;
+        let num_stokes_c = i32::try_from(num_stokes)
+            .map_err(|_| "VJP Stokes dimension exceeds the C API limit".to_string())?;
+
+        // The C++ output holds a non-owning map for the duration of its
+        // lifetime and assumes standard ndarray order, so normalize the
+        // layout and keep the owned cotangent alongside it.
+        let cotangent = cotangent.as_standard_layout().into_owned();
         let mut radiance = Array3::<f64>::zeros(cotangent.raw_dim());
         let output = unsafe {
             ffi::sk_output_vjp_create(
                 radiance.as_mut_ptr(),
                 cotangent.as_ptr(),
-                (num_wavel * num_los) as i32,
-                num_stokes as i32,
+                num_radiance_c,
+                num_stokes_c,
             )
         };
-        Self {
+        if output.is_null() {
+            return Err("Failed to create native VJP output".to_string());
+        }
+        Ok(Self {
             output,
             radiance,
             derivative_gradients: HashMap::new(),
             surface_gradients: HashMap::new(),
             _cotangent: cotangent,
-        }
+        })
     }
 
     pub fn with_derivative_gradient(&mut self, name: &str, size: usize) -> Result<(), String> {
+        let size_c = i32::try_from(size)
+            .map_err(|_| "VJP gradient size exceeds the C API limit".to_string())?;
         self.derivative_gradients
             .insert(name.to_string(), Array1::zeros(size));
         let gradient = self.derivative_gradients.get_mut(name).unwrap();
@@ -120,7 +171,7 @@ impl VjpOutput {
                 self.output,
                 name_c.as_ptr(),
                 gradient.as_mut_ptr(),
-                size as i32,
+                size_c,
             )
         };
         if result == 0 {
@@ -131,6 +182,8 @@ impl VjpOutput {
     }
 
     pub fn with_surface_gradient(&mut self, name: &str, size: usize) -> Result<(), String> {
+        let size_c = i32::try_from(size)
+            .map_err(|_| "Surface VJP gradient size exceeds the C API limit".to_string())?;
         self.surface_gradients
             .insert(name.to_string(), Array1::zeros(size));
         let gradient = self.surface_gradients.get_mut(name).unwrap();
@@ -140,7 +193,7 @@ impl VjpOutput {
                 self.output,
                 name_c.as_ptr(),
                 gradient.as_mut_ptr(),
-                size as i32,
+                size_c,
             )
         };
         if result == 0 {
@@ -386,5 +439,87 @@ mod tests {
     fn test_output_dimensions() {
         let output = Output::new(5, 8, 0, 2, 2);
         assert_eq!(output.radiance.shape(), &[5, 8, 2]);
+    }
+
+    #[test]
+    fn native_product_output_constructors_reject_invalid_descriptors() {
+        let mut radiance = [0.0];
+        let mut product = [0.0];
+
+        unsafe {
+            assert!(
+                ffi::sk_output_jvp_create(std::ptr::null_mut(), product.as_mut_ptr(), 1, 1,)
+                    .is_null()
+            );
+            assert!(
+                ffi::sk_output_jvp_create(radiance.as_mut_ptr(), product.as_mut_ptr(), -1, 1,)
+                    .is_null()
+            );
+            assert!(
+                ffi::sk_output_jvp_create(radiance.as_mut_ptr(), product.as_mut_ptr(), 1, 2,)
+                    .is_null()
+            );
+            assert!(
+                ffi::sk_output_vjp_create(radiance.as_mut_ptr(), product.as_ptr(), i32::MAX, 3,)
+                    .is_null()
+            );
+        }
+
+        assert!(JvpOutput::try_new(1, 1, 2).is_err());
+        assert!(JvpOutput::try_new(i32::MAX as usize, 1, 3).is_err());
+        assert!(VjpOutput::try_new(&Array3::zeros((1, 1, 2))).is_err());
+    }
+
+    #[test]
+    fn native_product_registration_rejects_null_inputs() {
+        let mut radiance = [0.0];
+        let mut product = [0.0];
+        let name = CString::new("parameter").unwrap();
+
+        unsafe {
+            let jvp = ffi::sk_output_jvp_create(radiance.as_mut_ptr(), product.as_mut_ptr(), 1, 1);
+            assert!(!jvp.is_null());
+            assert_eq!(
+                ffi::sk_output_jvp_assign_derivative_tangent(
+                    jvp,
+                    std::ptr::null(),
+                    product.as_ptr(),
+                    1,
+                ),
+                -1
+            );
+            assert_eq!(
+                ffi::sk_output_jvp_assign_derivative_tangent(
+                    jvp,
+                    name.as_ptr(),
+                    std::ptr::null(),
+                    1,
+                ),
+                -1
+            );
+            ffi::sk_output_jvp_destroy(jvp);
+
+            let vjp = ffi::sk_output_vjp_create(radiance.as_mut_ptr(), product.as_ptr(), 1, 1);
+            assert!(!vjp.is_null());
+            assert_eq!(
+                ffi::sk_output_vjp_assign_derivative_gradient(
+                    vjp,
+                    std::ptr::null(),
+                    product.as_mut_ptr(),
+                    1,
+                ),
+                -1
+            );
+            assert_eq!(
+                ffi::sk_output_vjp_assign_derivative_gradient(
+                    vjp,
+                    name.as_ptr(),
+                    std::ptr::null_mut(),
+                    1,
+                ),
+                -1
+            );
+            ffi::sk_output_vjp_destroy(vjp);
+        }
     }
 }

--- a/src/sasktran2/__init__.py
+++ b/src/sasktran2/__init__.py
@@ -42,7 +42,11 @@ from .config import Config
 from .engine import Engine
 from .geodetic import WGS84, Geodetic, SphericalGeoid
 from .geometry import Geometry1D, Geometry2D
-from .linearization import Linearization, StaleLinearizationError
+from .linearization import (
+    Linearization,
+    LinearizationBackend,
+    StaleLinearizationError,
+)
 from .viewinggeo.wrappers import (
     FluxObserverSolar,
     GroundViewingSolar,

--- a/src/sasktran2/engine.py
+++ b/src/sasktran2/engine.py
@@ -154,9 +154,10 @@ class Engine:
     def linearize(self, atmosphere: sk.Atmosphere) -> Linearization:
         """Construct the local linear radiance model for an atmosphere.
 
-        JVP and VJP operations stream contractions through the native output
-        path without allocating the complete structured radiance Jacobian.
-        The Jacobian is calculated and cached only if requested.
+        JVP and VJP operations use the most specialized backend supported by
+        all active line-of-sight sources. They do not allocate the complete
+        structured radiance Jacobian. The Jacobian is calculated and cached
+        only if requested.
 
         Parameters
         ----------

--- a/src/sasktran2/engine.py
+++ b/src/sasktran2/engine.py
@@ -9,6 +9,7 @@ import sasktran2 as sk
 from sasktran2._core_rust import PyEngine
 from sasktran2.linearization import (
     Linearization,
+    LinearizationBackend,
     _ParameterSpec,
     _semantic_parameter_name,
 )
@@ -184,6 +185,14 @@ class Engine:
         initial_output = self._engine._calculate_jvp(native_atmosphere, {}, {})
         value = self._radiance_dataarray(initial_output.radiance, atmosphere)
         registry = self._linearization_registry(atmosphere)
+        backend_names = {
+            1: LinearizationBackend.StreamingJacobian,
+            2: LinearizationBackend.Native,
+        }
+        backends = {
+            mode: backend_names[self._engine._linearization_backend(mode_index)]
+            for mode, mode_index in (("jvp", 1), ("vjp", 2))
+        }
 
         def load_jacobian() -> xr.Dataset:
             result, _ = self._calculate_radiance(
@@ -225,24 +234,37 @@ class Engine:
             )
             return self._radiance_dataarray(output.jvp, atmosphere)
 
-        def evaluate_vjp(cotangent: xr.DataArray) -> xr.Dataset:
+        def evaluate_vjp(
+            cotangent: xr.DataArray, parameters: tuple[str, ...]
+        ) -> xr.Dataset:
+            if not parameters:
+                return xr.Dataset()
+            volume_sizes = {
+                name: registry.volume_sizes[name]
+                for parameter in parameters
+                for name in registry.volume_names.get(parameter, ())
+            }
+            surface_sizes = {
+                name: registry.surface_sizes[name]
+                for parameter in parameters
+                for name in registry.surface_names.get(parameter, ())
+            }
             output = self._engine._calculate_vjp(
                 native_atmosphere,
                 np.ascontiguousarray(cotangent.values, dtype=np.float64),
-                registry.volume_sizes,
-                registry.surface_sizes,
+                volume_sizes,
+                surface_sizes,
             )
             gradients = {
                 parameter: xr.zeros_like(registry.tangent_template[parameter])
-                for parameter in registry.specs
+                for parameter in parameters
             }
-            for parameter, names in registry.volume_names.items():
-                for name in names:
+            for parameter in parameters:
+                for name in registry.volume_names.get(parameter, ()):
                     gradients[parameter].data += np.asarray(
                         output.derivative_gradients[name]
                     ).reshape(gradients[parameter].shape)
-            for parameter, names in registry.surface_names.items():
-                for name in names:
+                for name in registry.surface_names.get(parameter, ()):
                     gradients[parameter].data += np.asarray(
                         output.surface_gradients[name]
                     ).reshape(gradients[parameter].shape)
@@ -257,6 +279,7 @@ class Engine:
             load_jacobian,
             evaluate_jvp,
             evaluate_vjp,
+            backends,
             (self, native_atmosphere),
         )
 

--- a/src/sasktran2/engine.py
+++ b/src/sasktran2/engine.py
@@ -192,6 +192,18 @@ class Engine:
             jacobian: dict[str, xr.DataArray] = {}
             for parameter, output_name in registry.output_names.items():
                 block = result[output_name]
+                if not registry.specs[parameter].parameter_dims:
+                    scalar_dims = tuple(
+                        dim for dim in block.dims if dim not in value.dims
+                    )
+                    for dim in scalar_dims:
+                        if block.sizes[dim] != 1:
+                            msg = (
+                                f"Scalar parameter {parameter!r} has a non-scalar "
+                                f"Jacobian dimension {dim!r}"
+                            )
+                            raise ValueError(msg)
+                        block = block.isel({dim: 0}, drop=True)
                 if parameter in registry.log_parameters:
                     block = block * result["radiance"]
                 jacobian[parameter] = block
@@ -201,7 +213,9 @@ class Engine:
             volume_tangents: dict[str, np.ndarray] = {}
             surface_tangents: dict[str, np.ndarray] = {}
             for parameter in tangent.data_vars:
-                values = np.ascontiguousarray(tangent[parameter].values).reshape(-1)
+                values = np.ascontiguousarray(
+                    tangent[parameter].values, dtype=np.float64
+                ).reshape(-1)
                 for name in registry.volume_names.get(parameter, ()):
                     volume_tangents[name] = values
                 for name in registry.surface_names.get(parameter, ()):
@@ -214,7 +228,7 @@ class Engine:
         def evaluate_vjp(cotangent: xr.DataArray) -> xr.Dataset:
             output = self._engine._calculate_vjp(
                 native_atmosphere,
-                np.ascontiguousarray(cotangent.values),
+                np.ascontiguousarray(cotangent.values, dtype=np.float64),
                 registry.volume_sizes,
                 registry.surface_sizes,
             )
@@ -355,7 +369,7 @@ class Engine:
             interpolator = np.asarray(mapping.interpolator)
             if interpolator.size:
                 size = int(interpolator.shape[1])
-                if mapping.interp_dim == "dummy":
+                if mapping.interp_dim == "dummy" or size == 1:
                     dims: tuple[str, ...] = ()
                     shape: tuple[int, ...] = ()
                 else:

--- a/src/sasktran2/linearization.py
+++ b/src/sasktran2/linearization.py
@@ -298,9 +298,9 @@ class _EngineBackend:
 class Linearization:
     """Radiance and its local linear model at a built atmosphere state.
 
-    Engine-created instances stream Jacobian-vector and vector-Jacobian
-    contractions through the radiative-transfer output path. The complete
-    structured Jacobian is materialized only when requested.
+    Engine-created instances evaluate Jacobian-vector and vector-Jacobian
+    products with the best backend supported by the active sources. The
+    complete structured Jacobian is materialized only when requested.
     """
 
     def __init__(self, backend: _FullJacobianBackend | _EngineBackend) -> None:

--- a/src/sasktran2/linearization.py
+++ b/src/sasktran2/linearization.py
@@ -67,8 +67,10 @@ def _validated_array(
             msg = f"{description} coordinate for dimension {dim!r} does not match"
             raise ValueError(msg)
 
-    if not np.issubdtype(array.dtype, np.number):
-        msg = f"{description} must contain numeric values; got {array.dtype}"
+    if not np.issubdtype(array.dtype, np.number) or np.issubdtype(
+        array.dtype, np.complexfloating
+    ):
+        msg = f"{description} must contain real numeric values; got {array.dtype}"
         raise ValueError(msg)
 
     return array

--- a/src/sasktran2/linearization.py
+++ b/src/sasktran2/linearization.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
+from enum import Enum
 from types import MappingProxyType
 
 import numpy as np
 import xarray as xr
+
+
+class LinearizationBackend(str, Enum):
+    """Execution strategy used for a radiance derivative product."""
+
+    Native = "native"
+    StreamingJacobian = "streaming_jacobian"
+    MaterializedJacobian = "materialized_jacobian"
 
 
 @dataclass(frozen=True)
@@ -92,6 +101,31 @@ def _parameter_template(block: xr.DataArray, spec: _ParameterSpec) -> xr.DataArr
     )
 
 
+def _selected_parameters(
+    parameters: Iterable[str] | None,
+    specs: Mapping[str, _ParameterSpec],
+) -> tuple[str, ...]:
+    if parameters is None:
+        return tuple(specs)
+    if isinstance(parameters, str):
+        parameters = (parameters,)
+
+    selected = tuple(parameters)
+    if any(not isinstance(name, str) for name in selected):
+        msg = "VJP parameter names must be strings"
+        raise TypeError(msg)
+    if len(set(selected)) != len(selected):
+        msg = "VJP parameter names must not contain duplicates"
+        raise ValueError(msg)
+
+    unknown = set(selected) - set(specs)
+    if unknown:
+        names = ", ".join(sorted(unknown))
+        msg = f"Unknown VJP parameter(s): {names}"
+        raise ValueError(msg)
+    return selected
+
+
 class _FullJacobianBackend:
     """Linearization backend that contracts a cached structured Jacobian."""
 
@@ -106,6 +140,12 @@ class _FullJacobianBackend:
         self.jacobian = jacobian
         self.specs = MappingProxyType(dict(specs))
         self.tangent_template = tangent_template
+        self.backends = MappingProxyType(
+            {
+                "jvp": LinearizationBackend.MaterializedJacobian,
+                "vjp": LinearizationBackend.MaterializedJacobian,
+            }
+        )
 
     def jvp(self, tangent: xr.Dataset) -> xr.DataArray:
         if not isinstance(tangent, xr.Dataset):
@@ -141,17 +181,23 @@ class _FullJacobianBackend:
 
         return result
 
-    def vjp(self, cotangent: xr.DataArray) -> xr.Dataset:
+    def vjp(
+        self,
+        cotangent: xr.DataArray,
+        parameters: Iterable[str] | None = None,
+    ) -> xr.Dataset:
         cotangent = _validated_array(
             cotangent,
             self.value,
             tuple(self.value.dims),
             "The VJP radiance cotangent",
         )
+        selected = _selected_parameters(parameters, self.specs)
 
         gradients: dict[str, xr.DataArray] = {}
         output_dims = tuple(self.value.dims)
-        for name, spec in self.specs.items():
+        for name in selected:
+            spec = self.specs[name]
             weighted = self.jacobian[name] * cotangent
             contraction_dims = tuple(
                 dim for dim in output_dims if dim not in spec.diagonal_dims
@@ -179,7 +225,8 @@ class _EngineBackend:
         revision: int,
         jacobian_loader: Callable[[], xr.Dataset],
         jvp_evaluator: Callable[[xr.Dataset], xr.DataArray],
-        vjp_evaluator: Callable[[xr.DataArray], xr.Dataset],
+        vjp_evaluator: Callable[[xr.DataArray, tuple[str, ...]], xr.Dataset],
+        backends: Mapping[str, LinearizationBackend],
         owner,
     ) -> None:
         self.value = value
@@ -190,6 +237,7 @@ class _EngineBackend:
         self._jacobian_loader = jacobian_loader
         self._jvp_evaluator = jvp_evaluator
         self._vjp_evaluator = vjp_evaluator
+        self.backends = MappingProxyType(dict(backends))
         self._owner = owner
         self._jacobian: xr.Dataset | None = None
 
@@ -231,15 +279,20 @@ class _EngineBackend:
         self._require_current()
         return self._jvp_evaluator(xr.Dataset(normalized))
 
-    def vjp(self, cotangent: xr.DataArray) -> xr.Dataset:
+    def vjp(
+        self,
+        cotangent: xr.DataArray,
+        parameters: Iterable[str] | None = None,
+    ) -> xr.Dataset:
         cotangent = _validated_array(
             cotangent,
             self.value,
             tuple(self.value.dims),
             "The VJP radiance cotangent",
         )
+        selected = _selected_parameters(parameters, self.specs)
         self._require_current()
-        return self._vjp_evaluator(cotangent)
+        return self._vjp_evaluator(cotangent, selected)
 
 
 class Linearization:
@@ -263,7 +316,8 @@ class Linearization:
         revision: int,
         jacobian_loader: Callable[[], xr.Dataset],
         jvp_evaluator: Callable[[xr.Dataset], xr.DataArray],
-        vjp_evaluator: Callable[[xr.DataArray], xr.Dataset],
+        vjp_evaluator: Callable[[xr.DataArray, tuple[str, ...]], xr.Dataset],
+        backends: Mapping[str, LinearizationBackend],
         owner,
     ) -> Linearization:
         if not specs:
@@ -283,6 +337,7 @@ class Linearization:
                 jacobian_loader,
                 jvp_evaluator,
                 vjp_evaluator,
+                backends,
                 owner,
             )
         )
@@ -350,6 +405,11 @@ class Linearization:
         )
 
     @property
+    def backends(self) -> Mapping[str, LinearizationBackend]:
+        """Derivative-product execution strategies selected by the engine."""
+        return self._backend.backends
+
+    @property
     def tangent_template(self) -> xr.Dataset:
         """Zero tangent containing every parameter's input grid.
 
@@ -364,6 +424,20 @@ class Linearization:
         """Apply the radiance Jacobian to one labeled tangent direction."""
         return self._backend.jvp(tangent)
 
-    def vjp(self, cotangent: xr.DataArray) -> xr.Dataset:
-        """Apply the transpose radiance Jacobian to one radiance cotangent."""
-        return self._backend.vjp(cotangent)
+    def vjp(
+        self,
+        cotangent: xr.DataArray,
+        parameters: Iterable[str] | None = None,
+    ) -> xr.Dataset:
+        """Apply the transpose radiance Jacobian to one radiance cotangent.
+
+        Parameters
+        ----------
+        cotangent
+            Labeled radiance cotangent matching :attr:`value`.
+        parameters
+            Semantic parameter names to return. By default every parameter is
+            returned. Restricting this collection also avoids evaluating
+            unrequested derivative mappings in engine-created backends.
+        """
+        return self._backend.vjp(cotangent, parameters)

--- a/tests/engine/test_geometry2d_single_scatter.py
+++ b/tests/engine/test_geometry2d_single_scatter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 import sasktran2 as sk
+import xarray as xr
 
 EARTH_RADIUS_M = 6_372_000.0
 ALTITUDES_M = np.array([0.0, 10_000.0, 30_000.0])
@@ -459,6 +460,63 @@ def test_native_2d_extinction_ssa_and_phase_derivatives_match_finite_difference(
     numeric = (perturbed.radiance - base.radiance) / phase_delta
     analytic = base.wf_leg_coeff_2[horizontal_index, altitude_index]
     np.testing.assert_allclose(numeric, analytic, rtol=2.0e-6, atol=1.0e-12)
+
+
+def test_native_2d_exact_single_scatter_jvp_vjp_match_jacobian():
+    config = single_scatter_config()
+    geometry = geometry2d(np.array([-0.6, 0.0, 0.6]))
+    atmosphere = sk.Atmosphere(
+        geometry,
+        config,
+        wavelengths_nm=np.array([500.0, 650.0]),
+    )
+    location_factor = np.arange(np.prod(geometry.shape)).reshape(geometry.shape)
+    spectral_factor = np.array([1.0, 1.15])
+    atmosphere.storage.total_extinction[:] = (
+        1.0e-6 + 0.12e-6 * location_factor.ravel()[:, np.newaxis]
+    ) * spectral_factor
+    atmosphere.storage.ssa[:] = (
+        0.45 + 0.015 * location_factor.ravel()[:, np.newaxis]
+    ) * spectral_factor
+    atmosphere.leg_coeff.a1[0] = 1.0
+    atmosphere.leg_coeff.a1[2] = (
+        0.2 + 0.01 * location_factor.ravel()[:, np.newaxis]
+    ) * spectral_factor
+
+    engine = sk.Engine(config, geometry, parity_viewing())
+    lin = engine.linearize(atmosphere)
+    assert engine._engine._linearization_backend(1) == 2
+    assert engine._engine._linearization_backend(2) == 2
+
+    names = ["extinction", "ssa", "leg_coeff_2"]
+    tangent = lin.tangent_template[names]
+    for index, name in enumerate(names, start=1):
+        tangent[name].data[:] = np.linspace(
+            -0.2 * index,
+            0.3 * index,
+            tangent[name].size,
+        ).reshape(tangent[name].shape)
+
+    native_jvp = lin.jvp(tangent)
+    cotangent = xr.ones_like(lin.value)
+    cotangent.data[:] = np.linspace(-0.4, 0.7, cotangent.size).reshape(cotangent.shape)
+    native_vjp = lin.vjp(cotangent)
+    assert lin._backend._jacobian is None
+
+    expected_jvp = xr.zeros_like(lin.value)
+    for name in names:
+        expected_jvp += (lin.jacobian[name] * tangent[name]).sum(
+            lin.parameter_dims[name]
+        )
+        xr.testing.assert_allclose(
+            native_vjp[name],
+            (lin.jacobian[name] * cotangent).sum(lin.value.dims),
+        )
+    xr.testing.assert_allclose(native_jvp, expected_jvp)
+
+    lhs = float((native_jvp * cotangent).sum())
+    rhs = sum(float((tangent[name] * native_vjp[name]).sum()) for name in names)
+    np.testing.assert_allclose(lhs, rhs)
 
 
 def test_native_2d_polarized_phase_derivative_matches_finite_difference():

--- a/tests/engine/test_geometry2d_single_scatter.py
+++ b/tests/engine/test_geometry2d_single_scatter.py
@@ -464,14 +464,16 @@ def test_native_2d_extinction_ssa_and_phase_derivatives_match_finite_difference(
 
 def test_native_2d_exact_single_scatter_jvp_vjp_match_jacobian():
     config = single_scatter_config()
+    config.wavelength_batch_size = 3
     geometry = geometry2d(np.array([-0.6, 0.0, 0.6]))
+    wavelengths = np.linspace(500.0, 700.0, 5)
     atmosphere = sk.Atmosphere(
         geometry,
         config,
-        wavelengths_nm=np.array([500.0, 650.0]),
+        wavelengths_nm=wavelengths,
     )
     location_factor = np.arange(np.prod(geometry.shape)).reshape(geometry.shape)
-    spectral_factor = np.array([1.0, 1.15])
+    spectral_factor = np.linspace(0.9, 1.2, wavelengths.size)
     atmosphere.storage.total_extinction[:] = (
         1.0e-6 + 0.12e-6 * location_factor.ravel()[:, np.newaxis]
     ) * spectral_factor

--- a/tests/engine/test_linearization.py
+++ b/tests/engine/test_linearization.py
@@ -171,6 +171,39 @@ def test_jvp_validation_and_omitted_parameters():
         )
 
 
+@pytest.mark.parametrize("dtype", [np.int64, np.float32])
+def test_engine_products_accept_real_numeric_dtypes(dtype):
+    engine, atmosphere = _raw_engine_scenario()
+    lin = engine.linearize(atmosphere)
+
+    tangent = xr.Dataset(
+        {
+            "extinction": xr.DataArray(
+                np.ones(atmosphere.num_locations, dtype=dtype),
+                dims="altitude",
+                coords={"altitude": lin.tangent_template.altitude},
+            )
+        }
+    )
+    expected_jvp = lin.jacobian["extinction"].sum("altitude")
+    xr.testing.assert_allclose(lin.jvp(tangent), expected_jvp)
+
+    cotangent = xr.ones_like(lin.value).astype(dtype)
+    expected_vjp = (lin.jacobian["extinction"] * cotangent).sum(lin.value.dims)
+    xr.testing.assert_allclose(lin.vjp(cotangent)["extinction"], expected_vjp)
+
+
+def test_engine_products_reject_complex_inputs():
+    engine, atmosphere = _raw_engine_scenario()
+    lin = engine.linearize(atmosphere)
+    tangent = lin.tangent_template[["extinction"]].astype(np.complex128)
+
+    with pytest.raises(ValueError, match="real numeric"):
+        lin.jvp(tangent)
+    with pytest.raises(ValueError, match="real numeric"):
+        lin.vjp(xr.ones_like(lin.value).astype(np.complex128))
+
+
 def _raw_engine_scenario(*, calculate_derivatives: bool = True):
     config = sk.Config()
     config.single_scatter_source = sk.SingleScatterSource.Exact
@@ -264,6 +297,17 @@ def test_streaming_products_cover_surface_parameterizations(surface):
     cotangent = xr.ones_like(lin.value) * 0.7
     expected_vjp = (lin.jacobian[name] * cotangent).sum(lin.value.dims)
     xr.testing.assert_allclose(lin.vjp(cotangent)[name], expected_vjp)
+
+
+def test_constant_surface_parameter_has_scalar_domain():
+    engine, atmosphere = _constituent_engine_scenario(
+        sk.constituent.LambertianSurface(0.3)
+    )
+    lin = engine.linearize(atmosphere)
+
+    assert lin.parameter_dims["surface_albedo"] == ()
+    assert lin.tangent_template["surface_albedo"].dims == ()
+    assert lin.jacobian["surface_albedo"].dims == lin.value.dims
 
 
 def test_streaming_products_apply_polarized_output_rotation():

--- a/tests/engine/test_linearization.py
+++ b/tests/engine/test_linearization.py
@@ -295,14 +295,14 @@ def test_engine_linearize_matches_weighting_function_output():
     lin = engine.linearize(atmosphere)
 
     assert engine._engine._supports_linearization(0)
-    assert not engine._engine._supports_linearization(1)
-    assert not engine._engine._supports_linearization(2)
+    assert engine._engine._supports_linearization(1)
+    assert engine._engine._supports_linearization(2)
     assert engine._engine._linearization_backend(0) == 2
-    assert engine._engine._linearization_backend(1) == 1
-    assert engine._engine._linearization_backend(2) == 1
+    assert engine._engine._linearization_backend(1) == 2
+    assert engine._engine._linearization_backend(2) == 2
     assert lin.backends == {
-        "jvp": sk.LinearizationBackend.StreamingJacobian,
-        "vjp": sk.LinearizationBackend.StreamingJacobian,
+        "jvp": sk.LinearizationBackend.Native,
+        "vjp": sk.LinearizationBackend.Native,
     }
     xr.testing.assert_allclose(lin.value, expected["radiance"])
     xr.testing.assert_allclose(lin.jacobian["extinction"], expected["wf_extinction"])
@@ -320,7 +320,7 @@ def test_engine_linearize_matches_weighting_function_output():
         sk.constituent.LambertianSurface([0.2, 0.3, 0.4]),
     ],
 )
-def test_streaming_products_cover_surface_parameterizations(surface):
+def test_native_products_cover_surface_parameterizations(surface):
     engine, atmosphere = _constituent_engine_scenario(surface)
     lin = engine.linearize(atmosphere)
     name = "surface_albedo"
@@ -350,7 +350,7 @@ def test_constant_surface_parameter_has_scalar_domain():
     assert lin.jacobian["surface_albedo"].dims == lin.value.dims
 
 
-def test_streaming_products_apply_polarized_output_rotation():
+def test_native_products_apply_polarized_output_rotation():
     engine, atmosphere = _constituent_engine_scenario(
         sk.constituent.LambertianSurface([0.2, 0.3, 0.4]), num_stokes=3
     )
@@ -383,7 +383,7 @@ def test_constituent_rebuild_invalidates_linearization():
         lin.jvp(lin.tangent_template[["surface_albedo"]])
 
 
-def test_assign_name_parameter_mapping_streams_products():
+def test_native_products_apply_assign_name_parameter_mapping():
     engine, atmosphere = _constituent_engine_scenario(
         sk.constituent.LambertianSurface(0.3)
     )
@@ -487,7 +487,7 @@ def test_log_radiance_mapping_is_converted_for_linearization():
     )
 
 
-def test_engine_streaming_products_match_materialized_jacobian():
+def test_engine_native_products_match_materialized_jacobian():
     engine, atmosphere = _raw_engine_scenario()
     lin = engine.linearize(atmosphere)
 
@@ -562,7 +562,7 @@ def test_distinct_atmosphere_linearisations_coexist_on_one_engine():
     xr.testing.assert_allclose(gradient_a["surface_albedo"], expected_gradient_a)
 
 
-def test_streaming_products_do_not_materialize_jacobian():
+def test_native_products_do_not_materialize_jacobian():
     engine, atmosphere = _raw_engine_scenario()
     lin = engine.linearize(atmosphere)
     assert lin._backend._jacobian is None

--- a/tests/engine/test_linearization.py
+++ b/tests/engine/test_linearization.py
@@ -60,6 +60,10 @@ def test_structured_jvp_vjp_and_adjoint_identity():
     lin = _synthetic_linearization()
     assert lin.parameters == ("profile", "surface", "scalar", "structured")
     assert lin.parameter_dims["surface"] == ("wavelength",)
+    assert lin.backends == {
+        "jvp": sk.LinearizationBackend.MaterializedJacobian,
+        "vjp": sk.LinearizationBackend.MaterializedJacobian,
+    }
 
     tangent = xr.Dataset(
         {
@@ -117,6 +121,36 @@ def test_structured_jvp_vjp_and_adjoint_identity():
     lhs = float((lin.jvp(tangent) * cotangent).sum())
     rhs = sum(float((tangent[name] * gradient[name]).sum()) for name in tangent)
     np.testing.assert_allclose(lhs, rhs)
+
+
+def test_vjp_can_select_parameters():
+    lin = _synthetic_linearization()
+    cotangent = xr.ones_like(lin.value)
+
+    selected = lin.vjp(cotangent, parameters=("structured", "scalar"))
+
+    assert tuple(selected.data_vars) == ("structured", "scalar")
+    xr.testing.assert_allclose(
+        selected["structured"],
+        (lin.jacobian["structured"] * cotangent).sum(lin.value.dims),
+    )
+    xr.testing.assert_allclose(
+        selected["scalar"],
+        (lin.jacobian["scalar"] * cotangent).sum(lin.value.dims),
+    )
+    assert len(lin.vjp(cotangent, parameters=()).data_vars) == 0
+
+
+def test_vjp_rejects_invalid_parameter_selection():
+    lin = _synthetic_linearization()
+    cotangent = xr.ones_like(lin.value)
+
+    with pytest.raises(ValueError, match="Unknown VJP parameter"):
+        lin.vjp(cotangent, parameters=("missing",))
+    with pytest.raises(ValueError, match="must not contain duplicates"):
+        lin.vjp(cotangent, parameters=("profile", "profile"))
+    with pytest.raises(TypeError, match="must be strings"):
+        lin.vjp(cotangent, parameters=("profile", 1))
 
 
 def test_tangent_template_describes_parameter_domain():
@@ -266,6 +300,10 @@ def test_engine_linearize_matches_weighting_function_output():
     assert engine._engine._linearization_backend(0) == 2
     assert engine._engine._linearization_backend(1) == 1
     assert engine._engine._linearization_backend(2) == 1
+    assert lin.backends == {
+        "jvp": sk.LinearizationBackend.StreamingJacobian,
+        "vjp": sk.LinearizationBackend.StreamingJacobian,
+    }
     xr.testing.assert_allclose(lin.value, expected["radiance"])
     xr.testing.assert_allclose(lin.jacobian["extinction"], expected["wf_extinction"])
     xr.testing.assert_allclose(lin.jacobian["ssa"], expected["wf_ssa"])
@@ -296,7 +334,9 @@ def test_streaming_products_cover_surface_parameterizations(surface):
 
     cotangent = xr.ones_like(lin.value) * 0.7
     expected_vjp = (lin.jacobian[name] * cotangent).sum(lin.value.dims)
-    xr.testing.assert_allclose(lin.vjp(cotangent)[name], expected_vjp)
+    gradient = lin.vjp(cotangent, parameters=(name,))
+    assert tuple(gradient.data_vars) == (name,)
+    xr.testing.assert_allclose(gradient[name], expected_vjp)
 
 
 def test_constant_surface_parameter_has_scalar_domain():
@@ -387,7 +427,17 @@ def test_scalar_surface_emission_products():
         np.full((7, 2), 1.0e-5), np.zeros((7, 2))
     )
     atmosphere["surface"] = sk.constituent.SurfaceThermalEmission(290.0, 0.8)
-    lin = sk.Engine(config, geometry, viewing).linearize(atmosphere)
+    engine = sk.Engine(config, geometry, viewing)
+    lin = engine.linearize(atmosphere)
+
+    assert not engine._engine._supports_linearization(1)
+    assert not engine._engine._supports_linearization(2)
+    assert engine._engine._linearization_backend(1) == 1
+    assert engine._engine._linearization_backend(2) == 1
+    assert lin.backends == {
+        "jvp": sk.LinearizationBackend.StreamingJacobian,
+        "vjp": sk.LinearizationBackend.StreamingJacobian,
+    }
 
     assert lin.parameter_dims["surface_temperature_k"] == ()
     assert lin.parameter_dims["surface_emissivity"] == ()
@@ -409,6 +459,12 @@ def test_scalar_surface_emission_products():
         xr.testing.assert_allclose(
             gradient[name], (lin.jacobian[name] * cotangent).sum(lin.value.dims)
         )
+    selected_gradient = lin.vjp(cotangent, parameters=("surface_temperature_k",))
+    assert tuple(selected_gradient.data_vars) == ("surface_temperature_k",)
+    xr.testing.assert_allclose(
+        selected_gradient["surface_temperature_k"],
+        gradient["surface_temperature_k"],
+    )
 
 
 def test_log_radiance_mapping_is_converted_for_linearization():
@@ -470,6 +526,40 @@ def test_engine_streaming_products_match_materialized_jacobian():
     lhs = float((lin.jvp(tangent) * cotangent).sum())
     rhs = sum(float((tangent[name] * gradient[name]).sum()) for name in tangent)
     np.testing.assert_allclose(lhs, rhs)
+
+
+def test_distinct_atmosphere_linearisations_coexist_on_one_engine():
+    engine, atmosphere_a = _constituent_engine_scenario(
+        sk.constituent.LambertianSurface(0.2)
+    )
+    _, atmosphere_b = _constituent_engine_scenario(
+        sk.constituent.LambertianSurface(0.6)
+    )
+
+    linearization_a = engine.linearize(atmosphere_a)
+    tangent_a = linearization_a.tangent_template[["surface_albedo"]]
+    tangent_a["surface_albedo"].data[...] = 0.4
+    expected_a = (
+        linearization_a.jacobian["surface_albedo"] * tangent_a["surface_albedo"]
+    )
+
+    linearization_b = engine.linearize(atmosphere_b)
+    tangent_b = linearization_b.tangent_template[["surface_albedo"]]
+    tangent_b["surface_albedo"].data[...] = -0.3
+    expected_b = (
+        linearization_b.jacobian["surface_albedo"] * tangent_b["surface_albedo"]
+    )
+
+    assert not np.allclose(linearization_a.value, linearization_b.value)
+    xr.testing.assert_allclose(linearization_a.jvp(tangent_a), expected_a)
+    xr.testing.assert_allclose(linearization_b.jvp(tangent_b), expected_b)
+
+    cotangent_a = xr.ones_like(linearization_a.value) * 0.7
+    expected_gradient_a = (
+        linearization_a.jacobian["surface_albedo"] * cotangent_a
+    ).sum(linearization_a.value.dims)
+    gradient_a = linearization_a.vjp(cotangent_a, parameters=("surface_albedo",))
+    xr.testing.assert_allclose(gradient_a["surface_albedo"], expected_gradient_a)
 
 
 def test_streaming_products_do_not_materialize_jacobian():

--- a/tests/engine/test_linearization.py
+++ b/tests/engine/test_linearization.py
@@ -238,7 +238,11 @@ def test_engine_products_reject_complex_inputs():
         lin.vjp(xr.ones_like(lin.value).astype(np.complex128))
 
 
-def _raw_engine_scenario(*, calculate_derivatives: bool = True):
+def _raw_engine_scenario(
+    *,
+    calculate_derivatives: bool = True,
+    interpolation: sk.InterpolationMethod = sk.InterpolationMethod.LinearInterpolation,
+):
     config = sk.Config()
     config.single_scatter_source = sk.SingleScatterSource.Exact
     geometry = sk.Geometry1D(
@@ -246,7 +250,7 @@ def _raw_engine_scenario(*, calculate_derivatives: bool = True):
         0.0,
         6_372_000.0,
         np.arange(0.0, 30_001.0, 5_000.0),
-        sk.InterpolationMethod.LinearInterpolation,
+        interpolation,
         sk.GeometryType.Spherical,
     )
     viewing = sk.ViewingGeometry()
@@ -560,6 +564,31 @@ def test_distinct_atmosphere_linearisations_coexist_on_one_engine():
     ).sum(linearization_a.value.dims)
     gradient_a = linearization_a.vjp(cotangent_a, parameters=("surface_albedo",))
     xr.testing.assert_allclose(gradient_a["surface_albedo"], expected_gradient_a)
+
+
+def test_native_products_match_lower_interpolation_jacobian():
+    engine, atmosphere = _raw_engine_scenario(
+        interpolation=sk.InterpolationMethod.LowerInterpolation
+    )
+    expected = engine.calculate_radiance(atmosphere)
+    lin = engine.linearize(atmosphere)
+    xr.testing.assert_allclose(lin.value, expected["radiance"])
+
+    tangent = lin.tangent_template[["extinction", "ssa"]]
+    tangent["extinction"].data[:] = np.linspace(0.2, 0.8, 7)
+    tangent["ssa"].data[:] = np.linspace(-0.3, 0.1, 7)
+    expected_jvp = (lin.jacobian["extinction"] * tangent["extinction"]).sum(
+        "altitude"
+    ) + (lin.jacobian["ssa"] * tangent["ssa"]).sum("altitude")
+    xr.testing.assert_allclose(lin.jvp(tangent), expected_jvp)
+
+    cotangent = xr.ones_like(lin.value) * 1.7
+    gradient = lin.vjp(cotangent)
+    for name in tangent:
+        xr.testing.assert_allclose(
+            gradient[name],
+            (lin.jacobian[name] * cotangent).sum(lin.value.dims),
+        )
 
 
 def test_native_products_do_not_materialize_jacobian():

--- a/tests/engine/test_threading.py
+++ b/tests/engine/test_threading.py
@@ -70,3 +70,52 @@ def test_threading(threading_lib, threading_model):
         rad_threaded["radiance"].to_numpy(),
         rtol=1e-8,
     )
+
+
+@pytest.mark.parametrize(
+    "threading_model",
+    [sk.ThreadingModel.Wavelength, sk.ThreadingModel.Source],
+)
+def test_native_linearization_threading(threading_model):
+    if not build_info.openmp_support_enabled():
+        pytest.skip("OpenMP support is not enabled in this build of sasktran2.")
+
+    config = sk.Config()
+    config.single_scatter_source = sk.SingleScatterSource.Exact
+    config.multiple_scatter_source = sk.MultipleScatterSource.NoSource
+    config.threading_lib = sk.ThreadingLib.OpenMP
+    config.threading_model = threading_model
+    geometry = sk.Geometry1D(
+        0.6,
+        0.0,
+        6_372_000.0,
+        np.arange(0.0, 30_001.0, 5_000.0),
+        sk.InterpolationMethod.LinearInterpolation,
+        sk.GeometryType.Spherical,
+    )
+    viewing = sk.ViewingGeometry()
+    for cos_viewing_zenith in [0.5, 0.65, 0.8, 0.95]:
+        viewing.add_ray(sk.GroundViewingSolar(0.6, 0.2, cos_viewing_zenith, 100_000.0))
+    atmosphere = sk.Atmosphere(
+        geometry, config, wavelengths_nm=np.array([300.0, 350.0, 400.0])
+    )
+    sk.climatology.us76.add_us76_standard_atmosphere(atmosphere)
+    atmosphere["rayleigh"] = sk.constituent.Rayleigh()
+    atmosphere["surface"] = sk.constituent.LambertianSurface(0.3)
+
+    config.num_threads = 1
+    serial = sk.Engine(config, geometry, viewing).linearize(atmosphere)
+    tangent = serial.tangent_template[["pressure_pa"]]
+    tangent["pressure_pa"].data[:] = np.linspace(0.2, 0.8, atmosphere.num_locations)
+    serial_value = serial.value.copy(deep=True)
+    serial_jvp = serial.jvp(tangent).copy(deep=True)
+    cotangent = serial.value * 0 + 0.7
+    serial_vjp = serial.vjp(cotangent)["pressure_pa"].copy(deep=True)
+
+    config.num_threads = 2
+    threaded = sk.Engine(config, geometry, viewing).linearize(atmosphere)
+    np.testing.assert_allclose(threaded.value, serial_value, rtol=1e-12)
+    np.testing.assert_allclose(threaded.jvp(tangent), serial_jvp, rtol=1e-12)
+    np.testing.assert_allclose(
+        threaded.vjp(cotangent)["pressure_pa"], serial_vjp, rtol=1e-12
+    )

--- a/tests/engine/test_threading.py
+++ b/tests/engine/test_threading.py
@@ -72,19 +72,20 @@ def test_threading(threading_lib, threading_model):
     )
 
 
-@pytest.mark.parametrize(
-    "threading_model",
-    [sk.ThreadingModel.Wavelength, sk.ThreadingModel.Source],
-)
-def test_native_linearization_threading(threading_model):
-    if not build_info.openmp_support_enabled():
+@pytest.mark.parametrize(("threading_lib", "threading_model"), testdata)
+def test_native_linearization_threading(threading_lib, threading_model):
+    if (
+        not build_info.openmp_support_enabled()
+        and threading_lib == sk.ThreadingLib.OpenMP
+    ):
         pytest.skip("OpenMP support is not enabled in this build of sasktran2.")
 
     config = sk.Config()
     config.single_scatter_source = sk.SingleScatterSource.Exact
     config.multiple_scatter_source = sk.MultipleScatterSource.NoSource
-    config.threading_lib = sk.ThreadingLib.OpenMP
+    config.threading_lib = threading_lib
     config.threading_model = threading_model
+    config.wavelength_batch_size = 3
     geometry = sk.Geometry1D(
         0.6,
         0.0,
@@ -97,7 +98,9 @@ def test_native_linearization_threading(threading_model):
     for cos_viewing_zenith in [0.5, 0.65, 0.8, 0.95]:
         viewing.add_ray(sk.GroundViewingSolar(0.6, 0.2, cos_viewing_zenith, 100_000.0))
     atmosphere = sk.Atmosphere(
-        geometry, config, wavelengths_nm=np.array([300.0, 350.0, 400.0])
+        geometry,
+        config,
+        wavelengths_nm=np.array([300.0, 325.0, 350.0, 375.0, 400.0]),
     )
     sk.climatology.us76.add_us76_standard_atmosphere(atmosphere)
     atmosphere["rayleigh"] = sk.constituent.Rayleigh()


### PR DESCRIPTION
## Summary

Implements native radiance JVP and VJP execution for the exact single-scatter source using the interface introduced in #278.

- propagates tangents through optical depth, solar transmission, phase functions, SSA, extinction, and surface terms
- backpropagates radiance cotangents directly to native atmospheric and surface derivative storage
- supports scalar and polarized calculations, including structured 2-D atmospheres
- supports filtered VJPs so inactive parameter derivative storage is excluded from the native pullback
- reports `LinearizationBackend.Native` for exact-single-scatter products while mixed or unsupported source combinations retain the streaming fallback
- preserves the full-Jacobian implementation for callers that request `linearization.jacobian`
- selects the native backend through the source/integrator capability contract

The latest update also reduces native-product overhead by batching VJP work over wavelengths, reducing repeated constituent mapping, reusing per-thread scratch storage, and avoiding unnecessary derivative work. It hardens the Rust/C boundary by normalizing strided ndarray inputs and validating pointers, sizes, Stokes types, output buffer extents, and engine/output compatibility before native writes.

This PR is stacked on #278 and targets its interface branch so this diff remains source-specific. After #278 merges, the base can be changed to `main`.

## Motivation and impact

Exact single-scatter retrievals can use `jvp()` and `vjp()` without materializing the full radiance Jacobian. This reduces product memory to the tangent/cotangent working set while retaining the same public labeled linearization interface and giving a SciPy solver enough metadata to choose its strategy.

The boundary checks prevent direct Rust or C callers from silently misinterpreting non-contiguous arrays or writing through incompatible output descriptors. Existing `calculate_radiance()` behavior remains unchanged.

## Validation

- `pixi run build`
- `.pixi/envs/default/bin/python -m pytest -q tests/engine/test_linearization.py tests/engine/test_geometry2d_single_scatter.py tests/engine/test_threading.py` (53 passed, 4 skipped because OpenMP is disabled)
- `cargo test -p sasktran2-rs`
- full C++ suite (175 test cases, 287,053 assertions)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `pixi run pre-commit`
