### PR TITLE
Optimize DISCO numerical kernels

### DIFF
--- a/cpp/include/sasktran2/config.h
+++ b/cpp/include/sasktran2/config.h
@@ -2,7 +2,16 @@
 
 #include <spdlog/spdlog.h>
 
+namespace sasktran_disco {
+    template <int NSTOKES, int CNSTR> class PersistentConfiguration;
+}
+
 namespace sasktran2 {
+
+    namespace detail {
+        enum class BandedLUBackend { lapack = 0, unblocked = 1 };
+        class RuntimeBackendTuner;
+    } // namespace detail
 
     /** User Configuration object for the SASKTRAN2 model, all values have
      * default options.
@@ -695,6 +704,19 @@ namespace sasktran2 {
         void validate_config_geometry(int geotype) const;
 
       private:
+        friend class detail::RuntimeBackendTuner;
+        template <int NSTOKES, int CNSTR>
+        friend class ::sasktran_disco::PersistentConfiguration;
+
+        struct RuntimeBackends {
+            detail::BandedLUBackend do_banded_lu =
+                detail::BandedLUBackend::lapack;
+        };
+
+        detail::BandedLUBackend do_banded_lu_backend() const {
+            return m_runtime_backends.do_banded_lu;
+        }
+
         // TODO: Refactor these into individual source configs?
 
         int m_nthreads;
@@ -740,6 +762,8 @@ namespace sasktran2 {
         ThreadingModel m_threading_model;
 
         TwoStreamBackend m_two_stream_backend;
+
+        RuntimeBackends m_runtime_backends;
 
         SingleScatterPhaseMode m_singlescatter_phasemode;
 

--- a/cpp/include/sasktran2/engine.h
+++ b/cpp/include/sasktran2/engine.h
@@ -31,7 +31,7 @@ class Sasktran2Interface {
  */
 template <int NSTOKES> class Sasktran2 : public Sasktran2Interface {
   private:
-    const sasktran2::Config& m_config; /**< Internal reference to the config */
+    sasktran2::Config m_config; /**< Engine-owned configuration snapshot */
     const sasktran2::viewinggeometry::ViewingGeometryContainer&
         m_viewing_geometry; /**< Internal reference to the viewing geometry */
     const sasktran2::Geometry*

--- a/cpp/include/sasktran2/runtime_backend_tuner.h
+++ b/cpp/include/sasktran2/runtime_backend_tuner.h
@@ -20,8 +20,7 @@ namespace sasktran2::detail {
 
         /** Inspect a resolved value in tests and diagnostic tooling without
          * exposing mutable backend policy on Config. */
-        static BandedLUBackend
-        resolved_banded_lu_backend(const Config& config);
+        static BandedLUBackend resolved_banded_lu_backend(const Config& config);
     };
 
 } // namespace sasktran2::detail

--- a/cpp/include/sasktran2/runtime_backend_tuner.h
+++ b/cpp/include/sasktran2/runtime_backend_tuner.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <sasktran2/config.h>
+
+namespace sasktran2::detail {
+
+    /** Resolves machine-dependent implementation choices once, while an
+     * engine-owned Config snapshot is being constructed. */
+    class RuntimeBackendTuner {
+      public:
+        /** Resolve all applicable runtime backends for a one-dimensional
+         * engine with the supplied number of atmospheric layers. */
+        static void resolve(Config& config, int num_layers);
+
+        /** Apply the DISCO timing policy. LAPACK wins ties and cases where the
+         * unblocked implementation is less than 10% faster. */
+        static BandedLUBackend
+        select_banded_lu_backend(double lapack_nanoseconds,
+                                 double unblocked_nanoseconds);
+
+        /** Inspect a resolved value in tests and diagnostic tooling without
+         * exposing mutable backend policy on Config. */
+        static BandedLUBackend
+        resolved_banded_lu_backend(const Config& config);
+    };
+
+} // namespace sasktran2::detail

--- a/cpp/include/sktran_disco/sktran_do_linalg.h
+++ b/cpp/include/sktran_disco/sktran_do_linalg.h
@@ -190,9 +190,13 @@ namespace sasktran_disco {
                             double* right_hand_side,
                             lapack_int right_hand_side_leading_dimension);
 
-        /** Use the unblocked factorization where it outperforms blocked LU. */
-        bool use_unblocked_band_factorization(lapack_int lower_bandwidth,
-                                              lapack_int upper_bandwidth);
+        /** Solve a general-band system with the configured LAPACK backend. */
+        int dgbsv_configured(lapack_int n, lapack_int lower_bandwidth,
+                             lapack_int upper_bandwidth,
+                             lapack_int right_hand_sides, double* matrix,
+                             lapack_int leading_dimension, lapack_int* pivots,
+                             double* right_hand_side,
+                             lapack_int right_hand_side_leading_dimension);
 
     } // namespace la
 

--- a/cpp/include/sktran_disco/sktran_do_linalg.h
+++ b/cpp/include/sktran_disco/sktran_do_linalg.h
@@ -171,6 +171,29 @@ namespace sasktran_disco {
                                 Eigen::MatrixXd& z, Eigen::VectorXd& gamma,
                                 Eigen::VectorXd& mu, bool transpose);
 
+        /**
+         * Factor a general-band matrix in LAPACK column-major storage using
+         * the unblocked DGBTF2 algorithm.
+         */
+        int dgbtf2_unblocked(lapack_int n, lapack_int lower_bandwidth,
+                             lapack_int upper_bandwidth, double* matrix,
+                             lapack_int leading_dimension, lapack_int* pivots);
+
+        /**
+         * Factor with dgbtf2_unblocked and solve with the configured LAPACK
+         * dgbtrs implementation.
+         */
+        int dgbsv_unblocked(lapack_int n, lapack_int lower_bandwidth,
+                            lapack_int upper_bandwidth,
+                            lapack_int right_hand_sides, double* matrix,
+                            lapack_int leading_dimension, lapack_int* pivots,
+                            double* right_hand_side,
+                            lapack_int right_hand_side_leading_dimension);
+
+        /** Use the unblocked factorization where it outperforms blocked LU. */
+        bool use_unblocked_band_factorization(lapack_int lower_bandwidth,
+                                              lapack_int upper_bandwidth);
+
     } // namespace la
 
     /**

--- a/cpp/include/sktran_disco/sktran_do_memory.h
+++ b/cpp/include/sktran_disco/sktran_do_memory.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <sasktran2/math/real_eigensolver.h>
 #include "sktran_disco/sktran_do.h"
 #include "sktran_disco/sktran_do_surface.h"
 
@@ -148,6 +149,7 @@ namespace sasktran_disco {
         MatrixHLHS h_lhs;
         std::vector<MatrixHRHS> h_rhs;
 
+        Eigen::RealEigenSolver<Matrix> h_eigensolver;
         Eigen::PartialPivLU<MatrixHLHS> h_partiallu;
         Eigen::FullPivLU<MatrixHLHS> h_fullpivlu;
 

--- a/cpp/include/sktran_disco/sktran_do_pconfig.h
+++ b/cpp/include/sktran_disco/sktran_do_pconfig.h
@@ -75,6 +75,11 @@ namespace sasktran_disco {
          */
         inline bool backprop_bvp() const { return this->M_BACKPROP_BVP; }
 
+        /** Resolved backend for the general-band BVP factorization. */
+        inline sasktran2::detail::BandedLUBackend banded_lu_backend() const {
+            return m_banded_lu_backend;
+        }
+
         /**
          * @brief True if we are in single scatter only debug mode
          *
@@ -133,6 +138,9 @@ namespace sasktran_disco {
 
         mutable MemoryPool<NSTOKES, CNSTR> m_pool;
         int m_poolindex;
+
+        sasktran2::detail::BandedLUBackend m_banded_lu_backend =
+            sasktran2::detail::BandedLUBackend::lapack;
 
         /**
          * @brief Legendre polynomials for the cosine of the solar zenith angle

--- a/cpp/include/sktran_disco/sktran_do_rte.h
+++ b/cpp/include/sktran_disco/sktran_do_rte.h
@@ -354,6 +354,8 @@ namespace sasktran_disco {
         // Cached memory so we don't have to realloc for every layer/azimuth
         // direction
         RTEMemoryCache<NSTOKES, CNSTR>& m_cache;
+
+        const sasktran2::detail::BandedLUBackend m_banded_lu_backend;
     };
 
 } // namespace sasktran_disco

--- a/cpp/lib/CMakeLists.txt
+++ b/cpp/lib/CMakeLists.txt
@@ -8,6 +8,7 @@ target_include_directories(
 add_library(
   sasktran2
   config/config.cpp
+  config/runtime_backend_tuner.cpp
   unitsphere/lebedev_autogen.cpp
   unitsphere/lebedev.cpp
   unitsphere/unitsphere_ground.cpp

--- a/cpp/lib/CMakeLists.txt
+++ b/cpp/lib/CMakeLists.txt
@@ -52,6 +52,7 @@ add_library(
   sktran_disco/sktran_do.cpp
   sktran_disco/sktran_do_geometrylayerarray.cpp
   sktran_disco/sktran_do_layerarray.cpp
+  sktran_disco/sktran_do_banded_lu.cpp
   sktran_disco/sktran_do_opticallayer.cpp
   sktran_disco/sktran_do_pconfig.cpp
   sktran_disco/sktran_do_pentadiagonal.cpp

--- a/cpp/lib/config/runtime_backend_tuner.cpp
+++ b/cpp/lib/config/runtime_backend_tuner.cpp
@@ -1,0 +1,273 @@
+#include "sasktran2/runtime_backend_tuner.h"
+
+#include "sktran_disco/sktran_do.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+    using Backend = sasktran2::detail::BandedLUBackend;
+    using Clock = std::chrono::steady_clock;
+
+    struct BandSystem {
+        lapack_int size;
+        lapack_int bandwidth;
+        lapack_int leading_dimension;
+        std::vector<double> matrix;
+        std::vector<double> right_hand_side;
+        std::vector<lapack_int> pivots;
+
+        BandSystem(lapack_int system_size, lapack_int system_bandwidth)
+            : size(system_size), bandwidth(system_bandwidth),
+              leading_dimension(3 * system_bandwidth + 1),
+              right_hand_side(system_size), pivots(system_size) {
+            const auto matrix_size =
+                static_cast<std::size_t>(leading_dimension) *
+                static_cast<std::size_t>(size);
+            if (size <= 0 || bandwidth < 0 ||
+                matrix_size / static_cast<std::size_t>(size) !=
+                    static_cast<std::size_t>(leading_dimension)) {
+                throw std::length_error("Invalid band benchmark dimensions");
+            }
+            matrix.resize(matrix_size);
+        }
+
+        void reset() {
+            std::fill(matrix.begin(), matrix.end(), 0.0);
+            std::uint64_t random_state = 0x243f6a8885a308d3ULL;
+            const lapack_int diagonal_row = 2 * bandwidth;
+            for (lapack_int column = 0; column < size; ++column) {
+                const lapack_int first_row =
+                    std::max<lapack_int>(0, column - bandwidth);
+                const lapack_int last_row =
+                    std::min<lapack_int>(size - 1, column + bandwidth);
+                for (lapack_int row = first_row; row <= last_row; ++row) {
+                    random_state = random_state * 6364136223846793005ULL + 1;
+                    const double random_value =
+                        static_cast<double>((random_state >> 40) & 0xffffU) /
+                            65535.0 -
+                        0.5;
+                    double value = 0.03 * random_value;
+                    if (row == column) {
+                        value += 2.5 +
+                                 0.001 * static_cast<double>(column % 101);
+                    }
+                    // Exercise the row-interchange path periodically, as the
+                    // physical BVP is not guaranteed to be diagonal dominant.
+                    if (column % 17 == 0 && column + 1 < size) {
+                        if (row == column) {
+                            value = 0.25;
+                        } else if (row == column + 1) {
+                            value = 3.0;
+                        }
+                    }
+                    const lapack_int band_row =
+                        diagonal_row + row - column;
+                    matrix[column * leading_dimension + band_row] = value;
+                }
+            }
+            for (lapack_int row = 0; row < size; ++row) {
+                right_hand_side[row] =
+                    std::sin(0.13 * static_cast<double>(row + 1));
+            }
+        }
+    };
+
+    int solve(BandSystem& system, Backend backend) {
+        if (backend == Backend::unblocked) {
+            return sasktran_disco::la::dgbsv_unblocked(
+                system.size, system.bandwidth, system.bandwidth, 1,
+                system.matrix.data(), system.leading_dimension,
+                system.pivots.data(), system.right_hand_side.data(),
+                system.size);
+        }
+        return sasktran_disco::la::dgbsv_configured(
+            system.size, system.bandwidth, system.bandwidth, 1,
+            system.matrix.data(), system.leading_dimension,
+            system.pivots.data(), system.right_hand_side.data(), system.size);
+    }
+
+    int timed_solve(BandSystem& system, Backend backend,
+                    double& elapsed_nanoseconds) {
+        system.reset();
+        const auto start = Clock::now();
+        const int info = solve(system, backend);
+        const auto stop = Clock::now();
+        elapsed_nanoseconds =
+            std::chrono::duration<double, std::nano>(stop - start).count();
+        return info;
+    }
+
+    double median(std::vector<double> values) {
+        const auto middle = values.begin() + values.size() / 2;
+        std::nth_element(values.begin(), middle, values.end());
+        return *middle;
+    }
+
+    struct BenchmarkResult {
+        double lapack_nanoseconds = 0.0;
+        double unblocked_nanoseconds = 0.0;
+        bool valid = false;
+    };
+
+    BenchmarkResult benchmark_band_solvers(lapack_int size,
+                                           lapack_int bandwidth) {
+        BandSystem system(size, bandwidth);
+
+        // Warm both implementations and use the same synthetic system as a
+        // cheap correctness check before trusting the timing result.
+        system.reset();
+        const int lapack_warm_info = solve(system, Backend::lapack);
+        const auto lapack_solution = system.right_hand_side;
+        system.reset();
+        const int unblocked_warm_info = solve(system, Backend::unblocked);
+        if (lapack_warm_info != 0 || unblocked_warm_info != lapack_warm_info) {
+            return {};
+        }
+        for (std::size_t index = 0; index < lapack_solution.size(); ++index) {
+            const double scale =
+                std::max(1.0, std::abs(lapack_solution[index]));
+            if (std::abs(system.right_hand_side[index] -
+                         lapack_solution[index]) >
+                1.0e-11 * scale) {
+                return {};
+            }
+        }
+
+        std::vector<double> lapack_times;
+        std::vector<double> unblocked_times;
+        lapack_times.reserve(7);
+        unblocked_times.reserve(7);
+
+        double lapack_time;
+        double unblocked_time;
+        if (timed_solve(system, Backend::lapack, lapack_time) != 0 ||
+            timed_solve(system, Backend::unblocked, unblocked_time) != 0) {
+            return {};
+        }
+        lapack_times.push_back(lapack_time);
+        unblocked_times.push_back(unblocked_time);
+
+        const double slower_time = std::max(lapack_time, unblocked_time);
+        const int sample_count = slower_time < 2.0e5  ? 7
+                                 : slower_time < 2.0e6 ? 5
+                                 : slower_time < 1.0e7 ? 3
+                                                       : 1;
+        for (int sample = 1; sample < sample_count; ++sample) {
+            int lapack_info;
+            int unblocked_info;
+            if (sample % 2 == 0) {
+                lapack_info =
+                    timed_solve(system, Backend::lapack, lapack_time);
+                unblocked_info =
+                    timed_solve(system, Backend::unblocked, unblocked_time);
+            } else {
+                unblocked_info =
+                    timed_solve(system, Backend::unblocked, unblocked_time);
+                lapack_info =
+                    timed_solve(system, Backend::lapack, lapack_time);
+            }
+            if (lapack_info != 0 || unblocked_info != 0) {
+                return {};
+            }
+            lapack_times.push_back(lapack_time);
+            unblocked_times.push_back(unblocked_time);
+        }
+
+        return {median(lapack_times), median(unblocked_times), true};
+    }
+
+    bool environment_requests(const char* value, const char* requested) {
+        return value != nullptr && std::strcmp(value, requested) == 0;
+    }
+} // namespace
+
+namespace sasktran2::detail {
+    BandedLUBackend RuntimeBackendTuner::select_banded_lu_backend(
+        double lapack_nanoseconds, double unblocked_nanoseconds) {
+        if (!std::isfinite(lapack_nanoseconds) ||
+            !std::isfinite(unblocked_nanoseconds) ||
+            lapack_nanoseconds <= 0.0 || unblocked_nanoseconds <= 0.0) {
+            return Backend::lapack;
+        }
+        return unblocked_nanoseconds < 0.90 * lapack_nanoseconds
+                   ? Backend::unblocked
+                   : Backend::lapack;
+    }
+
+    BandedLUBackend
+    RuntimeBackendTuner::resolved_banded_lu_backend(const Config& config) {
+        return config.m_runtime_backends.do_banded_lu;
+    }
+
+    void RuntimeBackendTuner::resolve(Config& config, int num_layers) {
+        config.m_runtime_backends.do_banded_lu = Backend::lapack;
+        if (config.multiple_scatter_source() !=
+                Config::MultipleScatterSource::discrete_ordinates ||
+            num_layers <= 0) {
+            return;
+        }
+
+        // Preserve the original opt-out while also providing a deterministic
+        // developer override for reproducing either path.
+        if (std::getenv("SASKTRAN2_DISABLE_DO_UNBLOCKED_BAND_LU") != nullptr) {
+            return;
+        }
+        const char* override_backend =
+            std::getenv("SASKTRAN2_DO_BANDED_LU_BACKEND");
+        if (environment_requests(override_backend, "lapack")) {
+            return;
+        }
+
+        const int num_stokes = config.num_stokes();
+        const int num_streams = config.num_do_streams();
+        // The scalar two-stream case uses its dedicated pentadiagonal solver.
+        if (num_stokes == 1 && num_streams == 2) {
+            return;
+        }
+        if (environment_requests(override_backend, "unblocked")) {
+            config.m_runtime_backends.do_banded_lu = Backend::unblocked;
+            return;
+        }
+
+        const auto size = static_cast<long long>(num_streams) * num_stokes *
+                          num_layers;
+        const auto bandwidth =
+            3LL * num_streams * num_stokes / 2LL - 1LL;
+        if (size <= 0 || bandwidth <= 2 ||
+            size > std::numeric_limits<lapack_int>::max() ||
+            bandwidth > std::numeric_limits<lapack_int>::max()) {
+            return;
+        }
+
+        try {
+            const auto result = benchmark_band_solvers(
+                static_cast<lapack_int>(size),
+                static_cast<lapack_int>(bandwidth));
+            if (!result.valid) {
+                return;
+            }
+            config.m_runtime_backends.do_banded_lu =
+                select_banded_lu_backend(result.lapack_nanoseconds,
+                                         result.unblocked_nanoseconds);
+            spdlog::debug(
+                "DISCO band LU autotune (N={}, bandwidth={}): LAPACK {:.1f} "
+                "us, unblocked {:.1f} us; selected {}",
+                size, bandwidth, result.lapack_nanoseconds / 1000.0,
+                result.unblocked_nanoseconds / 1000.0,
+                config.m_runtime_backends.do_banded_lu == Backend::unblocked
+                    ? "unblocked"
+                    : "LAPACK");
+        } catch (const std::exception& error) {
+            spdlog::debug("DISCO band LU autotune failed; using LAPACK: {}",
+                          error.what());
+        }
+    }
+} // namespace sasktran2::detail

--- a/cpp/lib/config/runtime_backend_tuner.cpp
+++ b/cpp/lib/config/runtime_backend_tuner.cpp
@@ -56,8 +56,8 @@ namespace {
                         0.5;
                     double value = 0.03 * random_value;
                     if (row == column) {
-                        value += 2.5 +
-                                 0.001 * static_cast<double>(column % 101);
+                        value +=
+                            2.5 + 0.001 * static_cast<double>(column % 101);
                     }
                     // Exercise the row-interchange path periodically, as the
                     // physical BVP is not guaranteed to be diagonal dominant.
@@ -68,8 +68,7 @@ namespace {
                             value = 3.0;
                         }
                     }
-                    const lapack_int band_row =
-                        diagonal_row + row - column;
+                    const lapack_int band_row = diagonal_row + row - column;
                     matrix[column * leading_dimension + band_row] = value;
                 }
             }
@@ -135,8 +134,7 @@ namespace {
             const double scale =
                 std::max(1.0, std::abs(lapack_solution[index]));
             if (std::abs(system.right_hand_side[index] -
-                         lapack_solution[index]) >
-                1.0e-11 * scale) {
+                         lapack_solution[index]) > 1.0e-11 * scale) {
                 return {};
             }
         }
@@ -156,7 +154,7 @@ namespace {
         unblocked_times.push_back(unblocked_time);
 
         const double slower_time = std::max(lapack_time, unblocked_time);
-        const int sample_count = slower_time < 2.0e5  ? 7
+        const int sample_count = slower_time < 2.0e5   ? 7
                                  : slower_time < 2.0e6 ? 5
                                  : slower_time < 1.0e7 ? 3
                                                        : 1;
@@ -164,15 +162,13 @@ namespace {
             int lapack_info;
             int unblocked_info;
             if (sample % 2 == 0) {
-                lapack_info =
-                    timed_solve(system, Backend::lapack, lapack_time);
+                lapack_info = timed_solve(system, Backend::lapack, lapack_time);
                 unblocked_info =
                     timed_solve(system, Backend::unblocked, unblocked_time);
             } else {
                 unblocked_info =
                     timed_solve(system, Backend::unblocked, unblocked_time);
-                lapack_info =
-                    timed_solve(system, Backend::lapack, lapack_time);
+                lapack_info = timed_solve(system, Backend::lapack, lapack_time);
             }
             if (lapack_info != 0 || unblocked_info != 0) {
                 return {};
@@ -237,10 +233,9 @@ namespace sasktran2::detail {
             return;
         }
 
-        const auto size = static_cast<long long>(num_streams) * num_stokes *
-                          num_layers;
-        const auto bandwidth =
-            3LL * num_streams * num_stokes / 2LL - 1LL;
+        const auto size =
+            static_cast<long long>(num_streams) * num_stokes * num_layers;
+        const auto bandwidth = 3LL * num_streams * num_stokes / 2LL - 1LL;
         if (size <= 0 || bandwidth <= 2 ||
             size > std::numeric_limits<lapack_int>::max() ||
             bandwidth > std::numeric_limits<lapack_int>::max()) {
@@ -248,15 +243,14 @@ namespace sasktran2::detail {
         }
 
         try {
-            const auto result = benchmark_band_solvers(
-                static_cast<lapack_int>(size),
-                static_cast<lapack_int>(bandwidth));
+            const auto result =
+                benchmark_band_solvers(static_cast<lapack_int>(size),
+                                       static_cast<lapack_int>(bandwidth));
             if (!result.valid) {
                 return;
             }
-            config.m_runtime_backends.do_banded_lu =
-                select_banded_lu_backend(result.lapack_nanoseconds,
-                                         result.unblocked_nanoseconds);
+            config.m_runtime_backends.do_banded_lu = select_banded_lu_backend(
+                result.lapack_nanoseconds, result.unblocked_nanoseconds);
             spdlog::debug(
                 "DISCO band LU autotune (N={}, bandwidth={}): LAPACK {:.1f} "
                 "us, unblocked {:.1f} us; selected {}",

--- a/cpp/lib/config/runtime_backend_tuner.cpp
+++ b/cpp/lib/config/runtime_backend_tuner.cpp
@@ -205,9 +205,13 @@ namespace sasktran2::detail {
 
     void RuntimeBackendTuner::resolve(Config& config, int num_layers) {
         config.m_runtime_backends.do_banded_lu = Backend::lapack;
-        if (config.multiple_scatter_source() !=
+        const auto multiple_scatter_source = config.multiple_scatter_source();
+        const bool uses_discrete_ordinates =
+            multiple_scatter_source ==
                 Config::MultipleScatterSource::discrete_ordinates ||
-            num_layers <= 0) {
+            (multiple_scatter_source == Config::MultipleScatterSource::hr &&
+             config.initialize_hr_with_do());
+        if (!uses_discrete_ordinates || num_layers <= 0) {
             return;
         }
 
@@ -221,15 +225,17 @@ namespace sasktran2::detail {
         if (environment_requests(override_backend, "lapack")) {
             return;
         }
+        if (environment_requests(override_backend, "unblocked")) {
+            config.m_runtime_backends.do_banded_lu = Backend::unblocked;
+            return;
+        }
 
         const int num_stokes = config.num_stokes();
         const int num_streams = config.num_do_streams();
-        // The scalar two-stream case uses its dedicated pentadiagonal solver.
+        // Automatic tuning is unnecessary for the common scalar two-stream
+        // path, which uses its dedicated pentadiagonal solver. The explicit
+        // override above remains available to exercise generic paths.
         if (num_stokes == 1 && num_streams == 2) {
-            return;
-        }
-        if (environment_requests(override_backend, "unblocked")) {
-            config.m_runtime_backends.do_banded_lu = Backend::unblocked;
             return;
         }
 

--- a/cpp/lib/engine/engine.cpp
+++ b/cpp/lib/engine/engine.cpp
@@ -2,6 +2,7 @@
 #include "sasktran2/do_source.h"
 #include "sasktran2/geometry.h"
 #include "sasktran2/raytracing.h"
+#include "sasktran2/runtime_backend_tuner.h"
 #include "sasktran2/source_interface.h"
 #include "sktran_disco/twostream/meta.h"
 #ifdef SKTRAN_RUST_SUPPORT
@@ -52,6 +53,11 @@ template <int NSTOKES> void Sasktran2<NSTOKES>::initialize() {
 
     m_config.validate_config_geometry(
         m_geometry->coordinates().geometry_type());
+    if (m_geometry_1d != nullptr) {
+        sasktran2::detail::RuntimeBackendTuner::resolve(
+            m_config,
+            static_cast<int>(m_geometry_1d->altitude_grid().grid().size()) - 1);
+    }
     construct_raytracer();
     construct_integrator();
     construct_source_terms();

--- a/cpp/lib/sktran_disco/sktran_do_banded_lu.cpp
+++ b/cpp/lib/sktran_disco/sktran_do_banded_lu.cpp
@@ -18,8 +18,7 @@ namespace sasktran_disco::la {
         if (upper_bandwidth < 0) {
             return -3;
         }
-        if (leading_dimension <
-            2 * lower_bandwidth + upper_bandwidth + 1) {
+        if (leading_dimension < 2 * lower_bandwidth + upper_bandwidth + 1) {
             return -5;
         }
         if (n == 0) {
@@ -121,10 +120,9 @@ namespace sasktran_disco::la {
     }
 
     int dgbsv_unblocked(lapack_int n, lapack_int lower_bandwidth,
-                        lapack_int upper_bandwidth,
-                        lapack_int right_hand_sides, double* matrix,
-                        lapack_int leading_dimension, lapack_int* pivots,
-                        double* right_hand_side,
+                        lapack_int upper_bandwidth, lapack_int right_hand_sides,
+                        double* matrix, lapack_int leading_dimension,
+                        lapack_int* pivots, double* right_hand_side,
                         lapack_int right_hand_side_leading_dimension) {
         if (n < 0) {
             return -1;
@@ -138,16 +136,14 @@ namespace sasktran_disco::la {
         if (right_hand_sides < 0) {
             return -4;
         }
-        if (leading_dimension <
-            2 * lower_bandwidth + upper_bandwidth + 1) {
+        if (leading_dimension < 2 * lower_bandwidth + upper_bandwidth + 1) {
             return -6;
         }
         if (right_hand_side_leading_dimension < std::max<lapack_int>(1, n)) {
             return -9;
         }
-        lapack_int info =
-            dgbtf2_unblocked(n, lower_bandwidth, upper_bandwidth, matrix,
-                             leading_dimension, pivots);
+        lapack_int info = dgbtf2_unblocked(n, lower_bandwidth, upper_bandwidth,
+                                           matrix, leading_dimension, pivots);
         if (info != 0 || n == 0 || right_hand_sides == 0) {
             return info;
         }
@@ -158,10 +154,10 @@ namespace sasktran_disco::la {
                 &right_hand_sides, matrix, &leading_dimension, pivots,
                 right_hand_side, &right_hand_side_leading_dimension, &info);
 #else
-        info = LAPACKE_dgbtrs(
-            LAPACK_COL_MAJOR, 'N', n, lower_bandwidth, upper_bandwidth,
-            right_hand_sides, matrix, leading_dimension, pivots,
-            right_hand_side, right_hand_side_leading_dimension);
+        info = LAPACKE_dgbtrs(LAPACK_COL_MAJOR, 'N', n, lower_bandwidth,
+                              upper_bandwidth, right_hand_sides, matrix,
+                              leading_dimension, pivots, right_hand_side,
+                              right_hand_side_leading_dimension);
 #endif
         return info;
     }

--- a/cpp/lib/sktran_disco/sktran_do_banded_lu.cpp
+++ b/cpp/lib/sktran_disco/sktran_do_banded_lu.cpp
@@ -1,0 +1,185 @@
+#include "sktran_disco/sktran_do.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <limits>
+
+namespace sasktran_disco::la {
+    int dgbtf2_unblocked(lapack_int n, lapack_int lower_bandwidth,
+                         lapack_int upper_bandwidth, double* matrix,
+                         lapack_int leading_dimension, lapack_int* pivots) {
+        if (n < 0) {
+            return -1;
+        }
+        if (lower_bandwidth < 0) {
+            return -2;
+        }
+        if (upper_bandwidth < 0) {
+            return -3;
+        }
+        if (leading_dimension <
+            2 * lower_bandwidth + upper_bandwidth + 1) {
+            return -5;
+        }
+        if (n == 0) {
+            return 0;
+        }
+
+        const lapack_int diagonal_row = lower_bandwidth + upper_bandwidth;
+        for (lapack_int column = upper_bandwidth + 1;
+             column < std::min(diagonal_row, n); ++column) {
+            const lapack_int first_row = diagonal_row - column;
+            std::fill(matrix + column * leading_dimension + first_row,
+                      matrix + column * leading_dimension + lower_bandwidth,
+                      0.0);
+        }
+
+        lapack_int info = 0;
+        lapack_int last_updated_column = 0;
+        lapack_int fill_column = diagonal_row;
+        for (lapack_int column = 0; column < n; ++column) {
+            if (fill_column < n) {
+                std::fill_n(matrix + fill_column * leading_dimension,
+                            lower_bandwidth, 0.0);
+                ++fill_column;
+            }
+
+            const lapack_int lower_count =
+                std::min(lower_bandwidth, n - 1 - column);
+            const lapack_int column_start =
+                column * leading_dimension + diagonal_row;
+            lapack_int pivot_offset = 0;
+            double pivot_absolute = std::abs(matrix[column_start]);
+            for (lapack_int offset = 1; offset <= lower_count; ++offset) {
+                const double candidate =
+                    std::abs(matrix[column_start + offset]);
+                if (candidate > pivot_absolute) {
+                    pivot_absolute = candidate;
+                    pivot_offset = offset;
+                }
+            }
+            pivots[column] = column + pivot_offset + 1;
+
+            const double pivot = matrix[column_start + pivot_offset];
+            if (pivot == 0.0) {
+                if (info == 0) {
+                    info = column + 1;
+                }
+                continue;
+            }
+
+            last_updated_column = std::max(
+                last_updated_column,
+                std::min(column + upper_bandwidth + pivot_offset, n - 1));
+            if (pivot_offset != 0) {
+                for (lapack_int offset = 0;
+                     offset <= last_updated_column - column; ++offset) {
+                    const lapack_int pivot_index =
+                        (column + offset) * leading_dimension + diagonal_row +
+                        pivot_offset - offset;
+                    const lapack_int diagonal_index =
+                        (column + offset) * leading_dimension + diagonal_row -
+                        offset;
+                    std::swap(matrix[pivot_index], matrix[diagonal_index]);
+                }
+            }
+
+            if (lower_count == 0) {
+                continue;
+            }
+            const double diagonal = matrix[column_start];
+            if (std::abs(diagonal) >= std::numeric_limits<double>::min()) {
+                const double inverse_diagonal = 1.0 / diagonal;
+                for (lapack_int offset = 1; offset <= lower_count; ++offset) {
+                    matrix[column_start + offset] *= inverse_diagonal;
+                }
+            } else {
+                for (lapack_int offset = 1; offset <= lower_count; ++offset) {
+                    matrix[column_start + offset] /= diagonal;
+                }
+            }
+
+            for (lapack_int column_offset = 1;
+                 column_offset <= last_updated_column - column;
+                 ++column_offset) {
+                const lapack_int target_start =
+                    (column + column_offset) * leading_dimension +
+                    diagonal_row - column_offset;
+                const double upper = matrix[target_start];
+                if (upper == 0.0) {
+                    continue;
+                }
+                const double scaled_upper = -upper;
+                for (lapack_int offset = 1; offset <= lower_count; ++offset) {
+                    matrix[target_start + offset] +=
+                        matrix[column_start + offset] * scaled_upper;
+                }
+            }
+        }
+        return info;
+    }
+
+    int dgbsv_unblocked(lapack_int n, lapack_int lower_bandwidth,
+                        lapack_int upper_bandwidth,
+                        lapack_int right_hand_sides, double* matrix,
+                        lapack_int leading_dimension, lapack_int* pivots,
+                        double* right_hand_side,
+                        lapack_int right_hand_side_leading_dimension) {
+        if (n < 0) {
+            return -1;
+        }
+        if (lower_bandwidth < 0) {
+            return -2;
+        }
+        if (upper_bandwidth < 0) {
+            return -3;
+        }
+        if (right_hand_sides < 0) {
+            return -4;
+        }
+        if (leading_dimension <
+            2 * lower_bandwidth + upper_bandwidth + 1) {
+            return -6;
+        }
+        if (right_hand_side_leading_dimension < std::max<lapack_int>(1, n)) {
+            return -9;
+        }
+        lapack_int info =
+            dgbtf2_unblocked(n, lower_bandwidth, upper_bandwidth, matrix,
+                             leading_dimension, pivots);
+        if (info != 0 || n == 0 || right_hand_sides == 0) {
+            return info;
+        }
+
+#if defined(SKTRAN_USE_ACCELERATE) || defined(SKTRAN_NO_LAPACKE)
+        char transpose = 'N';
+        dgbtrs_(&transpose, &n, &lower_bandwidth, &upper_bandwidth,
+                &right_hand_sides, matrix, &leading_dimension, pivots,
+                right_hand_side, &right_hand_side_leading_dimension, &info);
+#else
+        info = LAPACKE_dgbtrs(
+            LAPACK_COL_MAJOR, 'N', n, lower_bandwidth, upper_bandwidth,
+            right_hand_sides, matrix, leading_dimension, pivots,
+            right_hand_side, right_hand_side_leading_dimension);
+#endif
+        return info;
+    }
+
+    bool use_unblocked_band_factorization(lapack_int lower_bandwidth,
+                                          lapack_int upper_bandwidth) {
+#if defined(SKTRAN_USE_ACCELERATE) || defined(SKTRAN_USE_MKL)
+        // Keep vendor-tuned implementations until this crossover has been
+        // measured for them independently.
+        return false;
+#else
+        static const bool disabled =
+            std::getenv("SASKTRAN2_DISABLE_DO_UNBLOCKED_BAND_LU") != nullptr;
+        // Production DO bandwidths advance in steps of three. Benchmarks show
+        // the custom unblocked loop wins through 29, while the configured
+        // LAPACK's blocked path catches up at the next bandwidth (32).
+        return !disabled && lower_bandwidth == upper_bandwidth &&
+               lower_bandwidth > 2 && lower_bandwidth < 32;
+#endif
+    }
+} // namespace sasktran_disco::la

--- a/cpp/lib/sktran_disco/sktran_do_banded_lu.cpp
+++ b/cpp/lib/sktran_disco/sktran_do_banded_lu.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cstdlib>
 #include <limits>
 
 namespace sasktran_disco::la {
@@ -162,20 +161,23 @@ namespace sasktran_disco::la {
         return info;
     }
 
-    bool use_unblocked_band_factorization(lapack_int lower_bandwidth,
-                                          lapack_int upper_bandwidth) {
-#if defined(SKTRAN_USE_ACCELERATE) || defined(SKTRAN_USE_MKL)
-        // Keep vendor-tuned implementations until this crossover has been
-        // measured for them independently.
-        return false;
+    int dgbsv_configured(lapack_int n, lapack_int lower_bandwidth,
+                         lapack_int upper_bandwidth,
+                         lapack_int right_hand_sides, double* matrix,
+                         lapack_int leading_dimension, lapack_int* pivots,
+                         double* right_hand_side,
+                         lapack_int right_hand_side_leading_dimension) {
+#if defined(SKTRAN_USE_ACCELERATE) || defined(SKTRAN_NO_LAPACKE)
+        lapack_int info;
+        dgbsv_(&n, &lower_bandwidth, &upper_bandwidth, &right_hand_sides,
+               matrix, &leading_dimension, pivots, right_hand_side,
+               &right_hand_side_leading_dimension, &info);
+        return info;
 #else
-        static const bool disabled =
-            std::getenv("SASKTRAN2_DISABLE_DO_UNBLOCKED_BAND_LU") != nullptr;
-        // Production DO bandwidths advance in steps of three. Benchmarks show
-        // the custom unblocked loop wins through 29, while the configured
-        // LAPACK's blocked path catches up at the next bandwidth (32).
-        return !disabled && lower_bandwidth == upper_bandwidth &&
-               lower_bandwidth > 2 && lower_bandwidth < 32;
+        return LAPACKE_dgbsv(LAPACK_COL_MAJOR, n, lower_bandwidth,
+                             upper_bandwidth, right_hand_sides, matrix,
+                             leading_dimension, pivots, right_hand_side,
+                             right_hand_side_leading_dimension);
 #endif
     }
 } // namespace sasktran_disco::la

--- a/cpp/lib/sktran_disco/sktran_do_pconfig.cpp
+++ b/cpp/lib/sktran_disco/sktran_do_pconfig.cpp
@@ -29,6 +29,7 @@ void sasktran_disco::PersistentConfiguration<NSTOKES, CNSTR>::configure(
 
     const_cast<bool&>(this->M_SS_ONLY) = false;
     const_cast<bool&>(this->M_BACKPROP_BVP) = config.do_backprop();
+    m_banded_lu_backend = config.do_banded_lu_backend();
 
     m_lp_csz_storage.resize(
         this->M_NSTR,

--- a/cpp/lib/sktran_disco/sktran_do_rte.cpp
+++ b/cpp/lib/sktran_disco/sktran_do_rte.cpp
@@ -663,8 +663,9 @@ void sasktran_disco::RTESolver<1, 2>::solveParticularGreen(
     Cplus.value = 0.0;
     Cminus.value = 0.0;
 
-    double exp_thickness_eigval = exp(-thickness.value * eigval.value(0));
-    double exp_thickness_secant = exp(-thickness.value * average_secant.value);
+    const double exp_thickness_eigval = exp(-thickness.value * eigval.value(0));
+    const double exp_thickness_secant =
+        exp(-thickness.value * average_secant.value);
 
     // If average secant is close to eigval then we evaluate Cplus or Cminus
     // with a taylor series expansion instead
@@ -679,8 +680,7 @@ void sasktran_disco::RTESolver<1, 2>::solveParticularGreen(
                 (average_secant.value - eigval.value(0));
 
             m_cache.m_secant_to_Cplus(p, p) =
-                (transmission.value * thickness.value *
-                     exp(-1.0 * thickness.value * average_secant.value) -
+                (transmission.value * thickness.value * exp_thickness_secant -
                  Cplus.value) /
                 (average_secant.value - eigval.value(0));
 
@@ -694,7 +694,7 @@ void sasktran_disco::RTESolver<1, 2>::solveParticularGreen(
                 Cplus.deriv.noalias() +=
                     average_secant.deriv *
                     (transmission.value * thickness.value *
-                         exp(-1.0 * thickness.value * average_secant.value) -
+                         exp_thickness_secant -
                      Cplus.value) /
                     (average_secant.value - eigval.value(0));
             }
@@ -705,8 +705,7 @@ void sasktran_disco::RTESolver<1, 2>::solveParticularGreen(
                 (average_secant.value - eigval.value(0)) * transmission.deriv;
             Cplus.deriv.noalias() +=
                 average_secant.deriv *
-                (transmission.value * thickness.value *
-                     exp(-1.0 * thickness.value * average_secant.value) -
+                (transmission.value * thickness.value * exp_thickness_secant -
                  Cplus.value) /
                 (average_secant.value - eigval.value(0));
         }
@@ -724,54 +723,47 @@ void sasktran_disco::RTESolver<1, 2>::solveParticularGreen(
         }
     } else {
         // Second order taylor expansion of Cplus
-        Cplus.value = transmission.value *
-                      exp(-1.0 * thickness.value * eigval.value(0)) *
+        Cplus.value = transmission.value * exp_thickness_eigval *
                       thickness.value *
                       (1 - thickness.value / 2 *
                                (average_secant.value - eigval.value(0)));
 
         if (this->M_BACKPROP_BVP && SASKTRAN_DISCO_ENABLE_FULL_BACKPROP) {
             m_cache.m_trans_to_Cplus(p, p) =
-                exp(-1.0 * thickness.value * eigval.value(0)) *
-                thickness.value *
+                exp_thickness_eigval * thickness.value *
                 (1 - thickness.value / 2 *
                          (average_secant.value - eigval.value(0)));
 
             m_cache.m_secant_to_Cplus(p, p) =
                 -1.0 * thickness.value / 2.0 * thickness.value *
-                transmission.value *
-                exp(-1.0 * thickness.value * eigval.value(0));
+                transmission.value * exp_thickness_eigval;
 
             if (p != this->M_NLYR - 1) {
                 Cplus.deriv.setZero();
             } else {
 
                 Cplus.deriv.noalias() =
-                    exp(-1.0 * thickness.value * eigval.value(0)) *
-                    thickness.value *
+                    exp_thickness_eigval * thickness.value *
                     (1 - thickness.value / 2 *
                              (average_secant.value - eigval.value(0))) *
                     transmission.deriv;
                 ;
                 Cplus.deriv.noalias() +=
                     -1.0 * average_secant.deriv * thickness.value / 2.0 *
-                    thickness.value * transmission.value *
-                    exp(-1.0 * thickness.value * eigval.value(0));
+                    thickness.value * transmission.value * exp_thickness_eigval;
             }
 
         } else {
 
             Cplus.deriv.noalias() =
-                exp(-1.0 * thickness.value * eigval.value(0)) *
-                thickness.value *
+                exp_thickness_eigval * thickness.value *
                 (1 - thickness.value / 2 *
                          (average_secant.value - eigval.value(0))) *
                 transmission.deriv;
             ;
-            Cplus.deriv.noalias() +=
-                -1.0 * average_secant.deriv * thickness.value / 2.0 *
-                thickness.value * transmission.value *
-                exp(-1.0 * thickness.value * eigval.value(0));
+            Cplus.deriv.noalias() += -1.0 * average_secant.deriv *
+                                     thickness.value / 2.0 * thickness.value *
+                                     transmission.value * exp_thickness_eigval;
         }
 
         for (uint k = 0; k < numLayerDeriv; ++k) {
@@ -779,12 +771,10 @@ void sasktran_disco::RTESolver<1, 2>::solveParticularGreen(
                 eigval.deriv(k, 0) * Cplus.value * -1.0 * thickness.value;
             Cplus.deriv(k + layerStart) +=
                 eigval.deriv(k, 0) * thickness.value / 2.0 * thickness.value *
-                transmission.value *
-                exp(-1.0 * thickness.value * eigval.value(0));
+                transmission.value * exp_thickness_eigval;
 
             Cplus.deriv(k + layerStart) +=
-                thickness.deriv(k) * transmission.value *
-                exp(-1.0 * thickness.value * eigval.value(0)) *
+                thickness.deriv(k) * transmission.value * exp_thickness_eigval *
                 (1 -
                  thickness.value * (average_secant.value - eigval.value(0)));
             Cplus.deriv(k + layerStart) +=
@@ -974,6 +964,9 @@ void sasktran_disco::RTESolver<NSTOKES, CNSTR>::solveParticularGreen(
     auto& Cplus = m_cache.p_Cplus;
     auto& Cminus = m_cache.p_Cminus;
 
+    const double exp_thickness_secant =
+        exp(-thickness.value * average_secant.value);
+
     // For each homogeneous solution, add it's contribution in
     for (SolutionIndex i = 0; i < N * NSTOKES; ++i) {
         uint h_start = i * N * NSTOKES;
@@ -1038,13 +1031,14 @@ void sasktran_disco::RTESolver<NSTOKES, CNSTR>::solveParticularGreen(
         Cplus.value = 0.0;
         Cminus.value = 0.0;
         const auto& eigval = solution.value.dual_eigval();
+        const double exp_thickness_eigval =
+            exp(-thickness.value * eigval.value(i));
         // If average secant is close to eigval then we evaluate Cplus or Cminus
         // with a taylor series expansion instead
         if (abs(average_secant.value - eigval.value(i)) >
             SKTRAN_DO_GREENS_EPS) {
             Cplus.value = transmission.value *
-                          (exp(-thickness.value * eigval.value(i)) -
-                           exp(-thickness.value * average_secant.value)) /
+                          (exp_thickness_eigval - exp_thickness_secant) /
                           (average_secant.value - eigval.value(i));
 
             // If we are doing backprop, then we don't need the derivatives,
@@ -1052,13 +1046,12 @@ void sasktran_disco::RTESolver<NSTOKES, CNSTR>::solveParticularGreen(
             // calculation for the ground source
             if (this->M_BACKPROP_BVP && SASKTRAN_DISCO_ENABLE_FULL_BACKPROP) {
                 m_cache.m_trans_to_Cplus(p * N * NSTOKES + i, p) =
-                    (exp(-thickness.value * eigval.value(i)) -
-                     exp(-thickness.value * average_secant.value)) /
+                    (exp_thickness_eigval - exp_thickness_secant) /
                     (average_secant.value - eigval.value(i));
 
                 m_cache.m_secant_to_Cplus(p * N * NSTOKES + i, p) =
                     (transmission.value * thickness.value *
-                         exp(-1.0 * thickness.value * average_secant.value) -
+                         exp_thickness_secant -
                      Cplus.value) /
                     (average_secant.value - eigval.value(i));
 
@@ -1066,28 +1059,25 @@ void sasktran_disco::RTESolver<NSTOKES, CNSTR>::solveParticularGreen(
                     Cplus.deriv.setZero();
                 } else {
                     Cplus.deriv.noalias() =
-                        (exp(-thickness.value * eigval.value(i)) -
-                         exp(-thickness.value * average_secant.value)) /
+                        (exp_thickness_eigval - exp_thickness_secant) /
                         (average_secant.value - eigval.value(i)) *
                         transmission.deriv;
                     Cplus.deriv.noalias() +=
                         average_secant.deriv *
                         (transmission.value * thickness.value *
-                             exp(-1.0 * thickness.value *
-                                 average_secant.value) -
+                             exp_thickness_secant -
                          Cplus.value) /
                         (average_secant.value - eigval.value(i));
                 }
             } else {
                 Cplus.deriv.noalias() =
-                    (exp(-thickness.value * eigval.value(i)) -
-                     exp(-thickness.value * average_secant.value)) /
+                    (exp_thickness_eigval - exp_thickness_secant) /
                     (average_secant.value - eigval.value(i)) *
                     transmission.deriv;
                 Cplus.deriv.noalias() +=
                     average_secant.deriv *
                     (transmission.value * thickness.value *
-                         exp(-1.0 * thickness.value * average_secant.value) -
+                         exp_thickness_secant -
                      Cplus.value) /
                     (average_secant.value - eigval.value(i));
             }
@@ -1096,43 +1086,36 @@ void sasktran_disco::RTESolver<NSTOKES, CNSTR>::solveParticularGreen(
                 Cplus.deriv(k + layerStart) +=
                     eigval.deriv(k, i) /
                     (average_secant.value - eigval.value(i)) *
-                    (Cplus.value -
-                     transmission.value * thickness.value *
-                         exp(-1.0 * thickness.value * eigval.value(i)));
+                    (Cplus.value - transmission.value * thickness.value *
+                                       exp_thickness_eigval);
                 Cplus.deriv(k + layerStart) -=
                     thickness.deriv(k) * transmission.value /
                     (average_secant.value - eigval.value(i)) *
-                    (eigval.value(i) *
-                         exp(-1.0 * thickness.value * eigval.value(i)) -
-                     average_secant.value *
-                         exp(-1.0 * thickness.value * average_secant.value));
+                    (eigval.value(i) * exp_thickness_eigval -
+                     average_secant.value * exp_thickness_secant);
             }
         } else {
             // Second order taylor expansion of Cplus
-            Cplus.value = transmission.value *
-                          exp(-1.0 * thickness.value * eigval.value(i)) *
+            Cplus.value = transmission.value * exp_thickness_eigval *
                           thickness.value *
                           (1 - thickness.value / 2 *
                                    (average_secant.value - eigval.value(i)));
 
             if (this->M_BACKPROP_BVP && SASKTRAN_DISCO_ENABLE_FULL_BACKPROP) {
                 m_cache.m_trans_to_Cplus(p * N * NSTOKES + i, p) =
-                    exp(-1.0 * thickness.value * eigval.value(i)) *
-                    thickness.value *
+                    exp_thickness_eigval * thickness.value *
                     (1 - thickness.value / 2 *
                              (average_secant.value - eigval.value(i)));
 
                 m_cache.m_secant_to_Cplus(p * N * NSTOKES + i, p) =
                     -1.0 * thickness.value / 2.0 * thickness.value *
-                    transmission.value *
-                    exp(-1.0 * thickness.value * eigval.value(i));
+                    transmission.value * exp_thickness_eigval;
 
                 if (p != this->M_NLYR - 1) {
                     Cplus.deriv.setZero();
                 } else {
                     Cplus.deriv.noalias() =
-                        exp(-1.0 * thickness.value * eigval.value(i)) *
-                        thickness.value *
+                        exp_thickness_eigval * thickness.value *
                         (1 - thickness.value / 2 *
                                  (average_secant.value - eigval.value(i))) *
                         transmission.deriv;
@@ -1140,20 +1123,18 @@ void sasktran_disco::RTESolver<NSTOKES, CNSTR>::solveParticularGreen(
                     Cplus.deriv.noalias() +=
                         -1.0 * average_secant.deriv * thickness.value / 2.0 *
                         thickness.value * transmission.value *
-                        exp(-1.0 * thickness.value * eigval.value(i));
+                        exp_thickness_eigval;
                 }
             } else {
                 Cplus.deriv.noalias() =
-                    exp(-1.0 * thickness.value * eigval.value(i)) *
-                    thickness.value *
+                    exp_thickness_eigval * thickness.value *
                     (1 - thickness.value / 2 *
                              (average_secant.value - eigval.value(i))) *
                     transmission.deriv;
                 ;
                 Cplus.deriv.noalias() +=
                     -1.0 * average_secant.deriv * thickness.value / 2.0 *
-                    thickness.value * transmission.value *
-                    exp(-1.0 * thickness.value * eigval.value(i));
+                    thickness.value * transmission.value * exp_thickness_eigval;
             }
 
             for (uint k = 0; k < numLayerDeriv; ++k) {
@@ -1161,12 +1142,11 @@ void sasktran_disco::RTESolver<NSTOKES, CNSTR>::solveParticularGreen(
                     eigval.deriv(k, i) * Cplus.value * -1.0 * thickness.value;
                 Cplus.deriv(k + layerStart) +=
                     eigval.deriv(k, i) * thickness.value / 2.0 *
-                    thickness.value * transmission.value *
-                    exp(-1.0 * thickness.value * eigval.value(i));
+                    thickness.value * transmission.value * exp_thickness_eigval;
 
                 Cplus.deriv(k + layerStart) +=
                     thickness.deriv(k) * transmission.value *
-                    exp(-1.0 * thickness.value * eigval.value(i)) *
+                    exp_thickness_eigval *
                     (1 - thickness.value *
                              (average_secant.value - eigval.value(i)));
                 Cplus.deriv(k + layerStart) +=
@@ -1177,36 +1157,34 @@ void sasktran_disco::RTESolver<NSTOKES, CNSTR>::solveParticularGreen(
         if (abs(average_secant.value + eigval.value(i)) >
             SKTRAN_DO_GREENS_EPS) {
 
+            const double exp_thickness_eigval_plus_secant = exp(
+                -thickness.value * (average_secant.value + eigval.value(i)));
+
             Cminus.value = transmission.value *
-                           (1 - exp(-thickness.value * average_secant.value) *
-                                    exp(-thickness.value * eigval.value(i))) /
+                           (1 - exp_thickness_secant * exp_thickness_eigval) /
                            (average_secant.value + eigval.value(i));
 
             if (this->M_BACKPROP_BVP && SASKTRAN_DISCO_ENABLE_FULL_BACKPROP) {
                 m_cache.m_trans_to_Cminus(p * N * NSTOKES + i, p) =
-                    (1 - exp(-thickness.value * average_secant.value) *
-                             exp(-thickness.value * eigval.value(i))) /
+                    (1 - exp_thickness_secant * exp_thickness_eigval) /
                     (average_secant.value + eigval.value(i));
                 m_cache.m_secant_to_Cminus(p * N * NSTOKES + i, p) =
                     (1 / (average_secant.value + eigval.value(i))) *
                     (transmission.value * thickness.value *
-                         exp(-thickness.value *
-                             (average_secant.value + eigval.value(i))) -
+                         exp_thickness_eigval_plus_secant -
                      Cminus.value);
 
                 Cminus.deriv.setZero();
             } else {
                 Cminus.deriv.noalias() =
-                    (1 - exp(-thickness.value * average_secant.value) *
-                             exp(-thickness.value * eigval.value(i))) /
+                    (1 - exp_thickness_secant * exp_thickness_eigval) /
                     (average_secant.value + eigval.value(i)) *
                     transmission.deriv;
                 Cminus.deriv.noalias() +=
                     average_secant.deriv /
                     (average_secant.value + eigval.value(i)) *
                     (transmission.value * thickness.value *
-                         exp(-thickness.value *
-                             (average_secant.value + eigval.value(i))) -
+                         exp_thickness_eigval_plus_secant -
                      Cminus.value);
             }
 
@@ -1215,13 +1193,11 @@ void sasktran_disco::RTESolver<NSTOKES, CNSTR>::solveParticularGreen(
                     eigval.deriv(k, i) /
                     (average_secant.value + eigval.value(i)) *
                     (transmission.value * thickness.value *
-                         exp(-thickness.value *
-                             (average_secant.value + eigval.value(i))) -
+                         exp_thickness_eigval_plus_secant -
                      Cminus.value);
                 Cminus.deriv(k + layerStart) +=
                     thickness.deriv(k) * transmission.value *
-                    exp(-1 * thickness.value *
-                        (average_secant.value + eigval.value(i)));
+                    exp_thickness_eigval_plus_secant;
             }
         } else {
             // Second order taylor expansion of CMinus
@@ -1406,6 +1382,8 @@ void sasktran_disco::RTESolver<NSTOKES, CNSTR>::solveParticularGreenThermal(
     auto& Cplus = m_cache.p_Cplus_thermal[p];
     auto& Cminus = m_cache.p_Cminus_thermal[p];
 
+    const double exp_thickness_b1 = exp(-thickness.value * b1.value);
+
     // For each homogeneous solution, add it's contribution in
     for (SolutionIndex i = 0; i < N * NSTOKES; ++i) {
         uint h_start = i * N * NSTOKES;
@@ -1473,64 +1451,55 @@ void sasktran_disco::RTESolver<NSTOKES, CNSTR>::solveParticularGreenThermal(
         Cplus.value = 0.0;
         Cminus.value = 0.0;
         const auto& eigval = solution.value.dual_eigval();
+        const double exp_thickness_eigval =
+            exp(-thickness.value * eigval.value(i));
         // If b1 is close to eigval then we evaluate Cplus or Cminus
         // with a taylor series expansion instead
         if (abs(b1.value - eigval.value(i)) > SKTRAN_DO_GREENS_EPS) {
-            Cplus.value = b0.value *
-                          (exp(-thickness.value * eigval.value(i)) -
-                           exp(-thickness.value * b1.value)) /
+            Cplus.value = b0.value * (exp_thickness_eigval - exp_thickness_b1) /
                           (b1.value - eigval.value(i));
 
-            Cplus.deriv.noalias() = (exp(-thickness.value * eigval.value(i)) -
-                                     exp(-thickness.value * b1.value)) /
+            Cplus.deriv.noalias() = (exp_thickness_eigval - exp_thickness_b1) /
                                     (b1.value - eigval.value(i)) * b0.deriv;
             Cplus.deriv.noalias() +=
                 b1.deriv *
-                (b0.value * thickness.value *
-                     exp(-1.0 * thickness.value * b1.value) -
-                 Cplus.value) /
+                (b0.value * thickness.value * exp_thickness_b1 - Cplus.value) /
                 (b1.value - eigval.value(i));
 
             for (uint k = 0; k < numLayerDeriv; ++k) {
-                Cplus.deriv(k) +=
-                    eigval.deriv(k, i) / (b1.value - eigval.value(i)) *
-                    (Cplus.value -
-                     b0.value * thickness.value *
-                         exp(-1.0 * thickness.value * eigval.value(i)));
-                Cplus.deriv(k) -=
-                    thickness.deriv(k) * b0.value /
-                    (b1.value - eigval.value(i)) *
-                    (eigval.value(i) *
-                         exp(-1.0 * thickness.value * eigval.value(i)) -
-                     b1.value * exp(-1.0 * thickness.value * b1.value));
+                Cplus.deriv(k) += eigval.deriv(k, i) /
+                                  (b1.value - eigval.value(i)) *
+                                  (Cplus.value - b0.value * thickness.value *
+                                                     exp_thickness_eigval);
+                Cplus.deriv(k) -= thickness.deriv(k) * b0.value /
+                                  (b1.value - eigval.value(i)) *
+                                  (eigval.value(i) * exp_thickness_eigval -
+                                   b1.value * exp_thickness_b1);
             }
         } else {
             // Second order taylor expansion of Cplus
             Cplus.value =
-                b0.value * exp(-1.0 * thickness.value * eigval.value(i)) *
-                thickness.value *
+                b0.value * exp_thickness_eigval * thickness.value *
                 (1 - thickness.value / 2 * (b1.value - eigval.value(i)));
 
             Cplus.deriv.noalias() =
-                exp(-1.0 * thickness.value * eigval.value(i)) *
-                thickness.value *
+                exp_thickness_eigval * thickness.value *
                 (1 - thickness.value / 2 * (b1.value - eigval.value(i))) *
                 b0.deriv;
             ;
-            Cplus.deriv.noalias() +=
-                -1.0 * b1.deriv * thickness.value / 2.0 * thickness.value *
-                b0.value * exp(-1.0 * thickness.value * eigval.value(i));
+            Cplus.deriv.noalias() += -1.0 * b1.deriv * thickness.value / 2.0 *
+                                     thickness.value * b0.value *
+                                     exp_thickness_eigval;
 
             for (uint k = 0; k < numLayerDeriv; ++k) {
                 Cplus.deriv(k) +=
                     eigval.deriv(k, i) * Cplus.value * -1.0 * thickness.value;
                 Cplus.deriv(k) += eigval.deriv(k, i) * thickness.value / 2.0 *
                                   thickness.value * b0.value *
-                                  exp(-1.0 * thickness.value * eigval.value(i));
+                                  exp_thickness_eigval;
 
                 Cplus.deriv(k) +=
-                    thickness.deriv(k) * b0.value *
-                    exp(-1.0 * thickness.value * eigval.value(i)) *
+                    thickness.deriv(k) * b0.value * exp_thickness_eigval *
                     (1 - thickness.value * (b1.value - eigval.value(i)));
                 Cplus.deriv(k) +=
                     -1.0 * eigval.value(i) * Cplus.value * thickness.deriv(k);
@@ -1539,30 +1508,28 @@ void sasktran_disco::RTESolver<NSTOKES, CNSTR>::solveParticularGreenThermal(
 
         if (abs(b1.value + eigval.value(i)) > SKTRAN_DO_GREENS_EPS) {
 
+            const double exp_thickness_b1_plus_eigval =
+                exp(-thickness.value * (b1.value + eigval.value(i)));
+
             Cminus.value = b0.value *
-                           (1 - exp(-thickness.value * b1.value) *
-                                    exp(-thickness.value * eigval.value(i))) /
+                           (1 - exp_thickness_b1 * exp_thickness_eigval) /
                            (b1.value + eigval.value(i));
 
             Cminus.deriv.noalias() =
-                (1 - exp(-thickness.value * b1.value) *
-                         exp(-thickness.value * eigval.value(i))) /
+                (1 - exp_thickness_b1 * exp_thickness_eigval) /
                 (b1.value + eigval.value(i)) * b0.deriv;
             Cminus.deriv.noalias() +=
                 b1.deriv / (b1.value + eigval.value(i)) *
-                (b0.value * thickness.value *
-                     exp(-thickness.value * (b1.value + eigval.value(i))) -
+                (b0.value * thickness.value * exp_thickness_b1_plus_eigval -
                  Cminus.value);
 
             for (uint k = 0; k < numLayerDeriv; ++k) {
                 Cminus.deriv(k) +=
                     eigval.deriv(k, i) / (b1.value + eigval.value(i)) *
-                    (b0.value * thickness.value *
-                         exp(-thickness.value * (b1.value + eigval.value(i))) -
+                    (b0.value * thickness.value * exp_thickness_b1_plus_eigval -
                      Cminus.value);
-                Cminus.deriv(k) +=
-                    thickness.deriv(k) * b0.value *
-                    exp(-1 * thickness.value * (b1.value + eigval.value(i)));
+                Cminus.deriv(k) += thickness.deriv(k) * b0.value *
+                                   exp_thickness_b1_plus_eigval;
             }
         } else {
             // Second order taylor expansion of CMinus

--- a/cpp/lib/sktran_disco/sktran_do_rte.cpp
+++ b/cpp/lib/sktran_disco/sktran_do_rte.cpp
@@ -3,7 +3,6 @@
 #include "sktran_disco/sktran_do_opticallayer.h"
 #include "sktran_disco/sktran_do_rte.h"
 #include "sktran_disco/sktran_do_types.h"
-#include <sasktran2/math/real_eigensolver.h>
 #include "sktran_disco/sktran_do_lpproduct.h"
 #include <spdlog/spdlog.h>
 #include <thread>
@@ -432,7 +431,8 @@ void sasktran_disco::RTESolver<NSTOKES, CNSTR>::solveHomogeneous(
     if (SASKTRAN_DISCO_USE_EIGEN_EIGENSOLVER || CNSTR != -1) {
         // Eigen::SelfAdjointEigenSolver<Matrix> es(eigmtx_destroyable);
         ZoneScopedN("EigenSolver");
-        Eigen::RealEigenSolver<Matrix> es(eigmtx_destroyable);
+        auto& es = m_cache.h_eigensolver;
+        es.compute(eigmtx_destroyable);
 
         auto eigeninfo = es.info();
         if (eigeninfo != Eigen::Success) {

--- a/cpp/lib/sktran_disco/sktran_do_rte.cpp
+++ b/cpp/lib/sktran_disco/sktran_do_rte.cpp
@@ -245,7 +245,12 @@ void sasktran_disco::RTESolver<NSTOKES, CNSTR>::linearizeHomogeneous(
             rhs(N * NSTOKES, i) = 0.0;                // Orthogonality
         }
         MatrixHRHS& d_X_d_k = m_cache.h_d_X_d_k[layer.index()];
-        if (NSTOKES == 1) {
+        if (rhs.isZero(0)) {
+            // A homogeneous derivative system with an exactly zero RHS has
+            // the exactly zero solution. This is common once the azimuth order
+            // exceeds the active scattering moments.
+            d_X_d_k.setZero();
+        } else if (NSTOKES == 1) {
             m_cache.h_partiallu.compute(lhs);
             d_X_d_k.noalias() = m_cache.h_partiallu.solve(rhs);
         } else {

--- a/cpp/lib/sktran_disco/sktran_do_rte.cpp
+++ b/cpp/lib/sktran_disco/sktran_do_rte.cpp
@@ -962,6 +962,11 @@ void sasktran_disco::RTESolver<NSTOKES, CNSTR>::solveParticularGreen(
     Gminus_bottom.deriv.setZero();
     Gminus_top.deriv.setZero();
 
+    if (Qplus.value.isZero(0) && Qminus.value.isZero(0) &&
+        Qplus.deriv.isZero(0) && Qminus.deriv.isZero(0)) {
+        return;
+    }
+
     // Normalization constant
     LayerDual<double> norm(numLayerDeriv, p, layerStart);
 

--- a/cpp/lib/sktran_disco/sktran_do_rte.cpp
+++ b/cpp/lib/sktran_disco/sktran_do_rte.cpp
@@ -12,7 +12,8 @@ sasktran_disco::RTESolver<NSTOKES, CNSTR>::RTESolver(
     const PersistentConfiguration<NSTOKES, CNSTR>& config,
     OpticalLayerArray<NSTOKES, CNSTR>& layers)
     : RTESProperties<NSTOKES>(config), m_layers(layers),
-      m_cache(config.pool().thread_data().rte_cache()) {
+      m_cache(config.pool().thread_data().rte_cache()),
+      m_banded_lu_backend(config.banded_lu_backend()) {
     // Initialize tracker for which orders have been solved
     m_is_solved.resize(this->M_NSTR, false);
 
@@ -1669,22 +1670,17 @@ void sasktran_disco::RTESolver<NSTOKES, CNSTR>::solveBVP(AEOrder m) {
             N, 1, mat.data(), b.data(), N, m_cache.bvp_pd_alpha,
             m_cache.bvp_pd_beta, m_cache.bvp_pd_z, m_cache.bvp_pd_gamma,
             m_cache.bvp_pd_mu, false);
-    } else if (la::use_unblocked_band_factorization(NCD, NCD)) {
+    } else if (m_banded_lu_backend ==
+               sasktran2::detail::BandedLUBackend::unblocked) {
         ZoneScopedN("BVP Solve unblocked dgbtf2");
         errorcode = la::dgbsv_unblocked(N, NCD, NCD, 1, mat.data(), LDA,
                                         ipiv.data(), b.data(), N);
     } else {
-#if defined(SKTRAN_USE_ACCELERATE) || defined(SKTRAN_NO_LAPACKE)
-        lapack_int one = 1;
         {
-            ZoneScopedN("BVP Solve dgbsv_");
-            dgbsv_(&N, &NCD, &NCD, &one, mat.data(), &LDA, ipiv.data(),
-                   b.data(), &N, &errorcode);
+            ZoneScopedN("BVP Solve configured LAPACK");
+            errorcode = la::dgbsv_configured(N, NCD, NCD, 1, mat.data(), LDA,
+                                             ipiv.data(), b.data(), N);
         }
-#else
-        errorcode = LAPACKE_dgbsv(LAPACK_COL_MAJOR, N, NCD, NCD, 1, mat.data(),
-                                  LDA, ipiv.data(), b.data(), N);
-#endif
     }
 
     // We we failed then return immediately

--- a/cpp/lib/sktran_disco/sktran_do_rte.cpp
+++ b/cpp/lib/sktran_disco/sktran_do_rte.cpp
@@ -1689,6 +1689,10 @@ void sasktran_disco::RTESolver<NSTOKES, CNSTR>::solveBVP(AEOrder m) {
             N, 1, mat.data(), b.data(), N, m_cache.bvp_pd_alpha,
             m_cache.bvp_pd_beta, m_cache.bvp_pd_z, m_cache.bvp_pd_gamma,
             m_cache.bvp_pd_mu, false);
+    } else if (la::use_unblocked_band_factorization(NCD, NCD)) {
+        ZoneScopedN("BVP Solve unblocked dgbtf2");
+        errorcode = la::dgbsv_unblocked(N, NCD, NCD, 1, mat.data(), LDA,
+                                        ipiv.data(), b.data(), N);
     } else {
 #if defined(SKTRAN_USE_ACCELERATE) || defined(SKTRAN_NO_LAPACKE)
         lapack_int one = 1;

--- a/cpp/lib/sktran_disco/sktran_do_rte.cpp
+++ b/cpp/lib/sktran_disco/sktran_do_rte.cpp
@@ -475,7 +475,10 @@ void sasktran_disco::RTESolver<NSTOKES, CNSTR>::solveHomogeneous(
             }
         } else {
             eigvalsq = es.eigenvalues().real();
-            MX_plus = es.eigenvectors().real();
+            MX_plus = es.pseudoEigenvectors();
+            for (SolutionIndex j = 0; j < N * NSTOKES; ++j) {
+                MX_plus.col(j).normalize();
+            }
             reigval_imag.setZero();
         }
     } else {

--- a/cpp/lib/tests/CMakeLists.txt
+++ b/cpp/lib/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(
   engine/wf/test_wf_vector.cpp
   engine/hr/test_hr_basic.cpp
   sktran_disco/test_util.cpp
+  sktran_disco/test_band_factorization.cpp
   sktran_disco/tests_lowlevel.cpp
   sktran_disco/legacy/test_scalar.cpp
   sktran_disco/legacy/test_vector.cpp

--- a/cpp/lib/tests/sktran_disco/benchmark/bench_lowlevel.cpp
+++ b/cpp/lib/tests/sktran_disco/benchmark/bench_lowlevel.cpp
@@ -58,7 +58,7 @@ TEST_CASE("2StreamBenchmark", "[sktran_do][lowlevel][benchmark]") {
     };
 }
 */
-TEST_CASE("8StreamBenchmark", "[sktran_do][lowlevel][benchmark]") {
+TEST_CASE("8StreamBenchmark", "[.benchmark][sktran_do][lowlevel][do_full]") {
 #ifdef USE_OMP
     omp_set_num_threads(1);
 #endif
@@ -68,7 +68,7 @@ TEST_CASE("8StreamBenchmark", "[sktran_do][lowlevel][benchmark]") {
 
     int nlyr = 20;
     int nwavel = 40;
-    int nstr = 2;
+    int nstr = 8;
 
     Eigen::VectorXd grid_values(nlyr + 1);
     for (int i = 0; i < nlyr + 1; ++i) {
@@ -119,6 +119,8 @@ TEST_CASE("8StreamBenchmark", "[sktran_do][lowlevel][benchmark]") {
     Sasktran2<1> engine(config, &geo, viewing_geometry);
 
     sasktran2::OutputIdealDense<1> output;
-    engine.calculate_radiance(atmo, output);
+    BENCHMARK("8-stream scalar, 20 layers, 40 wavelengths") {
+        engine.calculate_radiance(atmo, output);
+    };
 }
 #endif

--- a/cpp/lib/tests/sktran_disco/test_band_factorization.cpp
+++ b/cpp/lib/tests/sktran_disco/test_band_factorization.cpp
@@ -152,7 +152,9 @@ TEST_CASE("Unblocked band factorization matches configured LAPACK",
             configured_lapack, configured_lapack_pivots);
 
         REQUIRE(custom_info == configured_lapack_info);
-#if defined(SKTRAN_USE_ACCELERATE) || defined(SKTRAN_USE_MKL)
+#if !defined(SKTRAN_USE_ACCELERATE) && !defined(SKTRAN_USE_MKL)
+        REQUIRE(custom_pivots == configured_lapack_pivots);
+#endif
         for (std::size_t index = 0; index < custom.right_hand_side.size();
              ++index) {
             REQUIRE(custom.right_hand_side[index] ==
@@ -160,11 +162,6 @@ TEST_CASE("Unblocked band factorization matches configured LAPACK",
                         .epsilon(2.0e-13)
                         .margin(2.0e-13));
         }
-#else
-        REQUIRE(custom_pivots == configured_lapack_pivots);
-        REQUIRE(custom.matrix == configured_lapack.matrix);
-        REQUIRE(custom.right_hand_side == configured_lapack.right_hand_side);
-#endif
     }
 }
 

--- a/cpp/lib/tests/sktran_disco/test_band_factorization.cpp
+++ b/cpp/lib/tests/sktran_disco/test_band_factorization.cpp
@@ -1,4 +1,5 @@
 #include <sasktran2/test_helper.h>
+#include <sasktran2/runtime_backend_tuner.h>
 
 #include <sktran_disco/sktran_do.h>
 
@@ -68,20 +69,11 @@ namespace {
 
     int solve_with_configured_lapack(BandSystem& system,
                                      std::vector<lapack_int>& pivots) {
-#if defined(SKTRAN_USE_ACCELERATE) || defined(SKTRAN_NO_LAPACKE)
-        lapack_int info;
-        dgbsv_(&system.size, &system.bandwidth, &system.bandwidth,
-               &system.right_hand_sides, system.matrix.data(),
-               &system.leading_dimension, pivots.data(),
-               system.right_hand_side.data(), &system.size, &info);
-        return info;
-#else
-        return LAPACKE_dgbsv(LAPACK_COL_MAJOR, system.size, system.bandwidth,
-                             system.bandwidth, system.right_hand_sides,
-                             system.matrix.data(), system.leading_dimension,
-                             pivots.data(), system.right_hand_side.data(),
-                             system.size);
-#endif
+        return sasktran_disco::la::dgbsv_configured(
+            system.size, system.bandwidth, system.bandwidth,
+            system.right_hand_sides, system.matrix.data(),
+            system.leading_dimension, pivots.data(),
+            system.right_hand_side.data(), system.size);
     }
 
     void benchmark_band_solve(lapack_int size, lapack_int bandwidth) {
@@ -110,6 +102,20 @@ namespace {
                     system.leading_dimension, pivots[run].data(),
                     system.right_hand_side.data(), system.size);
             });
+        };
+    }
+
+    void benchmark_runtime_selection(int num_stokes, int num_streams,
+                                     int num_layers) {
+        BENCHMARK("construction-time backend selection") {
+            sasktran2::Config config;
+            config.set_num_stokes(num_stokes);
+            config.set_num_do_streams(num_streams);
+            config.set_multiple_scatter_source(
+                sasktran2::Config::MultipleScatterSource::discrete_ordinates);
+            sasktran2::detail::RuntimeBackendTuner::resolve(config, num_layers);
+            return sasktran2::detail::RuntimeBackendTuner::
+                resolved_banded_lu_backend(config);
         };
     }
 } // namespace
@@ -177,18 +183,31 @@ TEST_CASE("Unblocked band factorization reports singular pivots",
                 pivots.data()) == 1);
 }
 
-TEST_CASE("Unblocked band factorization dispatches for narrow DO systems",
+TEST_CASE("Runtime band factorization policy prefers LAPACK for close results",
           "[sktran_do][band_factorization]") {
-    REQUIRE_FALSE(sasktran_disco::la::use_unblocked_band_factorization(2, 2));
-#if defined(SKTRAN_USE_ACCELERATE) || defined(SKTRAN_USE_MKL)
-    REQUIRE_FALSE(sasktran_disco::la::use_unblocked_band_factorization(5, 5));
-    REQUIRE_FALSE(sasktran_disco::la::use_unblocked_band_factorization(29, 29));
-#else
-    REQUIRE(sasktran_disco::la::use_unblocked_band_factorization(5, 5));
-    REQUIRE(sasktran_disco::la::use_unblocked_band_factorization(29, 29));
-#endif
-    REQUIRE_FALSE(sasktran_disco::la::use_unblocked_band_factorization(32, 32));
-    REQUIRE_FALSE(sasktran_disco::la::use_unblocked_band_factorization(11, 12));
+    using Backend = sasktran2::detail::BandedLUBackend;
+    using Tuner = sasktran2::detail::RuntimeBackendTuner;
+
+    REQUIRE(Tuner::select_banded_lu_backend(100.0, 80.0) == Backend::unblocked);
+    REQUIRE(Tuner::select_banded_lu_backend(100.0, 90.0) == Backend::lapack);
+    REQUIRE(Tuner::select_banded_lu_backend(100.0, 95.0) == Backend::lapack);
+    REQUIRE(Tuner::select_banded_lu_backend(100.0, 105.0) == Backend::lapack);
+    REQUIRE(Tuner::select_banded_lu_backend(0.0, 1.0) == Backend::lapack);
+}
+
+TEST_CASE("Runtime band factorization tuner resolves a supported backend",
+          "[sktran_do][band_factorization]") {
+    sasktran2::Config config;
+    config.set_num_do_streams(8);
+    config.set_multiple_scatter_source(
+        sasktran2::Config::MultipleScatterSource::discrete_ordinates);
+    sasktran2::detail::RuntimeBackendTuner::resolve(config, 20);
+
+    const auto backend =
+        sasktran2::detail::RuntimeBackendTuner::resolved_banded_lu_backend(
+            config);
+    REQUIRE((backend == sasktran2::detail::BandedLUBackend::lapack ||
+             backend == sasktran2::detail::BandedLUBackend::unblocked));
 }
 
 TEST_CASE("Band solve performance", "[.benchmark][band_solve]") {
@@ -215,4 +234,20 @@ TEST_CASE("Band solve performance", "[.benchmark][band_solve]") {
     SECTION("bandwidth 26, 100 layers") { benchmark_band_solve(18 * 100, 26); }
     SECTION("bandwidth 29, 100 layers") { benchmark_band_solve(20 * 100, 29); }
     SECTION("bandwidth 32, 100 layers") { benchmark_band_solve(22 * 100, 32); }
+}
+
+TEST_CASE("Runtime backend selection overhead",
+          "[.benchmark][band_backend_selection]") {
+    SECTION("scalar 4 streams, 20 layers") {
+        benchmark_runtime_selection(1, 4, 20);
+    }
+    SECTION("scalar 8 streams, 100 layers") {
+        benchmark_runtime_selection(1, 8, 100);
+    }
+    SECTION("scalar 16 streams, 100 layers") {
+        benchmark_runtime_selection(1, 16, 100);
+    }
+    SECTION("IQU 4 streams, 100 layers") {
+        benchmark_runtime_selection(3, 4, 100);
+    }
 }

--- a/cpp/lib/tests/sktran_disco/test_band_factorization.cpp
+++ b/cpp/lib/tests/sktran_disco/test_band_factorization.cpp
@@ -1,0 +1,248 @@
+#include <sasktran2/test_helper.h>
+
+#include <sktran_disco/sktran_do.h>
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+namespace {
+    struct BandSystem {
+        lapack_int size;
+        lapack_int bandwidth;
+        lapack_int right_hand_sides;
+        lapack_int leading_dimension;
+        std::vector<double> matrix;
+        std::vector<double> right_hand_side;
+        std::vector<double> expected;
+    };
+
+    BandSystem make_band_system(lapack_int size, lapack_int bandwidth,
+                                lapack_int right_hand_sides,
+                                bool require_pivoting = false) {
+        BandSystem result{size,
+                          bandwidth,
+                          right_hand_sides,
+                          3 * bandwidth + 1,
+                          std::vector<double>((3 * bandwidth + 1) * size,
+                                              -71.25),
+                          std::vector<double>(size * right_hand_sides, 0.0),
+                          std::vector<double>(size * right_hand_sides, 0.0)};
+        const lapack_int diagonal_row = 2 * bandwidth;
+        for (lapack_int rhs = 0; rhs < right_hand_sides; ++rhs) {
+            for (lapack_int row = 0; row < size; ++row) {
+                result.expected[rhs * size + row] =
+                    std::sin(0.13 * static_cast<double>((rhs + 1) * (row + 1)));
+            }
+        }
+        for (lapack_int column = 0; column < size; ++column) {
+            const lapack_int first_row = std::max<lapack_int>(0, column - bandwidth);
+            const lapack_int last_row =
+                std::min<lapack_int>(size - 1, column + bandwidth);
+            for (lapack_int row = first_row; row <= last_row; ++row) {
+                double value =
+                    0.015 * std::sin(static_cast<double>((row + 3) *
+                                                        (column + 5)));
+                if (row == column) {
+                    value += 2.5 + 0.001 * static_cast<double>(row);
+                }
+                if (require_pivoting && column % 5 == 0 &&
+                    column + 1 < size) {
+                    if (row == column) {
+                        value = 0.25;
+                    } else if (row == column + 1) {
+                        value = 3.0;
+                    }
+                }
+                const lapack_int band_row = diagonal_row + row - column;
+                result.matrix[column * result.leading_dimension + band_row] =
+                    value;
+                for (lapack_int rhs = 0; rhs < right_hand_sides; ++rhs) {
+                    result.right_hand_side[rhs * size + row] +=
+                        value * result.expected[rhs * size + column];
+                }
+            }
+        }
+        return result;
+    }
+
+    int solve_with_configured_lapack(BandSystem& system,
+                                     std::vector<lapack_int>& pivots) {
+#if defined(SKTRAN_USE_ACCELERATE) || defined(SKTRAN_NO_LAPACKE)
+        lapack_int info;
+        dgbsv_(&system.size, &system.bandwidth, &system.bandwidth,
+               &system.right_hand_sides, system.matrix.data(),
+               &system.leading_dimension, pivots.data(),
+               system.right_hand_side.data(), &system.size, &info);
+        return info;
+#else
+        return LAPACKE_dgbsv(
+            LAPACK_COL_MAJOR, system.size, system.bandwidth, system.bandwidth,
+            system.right_hand_sides, system.matrix.data(),
+            system.leading_dimension, pivots.data(),
+            system.right_hand_side.data(), system.size);
+#endif
+    }
+
+    void benchmark_band_solve(lapack_int size, lapack_int bandwidth) {
+        const auto source = make_band_system(size, bandwidth, 1, true);
+
+        BENCHMARK_ADVANCED("configured LAPACK")(
+            Catch::Benchmark::Chronometer meter) {
+            std::vector<BandSystem> systems(meter.runs(), source);
+            std::vector<std::vector<lapack_int>> pivots(
+                meter.runs(), std::vector<lapack_int>(size));
+            meter.measure([&](int run) {
+                return solve_with_configured_lapack(systems[run], pivots[run]);
+            });
+        };
+
+        BENCHMARK_ADVANCED("unblocked C++")(
+            Catch::Benchmark::Chronometer meter) {
+            std::vector<BandSystem> systems(meter.runs(), source);
+            std::vector<std::vector<lapack_int>> pivots(
+                meter.runs(), std::vector<lapack_int>(size));
+            meter.measure([&](int run) {
+                auto& system = systems[run];
+                return sasktran_disco::la::dgbsv_unblocked(
+                    system.size, system.bandwidth, system.bandwidth,
+                    system.right_hand_sides, system.matrix.data(),
+                    system.leading_dimension, pivots[run].data(),
+                    system.right_hand_side.data(), system.size);
+            });
+        };
+    }
+} // namespace
+
+TEST_CASE("Unblocked band solve reproduces known solutions",
+          "[sktran_do][band_factorization]") {
+    for (const lapack_int bandwidth : {lapack_int{5}, lapack_int{11},
+                                       lapack_int{17}}) {
+        auto system = make_band_system(6 * bandwidth + 7, bandwidth, 3);
+        std::vector<lapack_int> pivots(system.size);
+        const int info = sasktran_disco::la::dgbsv_unblocked(
+            system.size, system.bandwidth, system.bandwidth,
+            system.right_hand_sides, system.matrix.data(),
+            system.leading_dimension, pivots.data(),
+            system.right_hand_side.data(), system.size);
+        REQUIRE(info == 0);
+        for (std::size_t index = 0; index < system.expected.size(); ++index) {
+            REQUIRE(std::abs(system.right_hand_side[index] -
+                             system.expected[index]) < 2.0e-13);
+        }
+    }
+}
+
+TEST_CASE("Unblocked band factorization matches configured LAPACK",
+          "[sktran_do][band_factorization]") {
+    for (const lapack_int bandwidth : {
+             lapack_int{5}, lapack_int{8}, lapack_int{11}, lapack_int{17},
+             lapack_int{23}, lapack_int{26}, lapack_int{29}}) {
+        auto custom = make_band_system(10 * bandwidth + 3, bandwidth, 3, true);
+        auto configured_lapack = custom;
+        std::vector<lapack_int> custom_pivots(custom.size);
+        std::vector<lapack_int> configured_lapack_pivots(custom.size);
+
+        const int custom_info = sasktran_disco::la::dgbsv_unblocked(
+            custom.size, custom.bandwidth, custom.bandwidth,
+            custom.right_hand_sides, custom.matrix.data(),
+            custom.leading_dimension, custom_pivots.data(),
+            custom.right_hand_side.data(), custom.size);
+        const int configured_lapack_info = solve_with_configured_lapack(
+            configured_lapack, configured_lapack_pivots);
+
+        REQUIRE(custom_info == configured_lapack_info);
+#if defined(SKTRAN_USE_ACCELERATE) || defined(SKTRAN_USE_MKL)
+        for (std::size_t index = 0; index < custom.right_hand_side.size();
+             ++index) {
+            REQUIRE(custom.right_hand_side[index] ==
+                    Catch::Approx(configured_lapack.right_hand_side[index])
+                        .epsilon(2.0e-13)
+                        .margin(2.0e-13));
+        }
+#else
+        REQUIRE(custom_pivots == configured_lapack_pivots);
+        REQUIRE(custom.matrix == configured_lapack.matrix);
+        REQUIRE(custom.right_hand_side == configured_lapack.right_hand_side);
+#endif
+    }
+}
+
+TEST_CASE("Unblocked band factorization reports singular pivots",
+          "[sktran_do][band_factorization]") {
+    constexpr lapack_int size = 12;
+    constexpr lapack_int bandwidth = 3;
+    constexpr lapack_int leading_dimension = 3 * bandwidth + 1;
+    std::vector<double> matrix(leading_dimension * size, 0.0);
+    std::vector<lapack_int> pivots(size);
+    REQUIRE(sasktran_disco::la::dgbtf2_unblocked(
+                size, bandwidth, bandwidth, matrix.data(), leading_dimension,
+                pivots.data()) == 1);
+}
+
+TEST_CASE("Unblocked band factorization dispatches for narrow DO systems",
+          "[sktran_do][band_factorization]") {
+    REQUIRE_FALSE(
+        sasktran_disco::la::use_unblocked_band_factorization(2, 2));
+#if defined(SKTRAN_USE_ACCELERATE) || defined(SKTRAN_USE_MKL)
+    REQUIRE_FALSE(
+        sasktran_disco::la::use_unblocked_band_factorization(5, 5));
+    REQUIRE_FALSE(
+        sasktran_disco::la::use_unblocked_band_factorization(29, 29));
+#else
+    REQUIRE(sasktran_disco::la::use_unblocked_band_factorization(5, 5));
+    REQUIRE(sasktran_disco::la::use_unblocked_band_factorization(29, 29));
+#endif
+    REQUIRE_FALSE(
+        sasktran_disco::la::use_unblocked_band_factorization(32, 32));
+    REQUIRE_FALSE(
+        sasktran_disco::la::use_unblocked_band_factorization(11, 12));
+}
+
+TEST_CASE("Band solve performance", "[.benchmark][band_solve]") {
+    SECTION("scalar 4 streams, 20 layers") {
+        benchmark_band_solve(4 * 20, 5);
+    }
+    SECTION("scalar 4 streams, 100 layers") {
+        benchmark_band_solve(4 * 100, 5);
+    }
+    SECTION("scalar 8 streams, 20 layers") {
+        benchmark_band_solve(8 * 20, 11);
+    }
+    SECTION("scalar 8 streams, 100 layers") {
+        benchmark_band_solve(8 * 100, 11);
+    }
+    SECTION("scalar 16 streams, 20 layers") {
+        benchmark_band_solve(16 * 20, 23);
+    }
+    SECTION("scalar 16 streams, 100 layers") {
+        benchmark_band_solve(16 * 100, 23);
+    }
+    SECTION("IQU 2 streams, 20 layers") {
+        benchmark_band_solve(6 * 20, 8);
+    }
+    SECTION("IQU 2 streams, 100 layers") {
+        benchmark_band_solve(6 * 100, 8);
+    }
+    SECTION("IQU 4 streams, 20 layers") {
+        benchmark_band_solve(12 * 20, 17);
+    }
+    SECTION("IQU 4 streams, 100 layers") {
+        benchmark_band_solve(12 * 100, 17);
+    }
+    SECTION("IQU 8 streams, 20 layers") {
+        benchmark_band_solve(24 * 20, 35);
+    }
+    SECTION("IQU 8 streams, 100 layers") {
+        benchmark_band_solve(24 * 100, 35);
+    }
+    SECTION("bandwidth 26, 100 layers") {
+        benchmark_band_solve(18 * 100, 26);
+    }
+    SECTION("bandwidth 29, 100 layers") {
+        benchmark_band_solve(20 * 100, 29);
+    }
+    SECTION("bandwidth 32, 100 layers") {
+        benchmark_band_solve(22 * 100, 32);
+    }
+}

--- a/cpp/lib/tests/sktran_disco/test_band_factorization.cpp
+++ b/cpp/lib/tests/sktran_disco/test_band_factorization.cpp
@@ -20,14 +20,14 @@ namespace {
     BandSystem make_band_system(lapack_int size, lapack_int bandwidth,
                                 lapack_int right_hand_sides,
                                 bool require_pivoting = false) {
-        BandSystem result{size,
-                          bandwidth,
-                          right_hand_sides,
-                          3 * bandwidth + 1,
-                          std::vector<double>((3 * bandwidth + 1) * size,
-                                              -71.25),
-                          std::vector<double>(size * right_hand_sides, 0.0),
-                          std::vector<double>(size * right_hand_sides, 0.0)};
+        BandSystem result{
+            size,
+            bandwidth,
+            right_hand_sides,
+            3 * bandwidth + 1,
+            std::vector<double>((3 * bandwidth + 1) * size, -71.25),
+            std::vector<double>(size * right_hand_sides, 0.0),
+            std::vector<double>(size * right_hand_sides, 0.0)};
         const lapack_int diagonal_row = 2 * bandwidth;
         for (lapack_int rhs = 0; rhs < right_hand_sides; ++rhs) {
             for (lapack_int row = 0; row < size; ++row) {
@@ -36,18 +36,18 @@ namespace {
             }
         }
         for (lapack_int column = 0; column < size; ++column) {
-            const lapack_int first_row = std::max<lapack_int>(0, column - bandwidth);
+            const lapack_int first_row =
+                std::max<lapack_int>(0, column - bandwidth);
             const lapack_int last_row =
                 std::min<lapack_int>(size - 1, column + bandwidth);
             for (lapack_int row = first_row; row <= last_row; ++row) {
                 double value =
-                    0.015 * std::sin(static_cast<double>((row + 3) *
-                                                        (column + 5)));
+                    0.015 *
+                    std::sin(static_cast<double>((row + 3) * (column + 5)));
                 if (row == column) {
                     value += 2.5 + 0.001 * static_cast<double>(row);
                 }
-                if (require_pivoting && column % 5 == 0 &&
-                    column + 1 < size) {
+                if (require_pivoting && column % 5 == 0 && column + 1 < size) {
                     if (row == column) {
                         value = 0.25;
                     } else if (row == column + 1) {
@@ -76,19 +76,19 @@ namespace {
                system.right_hand_side.data(), &system.size, &info);
         return info;
 #else
-        return LAPACKE_dgbsv(
-            LAPACK_COL_MAJOR, system.size, system.bandwidth, system.bandwidth,
-            system.right_hand_sides, system.matrix.data(),
-            system.leading_dimension, pivots.data(),
-            system.right_hand_side.data(), system.size);
+        return LAPACKE_dgbsv(LAPACK_COL_MAJOR, system.size, system.bandwidth,
+                             system.bandwidth, system.right_hand_sides,
+                             system.matrix.data(), system.leading_dimension,
+                             pivots.data(), system.right_hand_side.data(),
+                             system.size);
 #endif
     }
 
     void benchmark_band_solve(lapack_int size, lapack_int bandwidth) {
         const auto source = make_band_system(size, bandwidth, 1, true);
 
-        BENCHMARK_ADVANCED("configured LAPACK")(
-            Catch::Benchmark::Chronometer meter) {
+        BENCHMARK_ADVANCED("configured LAPACK")
+        (Catch::Benchmark::Chronometer meter) {
             std::vector<BandSystem> systems(meter.runs(), source);
             std::vector<std::vector<lapack_int>> pivots(
                 meter.runs(), std::vector<lapack_int>(size));
@@ -97,8 +97,8 @@ namespace {
             });
         };
 
-        BENCHMARK_ADVANCED("unblocked C++")(
-            Catch::Benchmark::Chronometer meter) {
+        BENCHMARK_ADVANCED("unblocked C++")
+        (Catch::Benchmark::Chronometer meter) {
             std::vector<BandSystem> systems(meter.runs(), source);
             std::vector<std::vector<lapack_int>> pivots(
                 meter.runs(), std::vector<lapack_int>(size));
@@ -116,8 +116,8 @@ namespace {
 
 TEST_CASE("Unblocked band solve reproduces known solutions",
           "[sktran_do][band_factorization]") {
-    for (const lapack_int bandwidth : {lapack_int{5}, lapack_int{11},
-                                       lapack_int{17}}) {
+    for (const lapack_int bandwidth :
+         {lapack_int{5}, lapack_int{11}, lapack_int{17}}) {
         auto system = make_band_system(6 * bandwidth + 7, bandwidth, 3);
         std::vector<lapack_int> pivots(system.size);
         const int info = sasktran_disco::la::dgbsv_unblocked(
@@ -135,9 +135,9 @@ TEST_CASE("Unblocked band solve reproduces known solutions",
 
 TEST_CASE("Unblocked band factorization matches configured LAPACK",
           "[sktran_do][band_factorization]") {
-    for (const lapack_int bandwidth : {
-             lapack_int{5}, lapack_int{8}, lapack_int{11}, lapack_int{17},
-             lapack_int{23}, lapack_int{26}, lapack_int{29}}) {
+    for (const lapack_int bandwidth :
+         {lapack_int{5}, lapack_int{8}, lapack_int{11}, lapack_int{17},
+          lapack_int{23}, lapack_int{26}, lapack_int{29}}) {
         auto custom = make_band_system(10 * bandwidth + 3, bandwidth, 3, true);
         auto configured_lapack = custom;
         std::vector<lapack_int> custom_pivots(custom.size);
@@ -182,33 +182,24 @@ TEST_CASE("Unblocked band factorization reports singular pivots",
 
 TEST_CASE("Unblocked band factorization dispatches for narrow DO systems",
           "[sktran_do][band_factorization]") {
-    REQUIRE_FALSE(
-        sasktran_disco::la::use_unblocked_band_factorization(2, 2));
+    REQUIRE_FALSE(sasktran_disco::la::use_unblocked_band_factorization(2, 2));
 #if defined(SKTRAN_USE_ACCELERATE) || defined(SKTRAN_USE_MKL)
-    REQUIRE_FALSE(
-        sasktran_disco::la::use_unblocked_band_factorization(5, 5));
-    REQUIRE_FALSE(
-        sasktran_disco::la::use_unblocked_band_factorization(29, 29));
+    REQUIRE_FALSE(sasktran_disco::la::use_unblocked_band_factorization(5, 5));
+    REQUIRE_FALSE(sasktran_disco::la::use_unblocked_band_factorization(29, 29));
 #else
     REQUIRE(sasktran_disco::la::use_unblocked_band_factorization(5, 5));
     REQUIRE(sasktran_disco::la::use_unblocked_band_factorization(29, 29));
 #endif
-    REQUIRE_FALSE(
-        sasktran_disco::la::use_unblocked_band_factorization(32, 32));
-    REQUIRE_FALSE(
-        sasktran_disco::la::use_unblocked_band_factorization(11, 12));
+    REQUIRE_FALSE(sasktran_disco::la::use_unblocked_band_factorization(32, 32));
+    REQUIRE_FALSE(sasktran_disco::la::use_unblocked_band_factorization(11, 12));
 }
 
 TEST_CASE("Band solve performance", "[.benchmark][band_solve]") {
-    SECTION("scalar 4 streams, 20 layers") {
-        benchmark_band_solve(4 * 20, 5);
-    }
+    SECTION("scalar 4 streams, 20 layers") { benchmark_band_solve(4 * 20, 5); }
     SECTION("scalar 4 streams, 100 layers") {
         benchmark_band_solve(4 * 100, 5);
     }
-    SECTION("scalar 8 streams, 20 layers") {
-        benchmark_band_solve(8 * 20, 11);
-    }
+    SECTION("scalar 8 streams, 20 layers") { benchmark_band_solve(8 * 20, 11); }
     SECTION("scalar 8 streams, 100 layers") {
         benchmark_band_solve(8 * 100, 11);
     }
@@ -218,31 +209,13 @@ TEST_CASE("Band solve performance", "[.benchmark][band_solve]") {
     SECTION("scalar 16 streams, 100 layers") {
         benchmark_band_solve(16 * 100, 23);
     }
-    SECTION("IQU 2 streams, 20 layers") {
-        benchmark_band_solve(6 * 20, 8);
-    }
-    SECTION("IQU 2 streams, 100 layers") {
-        benchmark_band_solve(6 * 100, 8);
-    }
-    SECTION("IQU 4 streams, 20 layers") {
-        benchmark_band_solve(12 * 20, 17);
-    }
-    SECTION("IQU 4 streams, 100 layers") {
-        benchmark_band_solve(12 * 100, 17);
-    }
-    SECTION("IQU 8 streams, 20 layers") {
-        benchmark_band_solve(24 * 20, 35);
-    }
-    SECTION("IQU 8 streams, 100 layers") {
-        benchmark_band_solve(24 * 100, 35);
-    }
-    SECTION("bandwidth 26, 100 layers") {
-        benchmark_band_solve(18 * 100, 26);
-    }
-    SECTION("bandwidth 29, 100 layers") {
-        benchmark_band_solve(20 * 100, 29);
-    }
-    SECTION("bandwidth 32, 100 layers") {
-        benchmark_band_solve(22 * 100, 32);
-    }
+    SECTION("IQU 2 streams, 20 layers") { benchmark_band_solve(6 * 20, 8); }
+    SECTION("IQU 2 streams, 100 layers") { benchmark_band_solve(6 * 100, 8); }
+    SECTION("IQU 4 streams, 20 layers") { benchmark_band_solve(12 * 20, 17); }
+    SECTION("IQU 4 streams, 100 layers") { benchmark_band_solve(12 * 100, 17); }
+    SECTION("IQU 8 streams, 20 layers") { benchmark_band_solve(24 * 20, 35); }
+    SECTION("IQU 8 streams, 100 layers") { benchmark_band_solve(24 * 100, 35); }
+    SECTION("bandwidth 26, 100 layers") { benchmark_band_solve(18 * 100, 26); }
+    SECTION("bandwidth 29, 100 layers") { benchmark_band_solve(20 * 100, 29); }
+    SECTION("bandwidth 32, 100 layers") { benchmark_band_solve(22 * 100, 32); }
 }

--- a/cpp/lib/tests/sktran_disco/test_band_factorization.cpp
+++ b/cpp/lib/tests/sktran_disco/test_band_factorization.cpp
@@ -5,9 +5,52 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
 #include <vector>
 
 namespace {
+    bool set_environment_variable(
+        const std::string& name,
+        const std::optional<std::string>& value = std::nullopt) {
+#if defined(_WIN32)
+        return ::_putenv_s(name.c_str(), value ? value->c_str() : "") == 0;
+#else
+        return value ? ::setenv(name.c_str(), value->c_str(), 1) == 0
+                     : ::unsetenv(name.c_str()) == 0;
+#endif
+    }
+
+    class ScopedEnvironmentVariable {
+      public:
+        ScopedEnvironmentVariable(std::string name,
+                                  std::optional<std::string> value)
+            : m_name(std::move(name)) {
+            if (const char* original = std::getenv(m_name.c_str());
+                original != nullptr) {
+                m_original = original;
+            }
+            if (!set_environment_variable(m_name, value)) {
+                throw std::runtime_error("Failed to set environment variable");
+            }
+        }
+
+        ~ScopedEnvironmentVariable() {
+            (void)set_environment_variable(m_name, m_original);
+        }
+
+        ScopedEnvironmentVariable(const ScopedEnvironmentVariable&) = delete;
+        ScopedEnvironmentVariable&
+        operator=(const ScopedEnvironmentVariable&) = delete;
+
+      private:
+        std::string m_name;
+        std::optional<std::string> m_original;
+    };
+
     struct BandSystem {
         lapack_int size;
         lapack_int bandwidth;
@@ -195,19 +238,51 @@ TEST_CASE("Runtime band factorization policy prefers LAPACK for close results",
     REQUIRE(Tuner::select_banded_lu_backend(0.0, 1.0) == Backend::lapack);
 }
 
-TEST_CASE("Runtime band factorization tuner resolves a supported backend",
+TEST_CASE("Runtime band factorization tuner covers every DISCO source path",
           "[sktran_do][band_factorization]") {
-    sasktran2::Config config;
-    config.set_num_do_streams(8);
-    config.set_multiple_scatter_source(
-        sasktran2::Config::MultipleScatterSource::discrete_ordinates);
-    sasktran2::detail::RuntimeBackendTuner::resolve(config, 20);
+    using Backend = sasktran2::detail::BandedLUBackend;
+    using Source = sasktran2::Config::MultipleScatterSource;
+    using Tuner = sasktran2::detail::RuntimeBackendTuner;
 
-    const auto backend =
-        sasktran2::detail::RuntimeBackendTuner::resolved_banded_lu_backend(
-            config);
-    REQUIRE((backend == sasktran2::detail::BandedLUBackend::lapack ||
-             backend == sasktran2::detail::BandedLUBackend::unblocked));
+    const ScopedEnvironmentVariable enable_unblocked(
+        "SASKTRAN2_DISABLE_DO_UNBLOCKED_BAND_LU", std::nullopt);
+    const ScopedEnvironmentVariable force_unblocked(
+        "SASKTRAN2_DO_BANDED_LU_BACKEND", std::string("unblocked"));
+
+    SECTION("direct scalar two-stream source honors the explicit override") {
+        sasktran2::Config config;
+        config.set_num_stokes(1);
+        config.set_num_do_streams(2);
+        config.set_multiple_scatter_source(Source::discrete_ordinates);
+
+        Tuner::resolve(config, 20);
+
+        REQUIRE(Tuner::resolved_banded_lu_backend(config) ==
+                Backend::unblocked);
+    }
+
+    SECTION("HR initialized with discrete ordinates is tuned") {
+        sasktran2::Config config;
+        config.set_num_do_streams(8);
+        config.set_multiple_scatter_source(Source::hr);
+        config.set_initialize_hr_with_do(true);
+
+        Tuner::resolve(config, 20);
+
+        REQUIRE(Tuner::resolved_banded_lu_backend(config) ==
+                Backend::unblocked);
+    }
+
+    SECTION("HR without discrete-ordinates initialization is not tuned") {
+        sasktran2::Config config;
+        config.set_num_do_streams(8);
+        config.set_multiple_scatter_source(Source::hr);
+        config.set_initialize_hr_with_do(false);
+
+        Tuner::resolve(config, 20);
+
+        REQUIRE(Tuner::resolved_banded_lu_backend(config) == Backend::lapack);
+    }
 }
 
 TEST_CASE("Band solve performance", "[.benchmark][band_solve]") {


### PR DESCRIPTION
## Summary

- add a narrow-band DISCO factorization path with focused parity and performance tests
- choose between LAPACK and the unblocked implementation once at engine construction, including DISCO-initialized HR sources
- reuse eigensolver workspace and normalize eigenvectors in place
- skip exactly-zero homogeneous derivative solves and Green sources
- cache repeated solar and thermal Green-function exponentials

Each optimization is isolated in its own commit for review.

## Runtime backend selection

For direct DISCO sources and HR sources initialized with DISCO, engine construction benchmarks a synthetic band system matching the configured stream, Stokes, and layer dimensions. Both implementations must first produce matching solutions. LAPACK remains the default and wins close results; the unblocked implementation is selected only when its median time is at least 10% faster.

Selection can be made deterministic for diagnosis with `SASKTRAN2_DO_BANDED_LU_BACKEND=lapack` or `SASKTRAN2_DO_BANDED_LU_BACKEND=unblocked`. The existing `SASKTRAN2_DISABLE_DO_UNBLOCKED_BAND_LU` opt-out remains supported and takes precedence.

## Performance

For the representative one-thread scalar case with 8 streams, 20 layers, 40 wavelengths, and BVP backpropagation, the cumulative branch improved from 37.12 ms to 28.49 ms, a 23.2% reduction.

The one-time construction benchmark ranges from roughly 0.07 ms to 3.6 ms over the representative stream/layer configurations measured in this PR. The final exponential-caching change primarily benefits forward Jacobian calculations: source-heavy solar and thermal cases improved by roughly 1–2%, while backpropagation was unchanged within measurement noise.

## Numerical behavior

- radiance and Jacobian output hashes are bit-for-bit unchanged across scalar and polarized validation sweeps
- final Green-kernel hashes are unchanged for two-stream solar, eight-stream solar in forward and backprop modes, and eight-stream thermal calculations
- backend selection validates the unblocked solution against LAPACK before using benchmark timings
- all skips use exact-zero checks; no numerical tolerance or approximation was introduced

## Validation

- full pre-commit suite
- full Python suite: 450 passed, 13 skipped
- focused band-factorization tests: 4,309 assertions
- C++ DISCO tests: 4,344 assertions
- legacy DISCO tests: 911 assertions
- non-two-stream weighting-function tests: 44,503 assertions
- DISORT thermal-emission tests: 2 passed
- emission weighting-function tests: 4 passed

The full `[wf]` C++ tag also contains `twostream_engine_ground_extinction_wf_fd`, which fails on this machine for a near-zero finite-difference derivative and reproduces in isolation. It does not exercise the DISCO code changed here.
