### PR TITLE
Add black-box C++ successive-orders source

### DIFF
--- a/cpp/c_api/config.cpp
+++ b/cpp/c_api/config.cpp
@@ -2,6 +2,8 @@
 #include "sasktran2/config.h"
 #include "internal_types.h"
 #include <sasktran2.h>
+#include <algorithm>
+#include <cmath>
 
 extern "C" {
 Config* sk_config_create() { return new Config(); }
@@ -332,6 +334,126 @@ int sk_config_set_initialize_hr_with_do(Config* config, int initialize) {
     }
     config->impl.set_initialize_hr_with_do(initialize != 0);
     return 0; // Success
+}
+
+int sk_config_get_successive_orders_relative_tolerance(Config* config,
+                                                       double* tolerance) {
+    if (config == nullptr || tolerance == nullptr) {
+        return -1;
+    }
+    *tolerance = config->impl.successive_orders_relative_tolerance();
+    return 0;
+}
+
+int sk_config_set_successive_orders_relative_tolerance(Config* config,
+                                                       double tolerance) {
+    if (config == nullptr || !std::isfinite(tolerance) || tolerance < 0) {
+        return -1;
+    }
+    config->impl.set_successive_orders_relative_tolerance(tolerance);
+    return 0;
+}
+
+int sk_config_get_successive_orders_absolute_tolerance(Config* config,
+                                                       double* tolerance) {
+    if (config == nullptr || tolerance == nullptr) {
+        return -1;
+    }
+    *tolerance = config->impl.successive_orders_absolute_tolerance();
+    return 0;
+}
+
+int sk_config_set_successive_orders_absolute_tolerance(Config* config,
+                                                       double tolerance) {
+    if (config == nullptr || !std::isfinite(tolerance) || tolerance < 0) {
+        return -1;
+    }
+    config->impl.set_successive_orders_absolute_tolerance(tolerance);
+    return 0;
+}
+
+int sk_config_get_successive_orders_anderson_depth(Config* config, int* depth) {
+    if (config == nullptr || depth == nullptr) {
+        return -1;
+    }
+    *depth = config->impl.successive_orders_anderson_depth();
+    return 0;
+}
+
+int sk_config_set_successive_orders_anderson_depth(Config* config, int depth) {
+    if (config == nullptr || depth < 0) {
+        return -1;
+    }
+    config->impl.set_successive_orders_anderson_depth(depth);
+    return 0;
+}
+
+int sk_config_get_successive_orders_damping(Config* config, double* damping) {
+    if (config == nullptr || damping == nullptr) {
+        return -1;
+    }
+    *damping = config->impl.successive_orders_damping();
+    return 0;
+}
+
+int sk_config_set_successive_orders_damping(Config* config, double damping) {
+    if (config == nullptr || !std::isfinite(damping) || damping <= 0 ||
+        damping > 1) {
+        return -1;
+    }
+    config->impl.set_successive_orders_damping(damping);
+    return 0;
+}
+
+int sk_config_get_num_successive_orders_altitudes(Config* config,
+                                                  int* num_altitudes) {
+    if (config == nullptr || num_altitudes == nullptr) {
+        return -1;
+    }
+    *num_altitudes = static_cast<int>(
+        config->impl.successive_orders_altitude_grid_m().size());
+    return 0;
+}
+
+int sk_config_get_successive_orders_altitude_grid_m(Config* config,
+                                                    double* altitude_grid_m) {
+    if (config == nullptr) {
+        return -1;
+    }
+    const auto& configured_grid =
+        config->impl.successive_orders_altitude_grid_m();
+    if (!configured_grid.empty() && altitude_grid_m == nullptr) {
+        return -1;
+    }
+    if (!configured_grid.empty()) {
+        std::copy(configured_grid.begin(), configured_grid.end(),
+                  altitude_grid_m);
+    }
+    return 0;
+}
+
+int sk_config_set_successive_orders_altitude_grid_m(
+    Config* config, const double* altitude_grid_m, int num_altitudes) {
+    if (config == nullptr || num_altitudes < 0 ||
+        (num_altitudes > 0 && altitude_grid_m == nullptr)) {
+        return -1;
+    }
+    for (int altitude_index = 0; altitude_index < num_altitudes;
+         ++altitude_index) {
+        if (!std::isfinite(altitude_grid_m[altitude_index]) ||
+            (altitude_index > 0 && altitude_grid_m[altitude_index] <=
+                                       altitude_grid_m[altitude_index - 1])) {
+            return -2;
+        }
+    }
+    std::vector<double> configured_grid;
+    if (num_altitudes > 0) {
+        configured_grid.assign(altitude_grid_m,
+                               altitude_grid_m + num_altitudes);
+    }
+    config->impl.set_successive_orders_altitude_grid_m(
+        std::move(configured_grid));
+    return 0;
 }
 
 int sk_config_get_occultation_source(Config* config, int* occultation_source) {

--- a/cpp/include/c_api/config.h
+++ b/cpp/include/c_api/config.h
@@ -71,6 +71,26 @@ int sk_config_set_num_hr_full_incoming_points(Config* config, int num_points);
 int sk_config_get_initialize_hr_with_do(Config* config, int* initialize);
 int sk_config_set_initialize_hr_with_do(Config* config, int initialize);
 
+// C++ successive-orders configuration
+int sk_config_get_successive_orders_relative_tolerance(Config* config,
+                                                       double* tolerance);
+int sk_config_set_successive_orders_relative_tolerance(Config* config,
+                                                       double tolerance);
+int sk_config_get_successive_orders_absolute_tolerance(Config* config,
+                                                       double* tolerance);
+int sk_config_set_successive_orders_absolute_tolerance(Config* config,
+                                                       double tolerance);
+int sk_config_get_successive_orders_anderson_depth(Config* config, int* depth);
+int sk_config_set_successive_orders_anderson_depth(Config* config, int depth);
+int sk_config_get_successive_orders_damping(Config* config, double* damping);
+int sk_config_set_successive_orders_damping(Config* config, double damping);
+int sk_config_get_num_successive_orders_altitudes(Config* config,
+                                                  int* num_altitudes);
+int sk_config_get_successive_orders_altitude_grid_m(Config* config,
+                                                    double* altitude_grid_m);
+int sk_config_set_successive_orders_altitude_grid_m(
+    Config* config, const double* altitude_grid_m, int num_altitudes);
+
 // Source configuration methods
 int sk_config_get_occultation_source(Config* config, int* occultation_source);
 int sk_config_set_occultation_source(Config* config, int occultation_source);

--- a/cpp/include/sasktran2/config.h
+++ b/cpp/include/sasktran2/config.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <spdlog/spdlog.h>
+#include <utility>
+#include <vector>
 
 namespace sasktran_disco {
     template <int NSTOKES, int CNSTR> class PersistentConfiguration;
@@ -52,14 +54,20 @@ namespace sasktran2 {
          *  'hr' Uses a successive orders of scattering method to calculate the
          * multiple scatter source.
          *
+         *  'twostream' Uses the two-stream approximation.
+         *
          *  'none' Removes the multiple scatter source from the calculation.
+         *
+         *  'successive_orders_cpp' Uses the self-contained C++ successive
+         * orders implementation.
          *
          */
         enum class MultipleScatterSource {
             discrete_ordinates = 0,
             hr = 1,
             twostream = 2,
-            none = 3
+            none = 3,
+            successive_orders_cpp = 4
         };
 
         /** Enum that determines the accuracy of the weighting function solution
@@ -457,6 +465,49 @@ namespace sasktran2 {
             m_hr_nspherical_iterations = n;
         }
 
+        /** Relative residual tolerance for the C++ successive-orders source.
+         * Set both tolerances to zero to use a fixed iteration count. */
+        double successive_orders_relative_tolerance() const {
+            return m_successive_orders_relative_tolerance;
+        }
+        void set_successive_orders_relative_tolerance(double tolerance) {
+            m_successive_orders_relative_tolerance = tolerance;
+        }
+
+        /** Absolute residual tolerance for the C++ successive-orders source. */
+        double successive_orders_absolute_tolerance() const {
+            return m_successive_orders_absolute_tolerance;
+        }
+        void set_successive_orders_absolute_tolerance(double tolerance) {
+            m_successive_orders_absolute_tolerance = tolerance;
+        }
+
+        /** Anderson history depth. Zero selects damped Picard iteration. */
+        int successive_orders_anderson_depth() const {
+            return m_successive_orders_anderson_depth;
+        }
+        void set_successive_orders_anderson_depth(int depth) {
+            m_successive_orders_anderson_depth = depth;
+        }
+
+        /** Fixed-point damping in the interval (0, 1]. */
+        double successive_orders_damping() const {
+            return m_successive_orders_damping;
+        }
+        void set_successive_orders_damping(double damping) {
+            m_successive_orders_damping = damping;
+        }
+
+        /** Explicit source altitude grid in metres. An empty grid selects the
+         * source's default atmosphere-derived grid. */
+        const std::vector<double>& successive_orders_altitude_grid_m() const {
+            return m_successive_orders_altitude_grid_m;
+        }
+        void set_successive_orders_altitude_grid_m(
+            std::vector<double> altitude_grid_m) {
+            m_successive_orders_altitude_grid_m = std::move(altitude_grid_m);
+        }
+
         /**
          *
          * @return The number of incoming points at each diffuse point in the HR
@@ -726,6 +777,12 @@ namespace sasktran2 {
 
         int m_hr_nspherical_iterations;
         int m_hr_num_incoming_points;
+
+        double m_successive_orders_relative_tolerance = 1.0e-6;
+        double m_successive_orders_absolute_tolerance = 1.0e-12;
+        int m_successive_orders_anderson_depth = 3;
+        double m_successive_orders_damping = 1.0;
+        std::vector<double> m_successive_orders_altitude_grid_m;
 
         bool m_apply_delta_scaling;
 

--- a/cpp/include/sasktran2/config.h
+++ b/cpp/include/sasktran2/config.h
@@ -51,23 +51,23 @@ namespace sasktran2 {
          *  'discrete_ordinates' Uses the discrete ordinates method to calculate
          * the multiple scatter source.
          *
-         *  'hr' Uses a successive orders of scattering method to calculate the
-         * multiple scatter source.
+         *  'successive_orders_legacy' uses the legacy successive orders of
+         * scattering implementation.
          *
          *  'twostream' Uses the two-stream approximation.
          *
          *  'none' Removes the multiple scatter source from the calculation.
          *
-         *  'successive_orders_cpp' Uses the self-contained C++ successive
-         * orders implementation.
+         *  'successive_orders' uses the successive orders of scattering
+         * implementation.
          *
          */
         enum class MultipleScatterSource {
             discrete_ordinates = 0,
-            hr = 1,
+            successive_orders_legacy = 1,
             twostream = 2,
             none = 3,
-            successive_orders_cpp = 4
+            successive_orders = 4
         };
 
         /** Enum that determines the accuracy of the weighting function solution

--- a/cpp/lib/CMakeLists.txt
+++ b/cpp/lib/CMakeLists.txt
@@ -50,6 +50,15 @@ add_library(
   engine/engine.cpp
   hr/diffuse_point.cpp
   hr/diffuse_table.cpp
+  successive_orders/angular_basis.cpp
+  successive_orders/first_order.cpp
+  successive_orders/geometry.cpp
+  successive_orders/interpolation.cpp
+  successive_orders/problem.cpp
+  successive_orders/ray_transport.cpp
+  successive_orders/scattering.cpp
+  successive_orders/scattering_assembler.cpp
+  successive_orders/source.cpp
   derivative_mapping/derivative_mapping.cpp
   sktran_disco/sktran_do.cpp
   sktran_disco/sktran_do_geometrylayerarray.cpp

--- a/cpp/lib/config/runtime_backend_tuner.cpp
+++ b/cpp/lib/config/runtime_backend_tuner.cpp
@@ -209,7 +209,8 @@ namespace sasktran2::detail {
         const bool uses_discrete_ordinates =
             multiple_scatter_source ==
                 Config::MultipleScatterSource::discrete_ordinates ||
-            (multiple_scatter_source == Config::MultipleScatterSource::hr &&
+            (multiple_scatter_source ==
+                 Config::MultipleScatterSource::successive_orders_legacy &&
              config.initialize_hr_with_do());
         if (!uses_discrete_ordinates || num_layers <= 0) {
             return;

--- a/cpp/lib/engine/engine.cpp
+++ b/cpp/lib/engine/engine.cpp
@@ -4,6 +4,7 @@
 #include "sasktran2/raytracing.h"
 #include "sasktran2/runtime_backend_tuner.h"
 #include "sasktran2/source_interface.h"
+#include "../successive_orders/factory.h"
 #include "sktran_disco/twostream/cpp_source.h"
 #include "sktran_disco/twostream/meta.h"
 #include <memory>
@@ -313,6 +314,13 @@ template <int NSTOKES> void Sasktran2<NSTOKES>::construct_source_terms() {
                 *m_raytracer, *m_geometry_1d));
         m_los_source_terms.push_back(
             m_source_terms[m_source_terms.size() - 1].get());
+    } else if (m_config.multiple_scatter_source() ==
+               sasktran2::Config::MultipleScatterSource::
+                   successive_orders_cpp) {
+        m_source_terms.emplace_back(
+            sasktran2::successive_orders::make_successive_orders_source<
+                NSTOKES>(*m_raytracer, *m_geometry_1d));
+        m_los_source_terms.push_back(m_source_terms.back().get());
     } else if (m_config.multiple_scatter_source() ==
                sasktran2::Config::MultipleScatterSource::twostream) {
         if constexpr (NSTOKES == 1) {

--- a/cpp/lib/engine/engine.cpp
+++ b/cpp/lib/engine/engine.cpp
@@ -308,15 +308,15 @@ template <int NSTOKES> void Sasktran2<NSTOKES>::construct_source_terms() {
         m_los_source_terms.push_back(
             m_source_terms[m_source_terms.size() - 1].get());
     } else if (m_config.multiple_scatter_source() ==
-               sasktran2::Config::MultipleScatterSource::hr) {
+               sasktran2::Config::MultipleScatterSource::
+                   successive_orders_legacy) {
         m_source_terms.emplace_back(
             std::make_unique<sasktran2::hr::DiffuseTable<NSTOKES>>(
                 *m_raytracer, *m_geometry_1d));
         m_los_source_terms.push_back(
             m_source_terms[m_source_terms.size() - 1].get());
     } else if (m_config.multiple_scatter_source() ==
-               sasktran2::Config::MultipleScatterSource::
-                   successive_orders_cpp) {
+               sasktran2::Config::MultipleScatterSource::successive_orders) {
         m_source_terms.emplace_back(
             sasktran2::successive_orders::make_successive_orders_source<
                 NSTOKES>(*m_raytracer, *m_geometry_1d));

--- a/cpp/lib/successive_orders/angular_basis.cpp
+++ b/cpp/lib/successive_orders/angular_basis.cpp
@@ -1,0 +1,1027 @@
+#include "angular_basis.h"
+
+#include <sasktran2/math/scattering.h>
+#include <sasktran2/math/unitsphere.h>
+#include <sasktran2/math/wigner.h>
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <stdexcept>
+
+namespace sasktran2::successive_orders {
+    namespace {
+        void fill_basis(const sasktran2::math::UnitSphere& sphere,
+                        int num_coefficients, Eigen::MatrixXd& values,
+                        std::vector<int>& mode_degrees) {
+            const int num_modes = num_coefficients * num_coefficients;
+            values.setZero(sphere.num_points(), num_modes);
+            mode_degrees.assign(num_modes, 0);
+
+            Eigen::VectorXd degrees(num_coefficients);
+            for (int direction_index = 0; direction_index < sphere.num_points();
+                 ++direction_index) {
+                const Eigen::Vector3d direction =
+                    sphere.get_quad_position(direction_index).normalized();
+                const double theta =
+                    std::acos(std::clamp(direction.z(), -1.0, 1.0));
+                const double phi = std::atan2(direction.y(), direction.x());
+                for (int order = 0; order < num_coefficients; ++order) {
+                    sasktran2::math::WignerDCalculator calculator(order, 0);
+                    for (int degree = 0; degree < num_coefficients; ++degree) {
+                        degrees(degree) = calculator.d(theta, degree);
+                    }
+                    for (int degree = order; degree < num_coefficients;
+                         ++degree) {
+                        const int mode_start = degree * degree;
+                        mode_degrees[mode_start] = degree;
+                        if (order == 0) {
+                            values(direction_index, mode_start) =
+                                degrees(degree);
+                        } else {
+                            const double scale =
+                                std::sqrt(2.0) * degrees(degree);
+                            const int cosine_mode = mode_start + 2 * order - 1;
+                            const int sine_mode = mode_start + 2 * order;
+                            mode_degrees[cosine_mode] = degree;
+                            mode_degrees[sine_mode] = degree;
+                            values(direction_index, cosine_mode) =
+                                scale * std::cos(order * phi);
+                            values(direction_index, sine_mode) =
+                                scale * std::sin(order * phi);
+                        }
+                    }
+                }
+            }
+        }
+
+        void fill_wigner_degrees(sasktran2::math::WignerDCalculator& calculator,
+                                 double theta, int num_coefficients,
+                                 std::vector<double>& values) {
+#ifdef SKTRAN_RUST_SUPPORT
+            // The Rust-backed wrapper takes an output count, matching the
+            // vector length used by PhaseHandler.
+            calculator.vec_d_emplace(theta, num_coefficients, values.data());
+#else
+            // The legacy header-only fallback exposes an inclusive maximum
+            // degree instead. Avoid relying on that differing convention.
+            for (int degree = 0; degree < num_coefficients; ++degree) {
+                values[degree] = calculator.d(theta, degree);
+            }
+#endif
+        }
+    } // namespace
+
+    ScalarAngularBasis::ScalarAngularBasis(
+        const sasktran2::math::UnitSphere& incoming,
+        const sasktran2::math::UnitSphere& outgoing, int num_coefficients)
+        : m_num_coefficients(num_coefficients) {
+        if (num_coefficients < 1 || incoming.num_points() < 1 ||
+            outgoing.num_points() < 1) {
+            throw std::invalid_argument(
+                "invalid scalar successive-orders angular basis dimensions");
+        }
+
+        Eigen::MatrixXd incoming_basis;
+        fill_basis(incoming, num_coefficients, incoming_basis, m_mode_degrees);
+        std::vector<int> outgoing_degrees;
+        fill_basis(outgoing, num_coefficients, m_synthesis, outgoing_degrees);
+        if (outgoing_degrees != m_mode_degrees) {
+            throw std::logic_error(
+                "inconsistent successive-orders angular basis ordering");
+        }
+
+        m_analysis = incoming_basis.transpose();
+        for (int direction = 0; direction < incoming.num_points();
+             ++direction) {
+            m_analysis.col(direction) *= incoming.quadrature_weight(direction);
+        }
+    }
+
+    std::size_t ScalarAngularBasis::storage_bytes() const {
+        return static_cast<std::size_t>(m_analysis.size() +
+                                        m_synthesis.size()) *
+                   sizeof(double) +
+               m_mode_degrees.capacity() * sizeof(int);
+    }
+
+    void ScalarAngularBasis::validate_blocks(
+        Eigen::Ref<const Eigen::MatrixXd> incoming,
+        Eigen::Ref<const Eigen::MatrixXd> coefficients,
+        Eigen::Ref<const Eigen::MatrixXd> outgoing) const {
+        if (incoming.rows() != coefficients.rows() ||
+            outgoing.rows() != coefficients.rows() ||
+            incoming.cols() != input_size() ||
+            outgoing.cols() != output_size() ||
+            coefficients.cols() != num_coefficients()) {
+            throw std::invalid_argument(
+                "invalid scalar successive-orders scattering block dimensions");
+        }
+    }
+
+    void ScalarAngularBasis::multiply_coefficients(
+        Eigen::MatrixXd& moments,
+        Eigen::Ref<const Eigen::MatrixXd> coefficients) const {
+        for (int mode = 0; mode < num_modes(); ++mode) {
+            moments.col(mode).array() *=
+                coefficients.col(m_mode_degrees[mode]).array();
+        }
+    }
+
+    void
+    ScalarAngularBasis::apply(Eigen::Ref<const Eigen::MatrixXd> incoming,
+                              Eigen::Ref<const Eigen::MatrixXd> coefficients,
+                              Eigen::Ref<Eigen::MatrixXd> outgoing,
+                              Eigen::MatrixXd& moment_workspace) const {
+        apply_active(incoming, coefficients, num_coefficients(), outgoing,
+                     moment_workspace);
+    }
+
+    void ScalarAngularBasis::apply_active(
+        Eigen::Ref<const Eigen::MatrixXd> incoming,
+        Eigen::Ref<const Eigen::MatrixXd> coefficients, int active_coefficients,
+        Eigen::Ref<Eigen::MatrixXd> outgoing,
+        Eigen::MatrixXd& moment_workspace) const {
+        validate_blocks(incoming, coefficients, outgoing);
+        if (active_coefficients < 1 ||
+            active_coefficients > num_coefficients()) {
+            throw std::invalid_argument(
+                "invalid active scalar scattering coefficient count");
+        }
+        const int active_modes = active_coefficients * active_coefficients;
+        moment_workspace.resize(incoming.rows(), active_modes);
+        moment_workspace.noalias() =
+            incoming * m_analysis.topRows(active_modes).transpose();
+        for (int mode = 0; mode < active_modes; ++mode) {
+            moment_workspace.col(mode).array() *=
+                coefficients.col(m_mode_degrees[mode]).array();
+        }
+        outgoing.noalias() =
+            moment_workspace * m_synthesis.leftCols(active_modes).transpose();
+    }
+
+    void ScalarAngularBasis::apply_transpose(
+        Eigen::Ref<const Eigen::MatrixXd> outgoing,
+        Eigen::Ref<const Eigen::MatrixXd> coefficients,
+        Eigen::Ref<Eigen::MatrixXd> incoming,
+        Eigen::MatrixXd& moment_workspace) const {
+        apply_transpose_active(outgoing, coefficients, num_coefficients(),
+                               incoming, moment_workspace);
+    }
+
+    void ScalarAngularBasis::apply_transpose_active(
+        Eigen::Ref<const Eigen::MatrixXd> outgoing,
+        Eigen::Ref<const Eigen::MatrixXd> coefficients, int active_coefficients,
+        Eigen::Ref<Eigen::MatrixXd> incoming,
+        Eigen::MatrixXd& moment_workspace) const {
+        validate_blocks(incoming, coefficients, outgoing);
+        if (active_coefficients < 1 ||
+            active_coefficients > num_coefficients()) {
+            throw std::invalid_argument(
+                "invalid active scalar scattering coefficient count");
+        }
+        const int active_modes = active_coefficients * active_coefficients;
+        moment_workspace.resize(outgoing.rows(), active_modes);
+        moment_workspace.noalias() =
+            outgoing * m_synthesis.leftCols(active_modes);
+        for (int mode = 0; mode < active_modes; ++mode) {
+            moment_workspace.col(mode).array() *=
+                coefficients.col(m_mode_degrees[mode]).array();
+        }
+        incoming.noalias() =
+            moment_workspace * m_analysis.topRows(active_modes);
+    }
+
+    void ScalarAngularBasis::apply_jvp(
+        Eigen::Ref<const Eigen::MatrixXd> incoming,
+        Eigen::Ref<const Eigen::MatrixXd> incoming_tangent,
+        Eigen::Ref<const Eigen::MatrixXd> coefficients,
+        Eigen::Ref<const Eigen::MatrixXd> coefficient_tangent,
+        Eigen::Ref<Eigen::MatrixXd> outgoing_tangent,
+        Eigen::MatrixXd& moment_workspace,
+        Eigen::MatrixXd& tangent_workspace) const {
+        apply_jvp_active(incoming, incoming_tangent, coefficients,
+                         coefficient_tangent, num_coefficients(),
+                         outgoing_tangent, moment_workspace, tangent_workspace);
+    }
+
+    void ScalarAngularBasis::apply_jvp_active(
+        Eigen::Ref<const Eigen::MatrixXd> incoming,
+        Eigen::Ref<const Eigen::MatrixXd> incoming_tangent,
+        Eigen::Ref<const Eigen::MatrixXd> coefficients,
+        Eigen::Ref<const Eigen::MatrixXd> coefficient_tangent,
+        int active_coefficients, Eigen::Ref<Eigen::MatrixXd> outgoing_tangent,
+        Eigen::MatrixXd& moment_workspace,
+        Eigen::MatrixXd& tangent_workspace) const {
+        validate_blocks(incoming, coefficients, outgoing_tangent);
+        if (incoming_tangent.rows() != incoming.rows() ||
+            incoming_tangent.cols() != incoming.cols() ||
+            coefficient_tangent.rows() != coefficients.rows() ||
+            coefficient_tangent.cols() != coefficients.cols()) {
+            throw std::invalid_argument(
+                "invalid scalar successive-orders scattering JVP dimensions");
+        }
+        if (active_coefficients < 1 ||
+            active_coefficients > num_coefficients()) {
+            throw std::invalid_argument(
+                "invalid active scalar scattering JVP coefficient count");
+        }
+
+        const int active_modes = active_coefficients * active_coefficients;
+        moment_workspace.resize(incoming.rows(), active_modes);
+        tangent_workspace.resize(incoming.rows(), active_modes);
+        moment_workspace.noalias() =
+            incoming * m_analysis.topRows(active_modes).transpose();
+        tangent_workspace.noalias() =
+            incoming_tangent * m_analysis.topRows(active_modes).transpose();
+        for (int mode = 0; mode < active_modes; ++mode) {
+            const int degree = m_mode_degrees[mode];
+            tangent_workspace.col(mode).array() =
+                tangent_workspace.col(mode).array() *
+                    coefficients.col(degree).array() +
+                moment_workspace.col(mode).array() *
+                    coefficient_tangent.col(degree).array();
+        }
+        outgoing_tangent.noalias() =
+            tangent_workspace * m_synthesis.leftCols(active_modes).transpose();
+    }
+
+    void ScalarAngularBasis::apply_vjp(
+        Eigen::Ref<const Eigen::MatrixXd> incoming,
+        Eigen::Ref<const Eigen::MatrixXd> coefficients,
+        Eigen::Ref<const Eigen::MatrixXd> outgoing_cotangent,
+        Eigen::Ref<Eigen::MatrixXd> incoming_cotangent,
+        Eigen::Ref<Eigen::MatrixXd> coefficient_gradient,
+        Eigen::MatrixXd& analyzed_workspace,
+        Eigen::MatrixXd& moment_cotangent_workspace) const {
+        validate_blocks(incoming, coefficients, outgoing_cotangent);
+        if (incoming_cotangent.rows() != incoming.rows() ||
+            incoming_cotangent.cols() != incoming.cols() ||
+            coefficient_gradient.rows() != coefficients.rows() ||
+            coefficient_gradient.cols() != coefficients.cols()) {
+            throw std::invalid_argument(
+                "invalid scalar successive-orders scattering VJP dimensions");
+        }
+
+        analyzed_workspace.resize(incoming.rows(), num_modes());
+        moment_cotangent_workspace.resize(incoming.rows(), num_modes());
+        analyzed_workspace.noalias() = incoming * m_analysis.transpose();
+        moment_cotangent_workspace.noalias() = outgoing_cotangent * m_synthesis;
+
+        coefficient_gradient.setZero();
+        for (int mode = 0; mode < num_modes(); ++mode) {
+            const int degree = m_mode_degrees[mode];
+            coefficient_gradient.col(degree).array() +=
+                analyzed_workspace.col(mode).array() *
+                moment_cotangent_workspace.col(mode).array();
+            moment_cotangent_workspace.col(mode).array() *=
+                coefficients.col(degree).array();
+        }
+        incoming_cotangent.noalias() = moment_cotangent_workspace * m_analysis;
+    }
+
+    std::size_t VectorAngularWorkspace::storage_bytes() const {
+        std::size_t values = static_cast<std::size_t>(
+            stacked_input.size() + stacked_moments.size() +
+            real_products.size() + imaginary_products.size());
+        for (const auto& matrix : stokes_input) {
+            values += static_cast<std::size_t>(matrix.size());
+        }
+        for (const auto& matrix : stokes_output) {
+            values += static_cast<std::size_t>(matrix.size());
+        }
+        for (const auto& matrix : moments) {
+            values += static_cast<std::size_t>(matrix.size());
+        }
+        return values * sizeof(double);
+    }
+
+    VectorAngularBasis::VectorAngularBasis(
+        const sasktran2::math::UnitSphere& incoming,
+        const sasktran2::math::UnitSphere& outgoing, int num_coefficients)
+        : m_num_coefficients(num_coefficients),
+          m_mode_degrees(static_cast<std::size_t>(num_coefficients) *
+                             num_coefficients,
+                         0) {
+        if (num_coefficients < 1 || incoming.num_points() < 1 ||
+            outgoing.num_points() < 1) {
+            throw std::invalid_argument(
+                "invalid vector successive-orders angular basis dimensions");
+        }
+        const int modes = num_modes();
+        for (int channel = 0; channel < 3; ++channel) {
+            m_analysis_real[channel].setZero(modes, incoming.num_points());
+            m_analysis_imaginary[channel].setZero(modes, incoming.num_points());
+            m_synthesis_real[channel].setZero(outgoing.num_points(), modes);
+            m_synthesis_imaginary[channel].setZero(outgoing.num_points(),
+                                                   modes);
+        }
+
+        const std::array<int, 3> spins{0, 2, -2};
+        std::vector<Eigen::Vector3d> incoming_directions(incoming.num_points());
+        std::vector<Eigen::Vector3d> outgoing_directions(outgoing.num_points());
+        for (int index = 0; index < incoming.num_points(); ++index) {
+            incoming_directions[index] =
+                incoming.get_quad_position(index).normalized();
+        }
+        for (int index = 0; index < outgoing.num_points(); ++index) {
+            outgoing_directions[index] =
+                outgoing.get_quad_position(index).normalized();
+        }
+
+        // Reuse one recurrence calculator for an entire angular order and
+        // evaluate all degrees in one call. With the Rust-backed calculator
+        // this also removes tens of thousands of small FFI calls at setup.
+        for (int order = 1 - num_coefficients; order < num_coefficients;
+             ++order) {
+            std::array<sasktran2::math::WignerDCalculator, 3> calculators{
+                sasktran2::math::WignerDCalculator(order, spins[0]),
+                sasktran2::math::WignerDCalculator(order, spins[1]),
+                sasktran2::math::WignerDCalculator(order, spins[2])};
+            std::array<std::vector<double>, 3> degree_values;
+            for (auto& values : degree_values) {
+                values.resize(num_coefficients);
+            }
+            for (int direction_index = 0;
+                 direction_index < incoming.num_points(); ++direction_index) {
+                const auto& direction = incoming_directions[direction_index];
+                const double theta =
+                    std::acos(std::clamp(direction.z(), -1.0, 1.0));
+                const double phi = std::atan2(direction.y(), direction.x());
+                const double cosine = std::cos(order * phi);
+                const double sine = std::sin(order * phi);
+                const double weight =
+                    incoming.quadrature_weight(direction_index);
+                for (int channel = 0; channel < 3; ++channel) {
+                    fill_wigner_degrees(calculators[channel], theta,
+                                        num_coefficients,
+                                        degree_values[channel]);
+                }
+                for (int degree = std::abs(order); degree < num_coefficients;
+                     ++degree) {
+                    const int mode = degree * degree + order + degree;
+                    m_mode_degrees[mode] = degree;
+                    for (int channel = 0; channel < 3; ++channel) {
+                        const double value = degree_values[channel][degree];
+                        m_analysis_real[channel](mode, direction_index) =
+                            weight * value * cosine;
+                        m_analysis_imaginary[channel](mode, direction_index) =
+                            -weight * value * sine;
+                    }
+                }
+            }
+            for (int direction_index = 0;
+                 direction_index < outgoing.num_points(); ++direction_index) {
+                const auto& direction = outgoing_directions[direction_index];
+                const double theta =
+                    std::acos(std::clamp(direction.z(), -1.0, 1.0));
+                const double phi = std::atan2(direction.y(), direction.x());
+                const double cosine = std::cos(order * phi);
+                const double sine = std::sin(order * phi);
+                for (int channel = 0; channel < 3; ++channel) {
+                    fill_wigner_degrees(calculators[channel], theta,
+                                        num_coefficients,
+                                        degree_values[channel]);
+                }
+                for (int degree = std::abs(order); degree < num_coefficients;
+                     ++degree) {
+                    const int mode = degree * degree + order + degree;
+                    for (int channel = 0; channel < 3; ++channel) {
+                        const double value = degree_values[channel][degree];
+                        m_synthesis_real[channel](direction_index, mode) =
+                            value * cosine;
+                        m_synthesis_imaginary[channel](direction_index, mode) =
+                            value * sine;
+                    }
+                }
+            }
+        }
+
+        sasktran2::math::WignerDCalculator d00(0, 0);
+        sasktran2::math::WignerDCalculator d22(2, 2);
+        sasktran2::math::WignerDCalculator d02(0, 2);
+        sasktran2::math::WignerDCalculator d2m2(2, -2);
+        for (int output_index = 0; output_index < outgoing.num_points();
+             ++output_index) {
+            const auto& outgoing_direction = outgoing_directions[output_index];
+            for (int input_index = 0; input_index < incoming.num_points();
+                 ++input_index) {
+                const auto& incoming_direction =
+                    incoming_directions[input_index];
+                const double direction_cosine = std::clamp(
+                    incoming_direction.dot(outgoing_direction), -1.0, 1.0);
+                const bool special_frame =
+                    std::sqrt(std::max(0.0, 1.0 - direction_cosine *
+                                                      direction_cosine)) <
+                        1.0e-6 ||
+                    incoming_direction.head<2>().norm() < 1.0e-8 ||
+                    outgoing_direction.head<2>().norm() < 1.0e-8;
+                if (!special_frame) {
+                    continue;
+                }
+
+                FrameCorrection correction;
+                correction.input_index = input_index;
+                correction.output_index = output_index;
+                correction.values.assign(
+                    static_cast<std::size_t>(num_coefficients) * 4 * 9, 0.0);
+                double theta = 0.0;
+                double c1 = 0.0;
+                double c2 = 0.0;
+                double s1 = 0.0;
+                double s2 = 0.0;
+                int negation = 1;
+                sasktran2::math::stokes_scattering_factors(
+                    -incoming_direction, -outgoing_direction, theta, c1, c2, s1,
+                    s2, negation);
+                const double weight = incoming.quadrature_weight(input_index);
+                bool nonzero = false;
+                for (int degree = 0; degree < num_coefficients; ++degree) {
+                    const double value00 = d00.d(theta, degree);
+                    const double value02 = d02.d(theta, degree);
+                    const double value22 = d22.d(theta, degree);
+                    const double value2m2 = d2m2.d(theta, degree);
+                    const double wigner_add = value22 + value2m2;
+                    const double wigner_minus = value22 - value2m2;
+                    const int first_mode = degree * degree;
+                    const int last_mode = (degree + 1) * (degree + 1);
+                    for (int family = 0; family < 4; ++family) {
+                        std::array<double, 4> greek{};
+                        greek[family] = 1.0;
+                        Eigen::Matrix3d expected = Eigen::Matrix3d::Zero();
+                        expected(0, 0) = greek[0] * value00;
+                        expected(1, 0) = -greek[3] * c2 * value02;
+                        expected(2, 0) = -greek[3] * s2 * value02;
+                        expected(0, 1) = -greek[3] * c1 * value02;
+                        expected(0, 2) = greek[3] * s1 * value02;
+                        expected(1, 1) =
+                            0.5 * greek[1] *
+                                (c1 * c2 * wigner_add -
+                                 s1 * s2 * wigner_minus) +
+                            0.5 * greek[2] *
+                                (c1 * c2 * wigner_minus - s1 * s2 * wigner_add);
+                        expected(2, 1) =
+                            0.5 * greek[1] *
+                                (c1 * s2 * wigner_add +
+                                 s1 * c2 * wigner_minus) +
+                            0.5 * greek[2] *
+                                (c1 * s2 * wigner_minus + s1 * c2 * wigner_add);
+                        expected(1, 2) =
+                            -0.5 * greek[1] *
+                                (s1 * c2 * wigner_add +
+                                 c1 * s2 * wigner_minus) -
+                            0.5 * greek[2] *
+                                (s1 * c2 * wigner_minus + c1 * s2 * wigner_add);
+                        expected(2, 2) = 0.5 * greek[1] *
+                                             (-s1 * s2 * wigner_add +
+                                              c1 * c2 * wigner_minus) +
+                                         0.5 * greek[2] *
+                                             (-s1 * s2 * wigner_minus +
+                                              c1 * c2 * wigner_add);
+
+                        for (int input_stokes = 0; input_stokes < 3;
+                             ++input_stokes) {
+                            std::array<std::complex<double>, 3> result{};
+                            for (int mode = first_mode; mode < last_mode;
+                                 ++mode) {
+                                const std::complex<double> analysis0(
+                                    m_analysis_real[0](mode, input_index),
+                                    m_analysis_imaginary[0](mode, input_index));
+                                const std::complex<double> analysis1(
+                                    m_analysis_real[1](mode, input_index),
+                                    m_analysis_imaginary[1](mode, input_index));
+                                const std::complex<double> analysis2(
+                                    m_analysis_real[2](mode, input_index),
+                                    m_analysis_imaginary[2](mode, input_index));
+                                std::complex<double> intensity{};
+                                std::complex<double> plus{};
+                                std::complex<double> minus{};
+                                if (input_stokes == 0) {
+                                    intensity = analysis0;
+                                } else if (input_stokes == 1) {
+                                    plus = analysis1;
+                                    minus = analysis2;
+                                } else {
+                                    plus = std::complex<double>(0.0, 1.0) *
+                                           analysis1;
+                                    minus = std::complex<double>(0.0, -1.0) *
+                                            analysis2;
+                                }
+                                const std::array<std::complex<double>, 3> mixed{
+                                    greek[0] * intensity -
+                                        0.5 * greek[3] * (plus + minus),
+                                    -greek[3] * intensity +
+                                        0.5 * ((greek[1] + greek[2]) * plus +
+                                               (greek[1] - greek[2]) * minus),
+                                    -greek[3] * intensity +
+                                        0.5 * ((greek[1] - greek[2]) * plus +
+                                               (greek[1] + greek[2]) * minus)};
+                                for (int channel = 0; channel < 3; ++channel) {
+                                    const std::complex<double> synthesis(
+                                        m_synthesis_real[channel](output_index,
+                                                                  mode),
+                                        m_synthesis_imaginary[channel](
+                                            output_index, mode));
+                                    result[channel] +=
+                                        synthesis * mixed[channel];
+                                }
+                            }
+                            const std::array<double, 3> factored{
+                                result[0].real(),
+                                0.5 * (result[1].real() + result[2].real()),
+                                0.5 * (result[1].imag() - result[2].imag())};
+                            for (int output_stokes = 0; output_stokes < 3;
+                                 ++output_stokes) {
+                                const int index = ((degree * 4 + family) * 3 +
+                                                   output_stokes) *
+                                                      3 +
+                                                  input_stokes;
+                                correction.values[index] =
+                                    weight *
+                                        expected(output_stokes, input_stokes) -
+                                    factored[output_stokes];
+                                nonzero = nonzero ||
+                                          std::abs(correction.values[index]) >
+                                              1.0e-15;
+                            }
+                        }
+                    }
+                }
+                if (nonzero) {
+                    m_frame_corrections.push_back(std::move(correction));
+                }
+            }
+        }
+    }
+
+    std::size_t VectorAngularBasis::storage_bytes() const {
+        std::size_t values = 0;
+        for (int channel = 0; channel < 3; ++channel) {
+            values +=
+                static_cast<std::size_t>(m_analysis_real[channel].size() +
+                                         m_analysis_imaginary[channel].size() +
+                                         m_synthesis_real[channel].size() +
+                                         m_synthesis_imaginary[channel].size());
+        }
+        std::size_t correction_bytes =
+            m_frame_corrections.capacity() * sizeof(FrameCorrection);
+        for (const auto& correction : m_frame_corrections) {
+            correction_bytes += correction.values.capacity() * sizeof(double);
+        }
+        return values * sizeof(double) +
+               m_mode_degrees.capacity() * sizeof(int) + correction_bytes;
+    }
+
+    void VectorAngularBasis::validate_blocks(
+        Eigen::Ref<const Eigen::MatrixXd> incoming,
+        Eigen::Ref<const Eigen::MatrixXd> coefficients,
+        Eigen::Ref<const Eigen::MatrixXd> outgoing) const {
+        if (incoming.rows() != coefficients.rows() ||
+            outgoing.rows() != coefficients.rows() ||
+            incoming.cols() != input_size() ||
+            outgoing.cols() != output_size() ||
+            coefficients.cols() != 4 * num_coefficients()) {
+            throw std::invalid_argument(
+                "invalid vector successive-orders scattering block dimensions");
+        }
+    }
+
+    void VectorAngularBasis::analyze(Eigen::Ref<const Eigen::MatrixXd> incoming,
+                                     int active_modes,
+                                     VectorAngularWorkspace& workspace) const {
+        const int blocks = static_cast<int>(incoming.rows());
+        for (int component = 0; component < 3; ++component) {
+            workspace.stokes_input[component].resize(blocks,
+                                                     input_directions());
+        }
+        for (int block = 0; block < blocks; ++block) {
+            for (int direction = 0; direction < input_directions();
+                 ++direction) {
+                for (int component = 0; component < 3; ++component) {
+                    workspace.stokes_input[component](block, direction) =
+                        incoming(block, 3 * direction + component);
+                }
+            }
+        }
+
+        for (auto& moment : workspace.moments) {
+            moment.resize(blocks, active_modes);
+        }
+        workspace.moments[0].noalias() =
+            workspace.stokes_input[0] *
+            m_analysis_real[0].topRows(active_modes).transpose();
+        workspace.moments[1].noalias() =
+            workspace.stokes_input[0] *
+            m_analysis_imaginary[0].topRows(active_modes).transpose();
+
+        workspace.stacked_input.resize(2 * blocks, input_directions());
+        workspace.stacked_input.topRows(blocks) = workspace.stokes_input[1];
+        workspace.stacked_input.bottomRows(blocks) = workspace.stokes_input[2];
+        for (int channel = 1; channel < 3; ++channel) {
+            workspace.real_products.noalias() =
+                workspace.stacked_input *
+                m_analysis_real[channel].topRows(active_modes).transpose();
+            workspace.imaginary_products.noalias() =
+                workspace.stacked_input *
+                m_analysis_imaginary[channel].topRows(active_modes).transpose();
+            const auto q_real = workspace.real_products.topRows(blocks);
+            const auto u_real = workspace.real_products.bottomRows(blocks);
+            const auto q_imaginary =
+                workspace.imaginary_products.topRows(blocks);
+            const auto u_imaginary =
+                workspace.imaginary_products.bottomRows(blocks);
+            if (channel == 1) {
+                workspace.moments[2] = q_real - u_imaginary;
+                workspace.moments[3] = q_imaginary + u_real;
+            } else {
+                workspace.moments[4] = q_real + u_imaginary;
+                workspace.moments[5] = q_imaginary - u_real;
+            }
+        }
+    }
+
+    void VectorAngularBasis::apply_active(
+        Eigen::Ref<const Eigen::MatrixXd> incoming,
+        Eigen::Ref<const Eigen::MatrixXd> coefficients, int active_coefficients,
+        Eigen::Ref<Eigen::MatrixXd> outgoing,
+        VectorAngularWorkspace& workspace) const {
+        validate_blocks(incoming, coefficients, outgoing);
+        if (active_coefficients < 1 ||
+            active_coefficients > num_coefficients()) {
+            throw std::invalid_argument(
+                "invalid active vector scattering coefficient count");
+        }
+        const int blocks = static_cast<int>(incoming.rows());
+        const int active_modes = active_coefficients * active_coefficients;
+        analyze(incoming, active_modes, workspace);
+
+        for (int block = 0; block < blocks; ++block) {
+            for (int mode = 0; mode < active_modes; ++mode) {
+                const int degree = m_mode_degrees[mode];
+                const double a1 = coefficients(block, 4 * degree);
+                const double a2 = coefficients(block, 4 * degree + 1);
+                const double a3 = coefficients(block, 4 * degree + 2);
+                const double b1 = coefficients(block, 4 * degree + 3);
+                const double intensity_real = workspace.moments[0](block, mode);
+                const double intensity_imag = workspace.moments[1](block, mode);
+                const double plus_real = workspace.moments[2](block, mode);
+                const double plus_imag = workspace.moments[3](block, mode);
+                const double minus_real = workspace.moments[4](block, mode);
+                const double minus_imag = workspace.moments[5](block, mode);
+                workspace.moments[0](block, mode) =
+                    a1 * intensity_real - 0.5 * b1 * (plus_real + minus_real);
+                workspace.moments[1](block, mode) =
+                    a1 * intensity_imag - 0.5 * b1 * (plus_imag + minus_imag);
+                workspace.moments[2](block, mode) =
+                    -b1 * intensity_real +
+                    0.5 * ((a2 + a3) * plus_real + (a2 - a3) * minus_real);
+                workspace.moments[3](block, mode) =
+                    -b1 * intensity_imag +
+                    0.5 * ((a2 + a3) * plus_imag + (a2 - a3) * minus_imag);
+                workspace.moments[4](block, mode) =
+                    -b1 * intensity_real +
+                    0.5 * ((a2 - a3) * plus_real + (a2 + a3) * minus_real);
+                workspace.moments[5](block, mode) =
+                    -b1 * intensity_imag +
+                    0.5 * ((a2 - a3) * plus_imag + (a2 + a3) * minus_imag);
+            }
+        }
+
+        outgoing.setZero();
+        workspace.stacked_moments.resize(2 * blocks, active_modes);
+        for (int channel = 0; channel < 3; ++channel) {
+            workspace.stacked_moments.topRows(blocks) =
+                workspace.moments[2 * channel];
+            workspace.stacked_moments.bottomRows(blocks) =
+                workspace.moments[2 * channel + 1];
+            workspace.real_products.noalias() =
+                workspace.stacked_moments *
+                m_synthesis_real[channel].leftCols(active_modes).transpose();
+            workspace.imaginary_products.noalias() =
+                workspace.stacked_moments * m_synthesis_imaginary[channel]
+                                                .leftCols(active_modes)
+                                                .transpose();
+            for (int block = 0; block < blocks; ++block) {
+                for (int direction = 0; direction < output_directions();
+                     ++direction) {
+                    const double real =
+                        workspace.real_products(block, direction) -
+                        workspace.imaginary_products(block + blocks, direction);
+                    const double imaginary =
+                        workspace.imaginary_products(block, direction) +
+                        workspace.real_products(block + blocks, direction);
+                    if (channel == 0) {
+                        outgoing(block, 3 * direction) = real;
+                    } else if (channel == 1) {
+                        outgoing(block, 3 * direction + 1) = 0.5 * real;
+                        outgoing(block, 3 * direction + 2) = 0.5 * imaginary;
+                    } else {
+                        outgoing(block, 3 * direction + 1) += 0.5 * real;
+                        outgoing(block, 3 * direction + 2) -= 0.5 * imaginary;
+                    }
+                }
+            }
+        }
+        apply_frame_corrections(incoming, coefficients, active_coefficients,
+                                outgoing);
+    }
+
+    void VectorAngularBasis::analyze_synthesis_cotangent(
+        Eigen::Ref<const Eigen::MatrixXd> outgoing, int active_modes,
+        VectorAngularWorkspace& workspace) const {
+        const int blocks = static_cast<int>(outgoing.rows());
+        for (int component = 0; component < 3; ++component) {
+            workspace.stokes_output[component].resize(blocks,
+                                                      output_directions());
+        }
+        for (int block = 0; block < blocks; ++block) {
+            for (int direction = 0; direction < output_directions();
+                 ++direction) {
+                for (int component = 0; component < 3; ++component) {
+                    workspace.stokes_output[component](block, direction) =
+                        outgoing(block, 3 * direction + component);
+                }
+            }
+        }
+        for (auto& moment : workspace.moments) {
+            moment.resize(blocks, active_modes);
+        }
+        workspace.moments[0].noalias() =
+            workspace.stokes_output[0] *
+            m_synthesis_real[0].leftCols(active_modes);
+        workspace.moments[1].noalias() =
+            -workspace.stokes_output[0] *
+            m_synthesis_imaginary[0].leftCols(active_modes);
+
+        workspace.stacked_input.resize(2 * blocks, output_directions());
+        workspace.stacked_input.topRows(blocks) = workspace.stokes_output[1];
+        workspace.stacked_input.bottomRows(blocks) = workspace.stokes_output[2];
+        for (int channel = 1; channel < 3; ++channel) {
+            workspace.real_products.noalias() =
+                workspace.stacked_input *
+                m_synthesis_real[channel].leftCols(active_modes);
+            workspace.imaginary_products.noalias() =
+                workspace.stacked_input *
+                m_synthesis_imaginary[channel].leftCols(active_modes);
+            const auto q_real = workspace.real_products.topRows(blocks);
+            const auto u_real = workspace.real_products.bottomRows(blocks);
+            const auto q_imaginary =
+                workspace.imaginary_products.topRows(blocks);
+            const auto u_imaginary =
+                workspace.imaginary_products.bottomRows(blocks);
+            if (channel == 1) {
+                workspace.moments[2] = 0.5 * (q_real + u_imaginary);
+                workspace.moments[3] = 0.5 * (u_real - q_imaginary);
+            } else {
+                workspace.moments[4] = 0.5 * (q_real - u_imaginary);
+                workspace.moments[5] = -0.5 * (u_real + q_imaginary);
+            }
+        }
+    }
+
+    void VectorAngularBasis::apply_transpose_active(
+        Eigen::Ref<const Eigen::MatrixXd> outgoing,
+        Eigen::Ref<const Eigen::MatrixXd> coefficients, int active_coefficients,
+        Eigen::Ref<Eigen::MatrixXd> incoming,
+        VectorAngularWorkspace& workspace) const {
+        validate_blocks(incoming, coefficients, outgoing);
+        if (active_coefficients < 1 ||
+            active_coefficients > num_coefficients()) {
+            throw std::invalid_argument(
+                "invalid active vector scattering transpose coefficient count");
+        }
+        const int blocks = static_cast<int>(outgoing.rows());
+        const int active_modes = active_coefficients * active_coefficients;
+        analyze_synthesis_cotangent(outgoing, active_modes, workspace);
+
+        for (int block = 0; block < blocks; ++block) {
+            for (int mode = 0; mode < active_modes; ++mode) {
+                const int degree = m_mode_degrees[mode];
+                const double a1 = coefficients(block, 4 * degree);
+                const double a2 = coefficients(block, 4 * degree + 1);
+                const double a3 = coefficients(block, 4 * degree + 2);
+                const double b1 = coefficients(block, 4 * degree + 3);
+                const double intensity_real = workspace.moments[0](block, mode);
+                const double intensity_imag = workspace.moments[1](block, mode);
+                const double plus_real = workspace.moments[2](block, mode);
+                const double plus_imag = workspace.moments[3](block, mode);
+                const double minus_real = workspace.moments[4](block, mode);
+                const double minus_imag = workspace.moments[5](block, mode);
+                workspace.moments[0](block, mode) =
+                    a1 * intensity_real - b1 * (plus_real + minus_real);
+                workspace.moments[1](block, mode) =
+                    a1 * intensity_imag - b1 * (plus_imag + minus_imag);
+                workspace.moments[2](block, mode) =
+                    -0.5 * b1 * intensity_real +
+                    0.5 * ((a2 + a3) * plus_real + (a2 - a3) * minus_real);
+                workspace.moments[3](block, mode) =
+                    -0.5 * b1 * intensity_imag +
+                    0.5 * ((a2 + a3) * plus_imag + (a2 - a3) * minus_imag);
+                workspace.moments[4](block, mode) =
+                    -0.5 * b1 * intensity_real +
+                    0.5 * ((a2 - a3) * plus_real + (a2 + a3) * minus_real);
+                workspace.moments[5](block, mode) =
+                    -0.5 * b1 * intensity_imag +
+                    0.5 * ((a2 - a3) * plus_imag + (a2 + a3) * minus_imag);
+            }
+        }
+
+        incoming.setZero();
+        workspace.stacked_moments.resize(2 * blocks, active_modes);
+        for (int channel = 0; channel < 3; ++channel) {
+            workspace.stacked_moments.topRows(blocks) =
+                workspace.moments[2 * channel];
+            workspace.stacked_moments.bottomRows(blocks) =
+                workspace.moments[2 * channel + 1];
+            workspace.real_products.noalias() =
+                workspace.stacked_moments *
+                m_analysis_real[channel].topRows(active_modes);
+            workspace.imaginary_products.noalias() =
+                workspace.stacked_moments *
+                m_analysis_imaginary[channel].topRows(active_modes);
+            for (int block = 0; block < blocks; ++block) {
+                for (int direction = 0; direction < input_directions();
+                     ++direction) {
+                    const double real_real =
+                        workspace.real_products(block, direction);
+                    const double imaginary_real =
+                        workspace.real_products(block + blocks, direction);
+                    const double real_imaginary =
+                        workspace.imaginary_products(block, direction);
+                    const double imaginary_imaginary =
+                        workspace.imaginary_products(block + blocks, direction);
+                    if (channel == 0) {
+                        incoming(block, 3 * direction) =
+                            real_real + imaginary_imaginary;
+                    } else if (channel == 1) {
+                        incoming(block, 3 * direction + 1) +=
+                            real_real + imaginary_imaginary;
+                        incoming(block, 3 * direction + 2) +=
+                            imaginary_real - real_imaginary;
+                    } else {
+                        incoming(block, 3 * direction + 1) +=
+                            real_real + imaginary_imaginary;
+                        incoming(block, 3 * direction + 2) +=
+                            real_imaginary - imaginary_real;
+                    }
+                }
+            }
+        }
+        apply_frame_corrections_transpose(outgoing, coefficients,
+                                          active_coefficients, incoming);
+    }
+
+    void VectorAngularBasis::accumulate_coefficient_vjp(
+        Eigen::Ref<const Eigen::MatrixXd> incoming,
+        Eigen::Ref<const Eigen::MatrixXd> outgoing_cotangent,
+        Eigen::Ref<Eigen::MatrixXd> coefficient_gradient,
+        VectorAngularWorkspace& workspace) const {
+        if (incoming.rows() != outgoing_cotangent.rows() ||
+            incoming.cols() != input_size() ||
+            outgoing_cotangent.cols() != output_size() ||
+            coefficient_gradient.rows() != incoming.rows() ||
+            coefficient_gradient.cols() != 4 * num_coefficients()) {
+            throw std::invalid_argument(
+                "invalid vector scattering coefficient VJP dimensions");
+        }
+        const int blocks = static_cast<int>(incoming.rows());
+        const int modes = num_modes();
+        analyze(incoming, modes, workspace);
+        std::array<Eigen::MatrixXd, 6> analyzed = workspace.moments;
+        analyze_synthesis_cotangent(outgoing_cotangent, modes, workspace);
+        coefficient_gradient.setZero();
+        const auto real_inner = [](double left_real, double left_imag,
+                                   double right_real, double right_imag) {
+            return left_real * right_real + left_imag * right_imag;
+        };
+        for (int block = 0; block < blocks; ++block) {
+            for (int mode = 0; mode < modes; ++mode) {
+                const int degree = m_mode_degrees[mode];
+                const double ir = analyzed[0](block, mode);
+                const double ii = analyzed[1](block, mode);
+                const double pr = analyzed[2](block, mode);
+                const double pi = analyzed[3](block, mode);
+                const double mr = analyzed[4](block, mode);
+                const double mi = analyzed[5](block, mode);
+                const double iar = workspace.moments[0](block, mode);
+                const double iai = workspace.moments[1](block, mode);
+                const double par = workspace.moments[2](block, mode);
+                const double pai = workspace.moments[3](block, mode);
+                const double mar = workspace.moments[4](block, mode);
+                const double mai = workspace.moments[5](block, mode);
+                coefficient_gradient(block, 4 * degree) +=
+                    real_inner(iar, iai, ir, ii);
+                coefficient_gradient(block, 4 * degree + 1) +=
+                    0.5 * (real_inner(par, pai, pr + mr, pi + mi) +
+                           real_inner(mar, mai, pr + mr, pi + mi));
+                coefficient_gradient(block, 4 * degree + 2) +=
+                    0.5 * (real_inner(par, pai, pr - mr, pi - mi) +
+                           real_inner(mar, mai, mr - pr, mi - pi));
+                coefficient_gradient(block, 4 * degree + 3) +=
+                    real_inner(iar, iai, -0.5 * (pr + mr), -0.5 * (pi + mi)) +
+                    real_inner(par, pai, -ir, -ii) +
+                    real_inner(mar, mai, -ir, -ii);
+            }
+        }
+        accumulate_frame_correction_vjp(incoming, outgoing_cotangent,
+                                        coefficient_gradient);
+    }
+
+    void VectorAngularBasis::apply_frame_corrections(
+        Eigen::Ref<const Eigen::MatrixXd> incoming,
+        Eigen::Ref<const Eigen::MatrixXd> coefficients, int active_coefficients,
+        Eigen::Ref<Eigen::MatrixXd> outgoing) const {
+        for (int degree = 0; degree < active_coefficients; ++degree) {
+            for (int family = 0; family < 4; ++family) {
+                const int coefficient_index = 4 * degree + family;
+                if (coefficients.col(coefficient_index).isZero(0.0)) {
+                    continue;
+                }
+                const int matrix_start = coefficient_index * 9;
+                const auto coefficient_values =
+                    coefficients.col(coefficient_index).array();
+                for (const auto& correction : m_frame_corrections) {
+                    const int input_start = 3 * correction.input_index;
+                    const int output_start = 3 * correction.output_index;
+                    for (int row = 0; row < 3; ++row) {
+                        for (int column = 0; column < 3; ++column) {
+                            const double value =
+                                correction
+                                    .values[matrix_start + 3 * row + column];
+                            if (value != 0.0) {
+                                outgoing.col(output_start + row).array() +=
+                                    value * coefficient_values *
+                                    incoming.col(input_start + column).array();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    void VectorAngularBasis::apply_frame_corrections_transpose(
+        Eigen::Ref<const Eigen::MatrixXd> outgoing,
+        Eigen::Ref<const Eigen::MatrixXd> coefficients, int active_coefficients,
+        Eigen::Ref<Eigen::MatrixXd> incoming) const {
+        for (int degree = 0; degree < active_coefficients; ++degree) {
+            for (int family = 0; family < 4; ++family) {
+                const int coefficient_index = 4 * degree + family;
+                if (coefficients.col(coefficient_index).isZero(0.0)) {
+                    continue;
+                }
+                const int matrix_start = coefficient_index * 9;
+                const auto coefficient_values =
+                    coefficients.col(coefficient_index).array();
+                for (const auto& correction : m_frame_corrections) {
+                    const int input_start = 3 * correction.input_index;
+                    const int output_start = 3 * correction.output_index;
+                    for (int row = 0; row < 3; ++row) {
+                        for (int column = 0; column < 3; ++column) {
+                            const double value =
+                                correction
+                                    .values[matrix_start + 3 * row + column];
+                            if (value != 0.0) {
+                                incoming.col(input_start + column).array() +=
+                                    value * coefficient_values *
+                                    outgoing.col(output_start + row).array();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    void VectorAngularBasis::accumulate_frame_correction_vjp(
+        Eigen::Ref<const Eigen::MatrixXd> incoming,
+        Eigen::Ref<const Eigen::MatrixXd> outgoing_cotangent,
+        Eigen::Ref<Eigen::MatrixXd> coefficient_gradient) const {
+        for (int degree = 0; degree < num_coefficients(); ++degree) {
+            for (int family = 0; family < 4; ++family) {
+                const int coefficient_index = 4 * degree + family;
+                const int matrix_start = coefficient_index * 9;
+                for (const auto& correction : m_frame_corrections) {
+                    const int input_start = 3 * correction.input_index;
+                    const int output_start = 3 * correction.output_index;
+                    for (int row = 0; row < 3; ++row) {
+                        for (int column = 0; column < 3; ++column) {
+                            const double value =
+                                correction
+                                    .values[matrix_start + 3 * row + column];
+                            if (value != 0.0) {
+                                coefficient_gradient.col(coefficient_index)
+                                    .array() +=
+                                    value *
+                                    incoming.col(input_start + column).array() *
+                                    outgoing_cotangent.col(output_start + row)
+                                        .array();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+} // namespace sasktran2::successive_orders

--- a/cpp/lib/successive_orders/angular_basis.h
+++ b/cpp/lib/successive_orders/angular_basis.h
@@ -1,0 +1,210 @@
+#pragma once
+
+#include <Eigen/Core>
+
+#include <array>
+#include <cstddef>
+#include <complex>
+#include <vector>
+
+namespace sasktran2::math {
+    class UnitSphere;
+}
+
+namespace sasktran2::successive_orders {
+
+    /** Geometry-only real spherical-harmonic transform for scalar scattering.
+     *
+     * The normalization follows SASKTRAN's Legendre convention: the dot
+     * product of all degree-l modes evaluated at two directions is P_l of the
+     * direction cosine. Atmospheric Legendre coefficients therefore multiply
+     * the analyzed modes directly.
+     */
+    class ScalarAngularBasis {
+      public:
+        ScalarAngularBasis(const sasktran2::math::UnitSphere& incoming,
+                           const sasktran2::math::UnitSphere& outgoing,
+                           int num_coefficients);
+
+        int input_size() const { return static_cast<int>(m_analysis.cols()); }
+        int output_size() const { return static_cast<int>(m_synthesis.rows()); }
+        int num_coefficients() const { return m_num_coefficients; }
+        int num_modes() const {
+            return static_cast<int>(m_mode_degrees.size());
+        }
+
+        std::size_t storage_bytes() const;
+
+        /** Applies point-local scattering blocks.
+         *
+         * Inputs and outputs are point-major matrices. Coefficients have one
+         * row per point and one column per Legendre degree.
+         */
+        void apply(Eigen::Ref<const Eigen::MatrixXd> incoming,
+                   Eigen::Ref<const Eigen::MatrixXd> coefficients,
+                   Eigen::Ref<Eigen::MatrixXd> outgoing,
+                   Eigen::MatrixXd& moment_workspace) const;
+
+        void apply_active(Eigen::Ref<const Eigen::MatrixXd> incoming,
+                          Eigen::Ref<const Eigen::MatrixXd> coefficients,
+                          int active_coefficients,
+                          Eigen::Ref<Eigen::MatrixXd> outgoing,
+                          Eigen::MatrixXd& moment_workspace) const;
+
+        /** Applies the transpose with respect to angular radiances. */
+        void apply_transpose(Eigen::Ref<const Eigen::MatrixXd> outgoing,
+                             Eigen::Ref<const Eigen::MatrixXd> coefficients,
+                             Eigen::Ref<Eigen::MatrixXd> incoming,
+                             Eigen::MatrixXd& moment_workspace) const;
+
+        void
+        apply_transpose_active(Eigen::Ref<const Eigen::MatrixXd> outgoing,
+                               Eigen::Ref<const Eigen::MatrixXd> coefficients,
+                               int active_coefficients,
+                               Eigen::Ref<Eigen::MatrixXd> incoming,
+                               Eigen::MatrixXd& moment_workspace) const;
+
+        /** Forward product of the scattering operation. */
+        void apply_jvp(Eigen::Ref<const Eigen::MatrixXd> incoming,
+                       Eigen::Ref<const Eigen::MatrixXd> incoming_tangent,
+                       Eigen::Ref<const Eigen::MatrixXd> coefficients,
+                       Eigen::Ref<const Eigen::MatrixXd> coefficient_tangent,
+                       Eigen::Ref<Eigen::MatrixXd> outgoing_tangent,
+                       Eigen::MatrixXd& moment_workspace,
+                       Eigen::MatrixXd& tangent_workspace) const;
+
+        void
+        apply_jvp_active(Eigen::Ref<const Eigen::MatrixXd> incoming,
+                         Eigen::Ref<const Eigen::MatrixXd> incoming_tangent,
+                         Eigen::Ref<const Eigen::MatrixXd> coefficients,
+                         Eigen::Ref<const Eigen::MatrixXd> coefficient_tangent,
+                         int active_coefficients,
+                         Eigen::Ref<Eigen::MatrixXd> outgoing_tangent,
+                         Eigen::MatrixXd& moment_workspace,
+                         Eigen::MatrixXd& tangent_workspace) const;
+
+        /** Reverse product of the scattering operation. */
+        void apply_vjp(Eigen::Ref<const Eigen::MatrixXd> incoming,
+                       Eigen::Ref<const Eigen::MatrixXd> coefficients,
+                       Eigen::Ref<const Eigen::MatrixXd> outgoing_cotangent,
+                       Eigen::Ref<Eigen::MatrixXd> incoming_cotangent,
+                       Eigen::Ref<Eigen::MatrixXd> coefficient_gradient,
+                       Eigen::MatrixXd& analyzed_workspace,
+                       Eigen::MatrixXd& moment_cotangent_workspace) const;
+
+      private:
+        void validate_blocks(Eigen::Ref<const Eigen::MatrixXd> incoming,
+                             Eigen::Ref<const Eigen::MatrixXd> coefficients,
+                             Eigen::Ref<const Eigen::MatrixXd> outgoing) const;
+        void multiply_coefficients(
+            Eigen::MatrixXd& moments,
+            Eigen::Ref<const Eigen::MatrixXd> coefficients) const;
+
+        int m_num_coefficients;
+        Eigen::MatrixXd m_analysis;
+        Eigen::MatrixXd m_synthesis;
+        std::vector<int> m_mode_degrees;
+    };
+
+    /** Reusable storage for polarized spin-harmonic transforms. */
+    struct VectorAngularWorkspace {
+        std::array<Eigen::MatrixXd, 3> stokes_input;
+        std::array<Eigen::MatrixXd, 3> stokes_output;
+        std::array<Eigen::MatrixXd, 6> moments;
+        Eigen::MatrixXd stacked_input;
+        Eigen::MatrixXd stacked_moments;
+        Eigen::MatrixXd real_products;
+        Eigen::MatrixXd imaginary_products;
+
+        std::size_t storage_bytes() const;
+    };
+
+    /** Geometry-only spin-0/spin-2 transform for polarized I/Q/U scattering.
+     *
+     * Each (l,m) mode contains intensity, Q+iU, and Q-iU channels. The four
+     * Greek coefficient families mix these channels locally, allowing all
+     * atmospheric points to be scattered with matrix-matrix transforms rather
+     * than retaining one dense angular matrix per point.
+     */
+    class VectorAngularBasis {
+      public:
+        VectorAngularBasis(const sasktran2::math::UnitSphere& incoming,
+                           const sasktran2::math::UnitSphere& outgoing,
+                           int num_coefficients);
+
+        int input_directions() const {
+            return static_cast<int>(m_analysis_real[0].cols());
+        }
+        int output_directions() const {
+            return static_cast<int>(m_synthesis_real[0].rows());
+        }
+        int input_size() const { return 3 * input_directions(); }
+        int output_size() const { return 3 * output_directions(); }
+        int num_coefficients() const { return m_num_coefficients; }
+        int num_modes() const {
+            return static_cast<int>(m_mode_degrees.size());
+        }
+
+        std::size_t storage_bytes() const;
+
+        void apply_active(Eigen::Ref<const Eigen::MatrixXd> incoming,
+                          Eigen::Ref<const Eigen::MatrixXd> coefficients,
+                          int active_coefficients,
+                          Eigen::Ref<Eigen::MatrixXd> outgoing,
+                          VectorAngularWorkspace& workspace) const;
+
+        void
+        apply_transpose_active(Eigen::Ref<const Eigen::MatrixXd> outgoing,
+                               Eigen::Ref<const Eigen::MatrixXd> coefficients,
+                               int active_coefficients,
+                               Eigen::Ref<Eigen::MatrixXd> incoming,
+                               VectorAngularWorkspace& workspace) const;
+
+        void accumulate_coefficient_vjp(
+            Eigen::Ref<const Eigen::MatrixXd> incoming,
+            Eigen::Ref<const Eigen::MatrixXd> outgoing_cotangent,
+            Eigen::Ref<Eigen::MatrixXd> coefficient_gradient,
+            VectorAngularWorkspace& workspace) const;
+
+      private:
+        struct FrameCorrection {
+            int input_index = 0;
+            int output_index = 0;
+            // [degree, Greek family, output Stokes, input Stokes]
+            std::vector<double> values;
+        };
+
+        void validate_blocks(Eigen::Ref<const Eigen::MatrixXd> incoming,
+                             Eigen::Ref<const Eigen::MatrixXd> coefficients,
+                             Eigen::Ref<const Eigen::MatrixXd> outgoing) const;
+        void analyze(Eigen::Ref<const Eigen::MatrixXd> incoming,
+                     int active_modes, VectorAngularWorkspace& workspace) const;
+        void
+        analyze_synthesis_cotangent(Eigen::Ref<const Eigen::MatrixXd> outgoing,
+                                    int active_modes,
+                                    VectorAngularWorkspace& workspace) const;
+        void
+        apply_frame_corrections(Eigen::Ref<const Eigen::MatrixXd> incoming,
+                                Eigen::Ref<const Eigen::MatrixXd> coefficients,
+                                int active_coefficients,
+                                Eigen::Ref<Eigen::MatrixXd> outgoing) const;
+        void apply_frame_corrections_transpose(
+            Eigen::Ref<const Eigen::MatrixXd> outgoing,
+            Eigen::Ref<const Eigen::MatrixXd> coefficients,
+            int active_coefficients,
+            Eigen::Ref<Eigen::MatrixXd> incoming) const;
+        void accumulate_frame_correction_vjp(
+            Eigen::Ref<const Eigen::MatrixXd> incoming,
+            Eigen::Ref<const Eigen::MatrixXd> outgoing_cotangent,
+            Eigen::Ref<Eigen::MatrixXd> coefficient_gradient) const;
+
+        int m_num_coefficients;
+        std::array<Eigen::MatrixXd, 3> m_analysis_real;
+        std::array<Eigen::MatrixXd, 3> m_analysis_imaginary;
+        std::array<Eigen::MatrixXd, 3> m_synthesis_real;
+        std::array<Eigen::MatrixXd, 3> m_synthesis_imaginary;
+        std::vector<int> m_mode_degrees;
+        std::vector<FrameCorrection> m_frame_corrections;
+    };
+
+} // namespace sasktran2::successive_orders

--- a/cpp/lib/successive_orders/factory.h
+++ b/cpp/lib/successive_orders/factory.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <sasktran2/source_interface.h>
+
+#include <memory>
+
+namespace sasktran2 {
+    class Geometry1D;
+    namespace raytracing {
+        class RayTracerBase;
+    }
+} // namespace sasktran2
+
+namespace sasktran2::successive_orders {
+    /** Constructs the private C++ successive-orders implementation. */
+    template <int NSTOKES>
+    std::unique_ptr<SourceTermInterface<NSTOKES>>
+    make_successive_orders_source(
+        const sasktran2::raytracing::RayTracerBase& raytracer,
+        const sasktran2::Geometry1D& geometry);
+
+    extern template std::unique_ptr<SourceTermInterface<1>>
+    make_successive_orders_source<1>(
+        const sasktran2::raytracing::RayTracerBase&,
+        const sasktran2::Geometry1D&);
+    extern template std::unique_ptr<SourceTermInterface<3>>
+    make_successive_orders_source<3>(
+        const sasktran2::raytracing::RayTracerBase&,
+        const sasktran2::Geometry1D&);
+} // namespace sasktran2::successive_orders

--- a/cpp/lib/successive_orders/factory.h
+++ b/cpp/lib/successive_orders/factory.h
@@ -14,8 +14,7 @@ namespace sasktran2 {
 namespace sasktran2::successive_orders {
     /** Constructs the private C++ successive-orders implementation. */
     template <int NSTOKES>
-    std::unique_ptr<SourceTermInterface<NSTOKES>>
-    make_successive_orders_source(
+    std::unique_ptr<SourceTermInterface<NSTOKES>> make_successive_orders_source(
         const sasktran2::raytracing::RayTracerBase& raytracer,
         const sasktran2::Geometry1D& geometry);
 

--- a/cpp/lib/successive_orders/first_order.cpp
+++ b/cpp/lib/successive_orders/first_order.cpp
@@ -1,0 +1,2505 @@
+#include "first_order.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+#include <unordered_map>
+
+#ifdef SKTRAN_OPENMP_SUPPORT
+#include <omp.h>
+#endif
+
+namespace sasktran2::successive_orders {
+    namespace {
+        constexpr double minimum_layer_distance_m = 1.0e-4;
+        constexpr double inverse_four_pi = 1.0 / (4.0 * EIGEN_PI);
+
+        using EndpointKey = std::vector<std::pair<int, std::uint64_t>>;
+
+        struct EndpointKeyHash {
+            std::size_t operator()(const EndpointKey& key) const noexcept {
+                std::size_t result = key.size();
+                for (const auto& [index, weight] : key) {
+                    const std::size_t index_hash = std::hash<int>{}(index);
+                    const std::size_t weight_hash =
+                        std::hash<std::uint64_t>{}(weight);
+                    result ^= index_hash + 0x9e3779b9U + (result << 6U) +
+                              (result >> 2U);
+                    result ^= weight_hash + 0x9e3779b9U + (result << 6U) +
+                              (result >> 2U);
+                }
+                return result;
+            }
+        };
+
+        EndpointKey endpoint_key(
+            const sasktran2::raytracing::GridWeightStencilView& weights) {
+            EndpointKey result;
+            result.reserve(weights.size());
+            for (std::size_t index = 0; index < weights.size(); ++index) {
+                const auto [atmosphere_index, weight] = weights[index];
+                std::uint64_t bits;
+                static_assert(sizeof(bits) == sizeof(weight));
+                std::memcpy(&bits, &weight, sizeof(bits));
+                result.emplace_back(atmosphere_index, bits);
+            }
+            return result;
+        }
+
+        struct ScalarLayerTransfer {
+            double attenuation;
+            double source_factor;
+        };
+
+        ScalarLayerTransfer scalar_layer_transfer(double optical_depth) {
+            const double absolute_depth = std::abs(optical_depth);
+            if (absolute_depth < 1.0e-12) {
+                return {std::exp(-optical_depth), 1.0};
+            }
+            if (absolute_depth < 0.02) {
+                const double source_factor =
+                    1.0 +
+                    optical_depth *
+                        (-0.5 +
+                         optical_depth *
+                             (1.0 / 6.0 +
+                              optical_depth * (-1.0 / 24.0 +
+                                               optical_depth * (1.0 / 120.0))));
+                return {1.0 - optical_depth * source_factor, source_factor};
+            }
+            const double transmission_loss = -std::expm1(-optical_depth);
+            return {1.0 - transmission_loss, transmission_loss / optical_depth};
+        }
+
+        double constant_source_factor_derivative(double optical_depth,
+                                                 double factor) {
+            const double absolute_depth = std::abs(optical_depth);
+            if (absolute_depth < 1.0e-12) {
+                return -0.5;
+            }
+            if (absolute_depth < 0.02) {
+                return -0.5 +
+                       optical_depth *
+                           (1.0 / 3.0 +
+                            optical_depth *
+                                (-1.0 / 8.0 + optical_depth * (1.0 / 30.0)));
+            }
+            return 1.0 / optical_depth - factor * (1.0 + 1.0 / optical_depth);
+        }
+
+        template <int N>
+        EIGEN_STRONG_INLINE double fixed_dot(const double* left,
+                                             const double* right) {
+            double result = 0.0;
+            for (int index = 0; index < N; ++index) {
+                result += left[index] * right[index];
+            }
+            return result;
+        }
+
+        EIGEN_STRONG_INLINE double phase_dot(const double* coefficients,
+                                             const double* basis, int order) {
+            if (order == 3) {
+                return fixed_dot<3>(coefficients, basis);
+            }
+            if (order == 16) {
+                return fixed_dot<16>(coefficients, basis);
+            }
+            double result = 0.0;
+            for (int degree = 0; degree < order; ++degree) {
+                result += coefficients[degree] * basis[degree];
+            }
+            return result;
+        }
+
+        template <int N>
+        EIGEN_STRONG_INLINE void fixed_axpy(double scale, const double* input,
+                                            double* output) {
+            for (int index = 0; index < N; ++index) {
+                output[index] += scale * input[index];
+            }
+        }
+
+        EIGEN_STRONG_INLINE void phase_axpy(double scale, const double* basis,
+                                            int order, double* gradient) {
+            if (order == 16) {
+                fixed_axpy<16>(scale, basis, gradient);
+                return;
+            }
+            for (int degree = 0; degree < order; ++degree) {
+                gradient[degree] += scale * basis[degree];
+            }
+        }
+
+        void append_legendre_basis(double cosine, int count,
+                                   std::vector<double>& output) {
+            output.push_back(1.0);
+            if (count == 1) {
+                return;
+            }
+            output.push_back(cosine);
+            for (int degree = 2; degree < count; ++degree) {
+                const double value =
+                    ((2.0 * degree - 1.0) * cosine * output[output.size() - 1] -
+                     (degree - 1.0) * output[output.size() - 2]) /
+                    degree;
+                output.push_back(value);
+            }
+        }
+    } // namespace
+
+    template <int NSTOKES>
+    FirstOrderProvider<NSTOKES>::FirstOrderProvider(
+        const sasktran2::Geometry1D& geometry,
+        const sasktran2::raytracing::RayTracerBase& raytracer)
+        : m_geometry(geometry), m_source(geometry, raytracer),
+          m_solar_table(geometry, raytracer), m_integrator(false),
+          m_source_terms{&m_source} {}
+
+    template <int NSTOKES>
+    void FirstOrderProvider<NSTOKES>::initialize_config(
+        const sasktran2::Config& config) {
+        m_geometry_initialized = false;
+        m_atmosphere = nullptr;
+        m_num_rays = 0;
+        m_primal_scratch.clear();
+        m_gradient_scratch.clear();
+        m_vjp_radiance_scratch.clear();
+        m_vjp_cotangent_scratch.clear();
+        m_solar_product_scratch.clear();
+        m_solar_table_product_scratch.clear();
+        m_phase_product_scratch.clear();
+        m_phase_order_scratch.clear();
+        m_endpoint_extinction_tangent_scratch.clear();
+        m_endpoint_albedo_tangent_scratch.clear();
+        m_scalar_phase_orders.clear();
+        m_uniform_phase_active.clear();
+        m_uniform_phase_values.clear();
+        m_uniform_albedo_active.clear();
+        m_uniform_albedo_values.clear();
+        m_cached_solar_transmission.clear();
+        m_cached_solar_active.clear();
+        m_scalar_layer_cache.clear();
+        m_endpoint_medium_cache.clear();
+        m_scalar_vjp_scratch.clear();
+        m_source_geometry = nullptr;
+        m_solar_offsets.clear();
+        m_phase_basis.clear();
+        m_endpoint_slots.clear();
+        m_unique_endpoint_offsets.clear();
+        m_unique_endpoint_weights.clear();
+        m_scalar_packed_rays.clear();
+        m_scalar_packed_layers.clear();
+        m_solar_interpolation.resize(0, 0);
+        m_solar_ground_hit.clear();
+        m_num_threads = config.num_threads();
+        m_num_source_threads = config.num_source_threads();
+        m_num_wavelength_threads = config.num_wavelength_threads();
+        m_num_phase_moments = config.num_singlescatter_moments();
+        m_compact_scalar_requested =
+            NSTOKES == 1 && !config.multiple_scatter_refraction() &&
+            config.singlescatter_phasemode() ==
+                sasktran2::Config::SingleScatterPhaseMode::from_legendre;
+        m_use_compact_scalar = false;
+        if (m_num_threads < 1 || m_num_source_threads < 1 ||
+            m_num_wavelength_threads < 1) {
+            throw std::invalid_argument(
+                "Successive-orders first-order provider requires positive "
+                "thread counts");
+        }
+        if (m_compact_scalar_requested) {
+            m_solar_table.initialize_config(config);
+        } else {
+            m_source.initialize_config(config);
+            m_source.set_wavelength_block_capacity(1);
+        }
+    }
+
+    template <int NSTOKES>
+    void FirstOrderProvider<NSTOKES>::initialize_geometry(
+        const SourceGeometry1D& source_geometry) {
+        m_geometry_initialized = false;
+        m_atmosphere = nullptr;
+        m_num_rays = 0;
+        m_primal_scratch.clear();
+        m_gradient_scratch.clear();
+        m_vjp_radiance_scratch.clear();
+        m_vjp_cotangent_scratch.clear();
+        m_solar_product_scratch.clear();
+        m_solar_table_product_scratch.clear();
+        m_phase_product_scratch.clear();
+        m_phase_order_scratch.clear();
+        m_endpoint_extinction_tangent_scratch.clear();
+        m_endpoint_albedo_tangent_scratch.clear();
+        m_scalar_phase_orders.clear();
+        m_uniform_phase_active.clear();
+        m_uniform_phase_values.clear();
+        m_uniform_albedo_active.clear();
+        m_uniform_albedo_values.clear();
+        m_cached_solar_transmission.clear();
+        m_cached_solar_active.clear();
+        m_scalar_layer_cache.clear();
+        m_endpoint_medium_cache.clear();
+        m_scalar_vjp_scratch.clear();
+        m_source_geometry = nullptr;
+        m_solar_offsets.clear();
+        m_phase_basis.clear();
+        m_endpoint_slots.clear();
+        m_unique_endpoint_offsets.clear();
+        m_unique_endpoint_weights.clear();
+        m_scalar_packed_rays.clear();
+        m_scalar_packed_layers.clear();
+        m_solar_interpolation.resize(0, 0);
+        m_solar_ground_hit.clear();
+        const auto& viewing = source_geometry.incoming_viewing_geometry();
+        m_num_rays = static_cast<int>(viewing.traced_rays.size());
+        m_source_geometry = &source_geometry;
+        m_use_compact_scalar =
+            m_compact_scalar_requested &&
+            std::all_of(viewing.traced_rays.begin(), viewing.traced_rays.end(),
+                        [](const auto& ray) { return ray.is_straight; });
+        if (m_compact_scalar_requested && !m_use_compact_scalar) {
+            throw std::logic_error(
+                "Compact scalar successive-orders geometry unexpectedly "
+                "contains a refracted incoming ray");
+        }
+        m_use_lower_interpolation =
+            m_geometry.altitude_grid().interpolation_method() ==
+            sasktran2::grids::interpolation::lower;
+        if (m_use_compact_scalar) {
+            m_solar_table.initialize_geometry(viewing.traced_rays);
+            m_solar_table.generate_interpolation_matrix(
+                viewing.traced_rays, m_solar_interpolation, m_solar_ground_hit);
+            m_solar_interpolation.makeCompressed();
+        } else {
+            m_source.initialize_geometry(viewing);
+        }
+        if (!m_use_compact_scalar) {
+            m_integrator.initialize_geometry(viewing.traced_rays, m_geometry);
+            m_integrator.initialize_thread_storage(m_num_threads, 1);
+            m_integrator.initialize_vjp_storage(m_num_threads, 1);
+        }
+        m_primal_scratch.resize(m_num_threads);
+        m_gradient_scratch.resize(m_num_threads);
+        m_vjp_radiance_scratch.resize(m_num_threads);
+        m_vjp_cotangent_scratch.resize(m_num_threads);
+        m_solar_product_scratch.resize(m_num_threads);
+        m_solar_table_product_scratch.resize(m_num_threads);
+        m_phase_product_scratch.resize(m_num_threads);
+        m_phase_order_scratch.resize(m_num_threads);
+        m_scalar_vjp_scratch.resize(m_num_threads);
+        for (auto& scratch : m_primal_scratch) {
+            scratch.resize(1, 0, true);
+        }
+        for (auto& scratch : m_vjp_radiance_scratch) {
+            scratch.resize(NSTOKES, 1);
+        }
+        for (auto& scratch : m_vjp_cotangent_scratch) {
+            scratch.resize(NSTOKES, 1);
+        }
+        if (m_use_compact_scalar) {
+            m_solar_offsets.resize(static_cast<std::size_t>(m_num_rays) + 1);
+            int solar_offset = 0;
+            int maximum_layers = 0;
+            m_phase_basis.reserve(static_cast<std::size_t>(m_num_rays) *
+                                  m_num_phase_moments);
+            const auto& sun = m_geometry.coordinates().sun_unit();
+            for (int ray = 0; ray < m_num_rays; ++ray) {
+                const auto& traced_ray = viewing.traced_rays[ray];
+                m_solar_offsets[ray] = solar_offset;
+                solar_offset += static_cast<int>(traced_ray.layers.size()) + 1;
+                maximum_layers = std::max(
+                    maximum_layers, static_cast<int>(traced_ray.layers.size()));
+                const double cosine =
+                    traced_ray.layers.empty()
+                        ? 1.0
+                        : std::clamp(
+                              sun.dot(
+                                  traced_ray.layers.front().average_look_away),
+                              -1.0, 1.0);
+                append_legendre_basis(cosine, m_num_phase_moments,
+                                      m_phase_basis);
+            }
+            m_solar_offsets[m_num_rays] = solar_offset;
+            if (!m_use_lower_interpolation) {
+                m_endpoint_slots.assign(solar_offset, -1);
+                m_unique_endpoint_offsets.push_back(0);
+                std::unordered_map<EndpointKey, int, EndpointKeyHash> slots;
+                const auto assign_endpoint =
+                    [&](int solar_index,
+                        const sasktran2::raytracing::GridWeightStencilView&
+                            weights) {
+                        auto key = endpoint_key(weights);
+                        const auto [position, inserted] = slots.emplace(
+                            std::move(key), static_cast<int>(slots.size()));
+                        const int slot = position->second;
+                        m_endpoint_slots[solar_index] = slot;
+                        if (!inserted) {
+                            return;
+                        }
+                        for (std::size_t index = 0; index < weights.size();
+                             ++index) {
+                            const auto [atmosphere_index, weight] =
+                                weights[index];
+                            m_unique_endpoint_weights.push_back(
+                                {atmosphere_index, weight});
+                        }
+                        m_unique_endpoint_offsets.push_back(
+                            static_cast<int>(m_unique_endpoint_weights.size()));
+                    };
+                for (int ray = 0; ray < m_num_rays; ++ray) {
+                    const auto& traced_ray = viewing.traced_rays[ray];
+                    if (traced_ray.layers.empty()) {
+                        continue;
+                    }
+                    assign_endpoint(m_solar_offsets[ray],
+                                    traced_ray.exit_weights(0));
+                    for (int endpoint = 1;
+                         endpoint <= static_cast<int>(traced_ray.layers.size());
+                         ++endpoint) {
+                        assign_endpoint(
+                            m_solar_offsets[ray] + endpoint,
+                            traced_ray.entrance_weights(endpoint - 1));
+                    }
+                }
+            }
+            if (!m_use_lower_interpolation) {
+                m_scalar_packed_rays.resize(m_num_rays);
+                m_scalar_packed_layers.reserve(
+                    static_cast<std::size_t>(solar_offset - m_num_rays));
+                for (int ray = 0; ray < m_num_rays; ++ray) {
+                    const auto& traced_ray = viewing.traced_rays[ray];
+                    auto& packed_ray = m_scalar_packed_rays[ray];
+                    packed_ray.layer_begin = static_cast<std::uint32_t>(
+                        m_scalar_packed_layers.size());
+                    for (int layer = 0;
+                         layer < static_cast<int>(traced_ray.layers.size());
+                         ++layer) {
+                        const auto& traced_layer = traced_ray.layers[layer];
+                        m_scalar_packed_layers.push_back(
+                            {traced_layer.od_quad_start,
+                             traced_layer.od_quad_end});
+                    }
+                    packed_ray.layer_end = static_cast<std::uint32_t>(
+                        m_scalar_packed_layers.size());
+                }
+            }
+            const int unique_endpoints =
+                m_unique_endpoint_offsets.empty()
+                    ? 0
+                    : static_cast<int>(m_unique_endpoint_offsets.size()) - 1;
+            m_endpoint_extinction_tangent_scratch.resize(m_num_threads);
+            m_endpoint_albedo_tangent_scratch.resize(m_num_threads);
+            for (int thread = 0; thread < m_num_threads; ++thread) {
+                m_endpoint_extinction_tangent_scratch[thread].resize(
+                    unique_endpoints);
+                m_endpoint_albedo_tangent_scratch[thread].resize(
+                    unique_endpoints);
+            }
+            for (int thread = 0; thread < m_num_threads; ++thread) {
+                m_solar_product_scratch[thread].resize(solar_offset);
+                m_solar_table_product_scratch[thread].resize(
+                    m_solar_table.geometry_matrix().rows());
+                auto& vjp = m_scalar_vjp_scratch[thread];
+                vjp.optical_depth.resize(maximum_layers);
+                vjp.attenuation.resize(maximum_layers);
+                vjp.source_factor.resize(maximum_layers);
+                vjp.prefix_attenuation.resize(maximum_layers);
+                vjp.albedo.resize(maximum_layers);
+                vjp.endpoints.resize(static_cast<std::size_t>(maximum_layers) +
+                                     1);
+                vjp.endpoint_cotangent.resize(maximum_layers + 1);
+            }
+        }
+        m_geometry_initialized = true;
+    }
+
+    template <int NSTOKES>
+    void FirstOrderProvider<NSTOKES>::initialize_atmosphere(
+        const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere) {
+        if (!m_geometry_initialized) {
+            throw std::logic_error(
+                "Successive-orders first-order geometry is not initialized");
+        }
+        m_atmosphere = nullptr;
+        if (!m_use_compact_scalar) {
+            m_source.initialize_atmosphere(atmosphere);
+        }
+        if (!m_use_compact_scalar) {
+            m_integrator.initialize_atmosphere(atmosphere);
+        }
+        for (auto& gradient : m_gradient_scratch) {
+            gradient.resize(atmosphere.num_deriv(), 1);
+        }
+        if (m_use_compact_scalar) {
+            const int coefficient_count =
+                atmosphere.storage().total_extinction.rows() *
+                m_num_phase_moments;
+            for (auto& product : m_phase_product_scratch) {
+                product.resize(coefficient_count);
+            }
+            const int locations = atmosphere.storage().total_extinction.rows();
+            for (auto& orders : m_phase_order_scratch) {
+                orders.resize(locations);
+            }
+            m_scalar_phase_orders.resize(static_cast<std::size_t>(locations) *
+                                         atmosphere.num_wavel());
+            m_uniform_phase_active.assign(atmosphere.num_wavel(), 0);
+            m_uniform_phase_values.resize(
+                static_cast<std::size_t>(atmosphere.num_wavel()) * m_num_rays);
+            m_uniform_albedo_active.assign(atmosphere.num_wavel(), 0);
+            m_uniform_albedo_values.resize(atmosphere.num_wavel());
+            const auto& storage = atmosphere.storage();
+            for (int wavelength = 0; wavelength < atmosphere.num_wavel();
+                 ++wavelength) {
+                bool uniform_albedo = locations > 0;
+                for (int location = 1; location < locations && uniform_albedo;
+                     ++location) {
+                    uniform_albedo = storage.ssa(location, wavelength) ==
+                                     storage.ssa(0, wavelength);
+                }
+                if (uniform_albedo) {
+                    m_uniform_albedo_active[wavelength] = 1;
+                    m_uniform_albedo_values[wavelength] =
+                        storage.ssa(0, wavelength);
+                }
+                for (int location = 0; location < locations; ++location) {
+                    int order =
+                        std::min(storage.max_order(location, wavelength),
+                                 m_num_phase_moments);
+                    while (order > 0 && storage.leg_coeff(order - 1, location,
+                                                          wavelength) == 0.0) {
+                        --order;
+                    }
+                    m_scalar_phase_orders[static_cast<std::size_t>(wavelength) *
+                                              locations +
+                                          location] = order;
+                }
+                bool uniform = locations > 0;
+                for (int location = 1; location < locations && uniform;
+                     ++location) {
+                    for (int degree = 0; degree < m_num_phase_moments;
+                         ++degree) {
+                        if (storage.leg_coeff(degree, location, wavelength) !=
+                            storage.leg_coeff(degree, 0, wavelength)) {
+                            uniform = false;
+                            break;
+                        }
+                    }
+                }
+                if (uniform) {
+                    m_uniform_phase_active[wavelength] = 1;
+                    const int order = m_scalar_phase_orders
+                        [static_cast<std::size_t>(wavelength) * locations];
+                    const double* coefficients =
+                        &storage.leg_coeff(0, 0, wavelength);
+                    for (int ray = 0; ray < m_num_rays; ++ray) {
+                        const double* basis =
+                            m_phase_basis.data() +
+                            static_cast<std::size_t>(ray) * m_num_phase_moments;
+                        m_uniform_phase_values
+                            [static_cast<std::size_t>(wavelength) * m_num_rays +
+                             ray] = phase_dot(coefficients, basis, order);
+                    }
+                }
+            }
+        } else {
+            m_scalar_phase_orders.clear();
+            m_uniform_phase_active.clear();
+            m_uniform_phase_values.clear();
+            m_uniform_albedo_active.clear();
+            m_uniform_albedo_values.clear();
+        }
+        if (m_use_compact_scalar) {
+            m_cached_solar_transmission.resize(atmosphere.num_wavel());
+            m_cached_solar_active.assign(atmosphere.num_wavel(), 0);
+            const int solar_size = m_solar_offsets.back();
+            for (auto& transmission : m_cached_solar_transmission) {
+                transmission.resize(solar_size);
+            }
+            if (!m_unique_endpoint_offsets.empty()) {
+                const int endpoint_count =
+                    static_cast<int>(m_unique_endpoint_offsets.size()) - 1;
+                m_endpoint_medium_cache.resize(atmosphere.num_wavel());
+                for (auto& cache : m_endpoint_medium_cache) {
+                    cache.extinction.resize(endpoint_count);
+                    cache.albedo.resize(endpoint_count);
+                    cache.active = false;
+                }
+            } else {
+                m_endpoint_medium_cache.clear();
+            }
+            if (atmosphere.num_deriv() > 0) {
+                const int layer_count = solar_size - m_num_rays;
+                m_scalar_layer_cache.resize(atmosphere.num_wavel());
+                for (auto& cache : m_scalar_layer_cache) {
+                    cache.optical_depth.resize(layer_count);
+                    cache.source_factor.resize(layer_count);
+                    cache.active = false;
+                }
+            } else {
+                m_scalar_layer_cache.clear();
+            }
+        }
+        m_atmosphere = &atmosphere;
+    }
+
+    template <int NSTOKES>
+    void
+    FirstOrderProvider<NSTOKES>::validate_ready(int wavelength,
+                                                int wavelength_thread) const {
+        if (!m_geometry_initialized || m_atmosphere == nullptr ||
+            wavelength < 0 || wavelength >= m_atmosphere->num_wavel() ||
+            wavelength_thread < 0 ||
+            wavelength_thread >= m_num_wavelength_threads) {
+            throw std::invalid_argument(
+                "Invalid successive-orders first-order calculation");
+        }
+    }
+
+    template <int NSTOKES>
+    int
+    FirstOrderProvider<NSTOKES>::ray_thread_index(int wavelength_thread) const {
+#ifdef SKTRAN_OPENMP_SUPPORT
+        if (m_num_source_threads > 1) {
+            return omp_get_thread_num() + wavelength_thread;
+        }
+#endif
+        return wavelength_thread;
+    }
+
+    template <int NSTOKES>
+    const Eigen::VectorXd&
+    FirstOrderProvider<NSTOKES>::ensure_solar_transmission(
+        int wavelength, int wavelength_thread) {
+        auto& transmission = m_cached_solar_transmission.at(wavelength);
+        if (m_cached_solar_active.at(wavelength) == 0) {
+            auto& table = m_solar_table_product_scratch[wavelength_thread];
+            table.noalias() =
+                m_solar_table.geometry_matrix() *
+                m_atmosphere->storage().total_extinction.col(wavelength);
+            const double irradiance =
+                m_atmosphere->storage().solar_irradiance(wavelength);
+            transmission.noalias() = m_solar_interpolation * table;
+            transmission.array() = (-transmission.array()).exp() * irradiance;
+            for (int row = 0; row < m_solar_interpolation.rows(); ++row) {
+                if (m_solar_ground_hit[row]) {
+                    transmission(row) = 0.0;
+                }
+            }
+            m_cached_solar_active[wavelength] = 1;
+        }
+        return transmission;
+    }
+
+    template <int NSTOKES>
+    void FirstOrderProvider<NSTOKES>::ensure_endpoint_medium(int wavelength) {
+        if (m_endpoint_medium_cache.empty()) {
+            return;
+        }
+        auto& cache = m_endpoint_medium_cache[wavelength];
+        if (cache.active) {
+            return;
+        }
+        const auto& storage = m_atmosphere->storage();
+        for (int slot = 0; slot < cache.extinction.size(); ++slot) {
+            double extinction = 0.0;
+            double albedo = 0.0;
+            for (int index = m_unique_endpoint_offsets[slot];
+                 index < m_unique_endpoint_offsets[slot + 1]; ++index) {
+                const auto& value = m_unique_endpoint_weights[index];
+                extinction += value.weight *
+                              storage.total_extinction(value.index, wavelength);
+                albedo += value.weight * storage.ssa(value.index, wavelength);
+            }
+            cache.extinction(slot) = extinction;
+            cache.albedo(slot) = albedo;
+        }
+        cache.active = true;
+    }
+
+    template <int NSTOKES>
+    typename FirstOrderProvider<NSTOKES>::ScalarEndpoint
+    FirstOrderProvider<NSTOKES>::scalar_endpoint(
+        int wavelength, int ray, int layer, bool entrance, int solar_index,
+        const sasktran2::raytracing::GridWeightStencilView& weights) const {
+        ScalarEndpoint result;
+        const auto& storage = m_atmosphere->storage();
+        const int endpoint_slot =
+            m_endpoint_slots.empty() ? -1 : m_endpoint_slots[solar_index];
+        const bool use_endpoint_medium =
+            endpoint_slot >= 0 && !m_endpoint_medium_cache.empty() &&
+            m_endpoint_medium_cache[wavelength].active;
+        if (use_endpoint_medium) {
+            result.extinction =
+                m_endpoint_medium_cache[wavelength].extinction(endpoint_slot);
+            result.albedo =
+                m_endpoint_medium_cache[wavelength].albedo(endpoint_slot);
+        }
+        const double* basis =
+            m_phase_basis.data() +
+            static_cast<std::size_t>(ray) * m_num_phase_moments;
+        const bool uniform_phase = m_uniform_phase_active[wavelength] != 0;
+        if (uniform_phase) {
+            result.phase =
+                m_uniform_phase_values[static_cast<std::size_t>(wavelength) *
+                                           m_num_rays +
+                                       ray];
+        }
+        if (use_endpoint_medium && uniform_phase) {
+            return result;
+        }
+        for (std::size_t index = 0; index < weights.size(); ++index) {
+            const auto [atmosphere_index, weight] = weights[index];
+            if (weight == 0.0) {
+                continue;
+            }
+            if (!use_endpoint_medium) {
+                result.extinction += weight * storage.total_extinction(
+                                                  atmosphere_index, wavelength);
+                result.albedo +=
+                    weight * storage.ssa(atmosphere_index, wavelength);
+            }
+            if (!uniform_phase) {
+                const int locations = storage.total_extinction.rows();
+                const int order =
+                    m_scalar_phase_orders[static_cast<std::size_t>(wavelength) *
+                                              locations +
+                                          atmosphere_index];
+                const double* coefficients =
+                    &storage.leg_coeff(0, atmosphere_index, wavelength);
+                const double phase = phase_dot(coefficients, basis, order);
+                result.phase += weight * phase;
+            }
+        }
+        (void)layer;
+        (void)entrance;
+        (void)solar_index;
+        return result;
+    }
+
+    template <int NSTOKES>
+    template <bool USE_ENDPOINT_MEDIUM>
+    typename FirstOrderProvider<NSTOKES>::ScalarValueTangent
+    FirstOrderProvider<NSTOKES>::scalar_endpoint_jvp(
+        int wavelength, int wavelength_thread, int ray, int layer,
+        bool entrance, int solar_index,
+        const sasktran2::raytracing::GridWeightStencilView& weights,
+        const double* __restrict extinction_direction,
+        const double* __restrict albedo_direction,
+        const double* __restrict solar_tangent, bool uniform_albedo_direction,
+        double uniform_albedo_tangent, bool phase_tangent_active) const {
+        ScalarValueTangent result;
+        const auto& storage = m_atmosphere->storage();
+        const auto& coefficient_tangent =
+            m_phase_product_scratch[wavelength_thread];
+        const auto& tangent_orders = m_phase_order_scratch[wavelength_thread];
+        const double* basis =
+            m_phase_basis.data() +
+            static_cast<std::size_t>(ray) * m_num_phase_moments;
+        double extinction = 0.0;
+        double extinction_tangent = 0.0;
+        double albedo = 0.0;
+        double albedo_tangent =
+            uniform_albedo_direction ? uniform_albedo_tangent : 0.0;
+        double phase = 0.0;
+        double phase_tangent = 0.0;
+        const bool uniform_phase = m_uniform_phase_active[wavelength] != 0;
+        if (uniform_phase) {
+            phase =
+                m_uniform_phase_values[static_cast<std::size_t>(wavelength) *
+                                           m_num_rays +
+                                       ray];
+        }
+        if constexpr (USE_ENDPOINT_MEDIUM) {
+            const int endpoint_slot = m_endpoint_slots[solar_index];
+            extinction =
+                m_endpoint_medium_cache[wavelength].extinction(endpoint_slot);
+            albedo = m_endpoint_medium_cache[wavelength].albedo(endpoint_slot);
+            extinction_tangent =
+                m_endpoint_extinction_tangent_scratch[wavelength_thread](
+                    endpoint_slot);
+            albedo_tangent =
+                m_endpoint_albedo_tangent_scratch[wavelength_thread](
+                    endpoint_slot);
+        }
+        if constexpr (USE_ENDPOINT_MEDIUM) {
+            if (uniform_phase && !phase_tangent_active) {
+                const double solar =
+                    m_cached_solar_transmission[wavelength](solar_index);
+                const double solar_jvp = solar_tangent[solar_index];
+                const double phase_scale = phase * inverse_four_pi;
+                const double extinction_albedo = extinction * albedo;
+                result.value = extinction_albedo * solar * phase_scale;
+                result.tangent = ((extinction_tangent * albedo +
+                                   extinction * albedo_tangent) *
+                                      solar +
+                                  extinction_albedo * solar_jvp) *
+                                 phase_scale;
+                return result;
+            }
+        }
+        const bool require_weight_interpolation =
+            !USE_ENDPOINT_MEDIUM || !uniform_phase || phase_tangent_active;
+        for (std::size_t index = 0;
+             require_weight_interpolation && index < weights.size(); ++index) {
+            const auto [atmosphere_index, weight] = weights[index];
+            if (weight == 0.0) {
+                continue;
+            }
+            if constexpr (!USE_ENDPOINT_MEDIUM) {
+                extinction += weight * storage.total_extinction(
+                                           atmosphere_index, wavelength);
+                extinction_tangent +=
+                    weight * extinction_direction[atmosphere_index];
+            }
+            if constexpr (!USE_ENDPOINT_MEDIUM) {
+                albedo += weight * storage.ssa(atmosphere_index, wavelength);
+                if (!uniform_albedo_direction) {
+                    albedo_tangent +=
+                        weight * albedo_direction[atmosphere_index];
+                }
+            }
+            const double* tangent_coefficients =
+                coefficient_tangent.data() +
+                atmosphere_index * m_num_phase_moments;
+            if (phase_tangent_active) {
+                if (!uniform_phase) {
+                    const int locations = storage.total_extinction.rows();
+                    const int order = m_scalar_phase_orders
+                        [static_cast<std::size_t>(wavelength) * locations +
+                         atmosphere_index];
+                    const double* coefficients =
+                        &storage.leg_coeff(0, atmosphere_index, wavelength);
+                    phase += weight * phase_dot(coefficients, basis, order);
+                }
+                phase_tangent +=
+                    weight * phase_dot(tangent_coefficients, basis,
+                                       tangent_orders[atmosphere_index]);
+            } else if (!uniform_phase) {
+                const int locations = storage.total_extinction.rows();
+                const int order =
+                    m_scalar_phase_orders[static_cast<std::size_t>(wavelength) *
+                                              locations +
+                                          atmosphere_index];
+                const double* coefficients =
+                    &storage.leg_coeff(0, atmosphere_index, wavelength);
+                phase += weight * phase_dot(coefficients, basis, order);
+            }
+        }
+        const double solar =
+            m_cached_solar_transmission[wavelength](solar_index);
+        const double solar_jvp = solar_tangent[solar_index];
+        result.value = extinction * albedo * solar * phase * inverse_four_pi;
+        result.tangent =
+            (((extinction_tangent * albedo + extinction * albedo_tangent) *
+                  solar +
+              extinction * albedo * solar_jvp) *
+                 phase +
+             extinction * albedo * solar * phase_tangent) *
+            inverse_four_pi;
+        (void)layer;
+        (void)entrance;
+        return result;
+    }
+
+    template <int NSTOKES>
+    void FirstOrderProvider<NSTOKES>::accumulate_scalar_endpoint_vjp(
+        int wavelength, int ray, int layer, bool entrance, int solar_index,
+        const sasktran2::raytracing::GridWeightStencilView& weights,
+        const ScalarEndpoint& endpoint, double source_cotangent,
+        Eigen::Ref<Eigen::VectorXd> native_gradient,
+        Eigen::Ref<Eigen::VectorXd> solar_gradient,
+        Eigen::Ref<Eigen::VectorXd> coefficient_gradient) const {
+        if (source_cotangent == 0.0) {
+            return;
+        }
+        const auto& storage = m_atmosphere->storage();
+        const double scale = source_cotangent * inverse_four_pi;
+        const double extinction_cotangent = scale * endpoint.albedo *
+                                            endpoint.solar_transmission *
+                                            endpoint.phase;
+        const double albedo_cotangent = scale * endpoint.extinction *
+                                        endpoint.solar_transmission *
+                                        endpoint.phase;
+        const double solar_cotangent =
+            scale * endpoint.extinction * endpoint.albedo * endpoint.phase;
+        const double phase_cotangent = scale * endpoint.extinction *
+                                       endpoint.albedo *
+                                       endpoint.solar_transmission;
+        const double* basis =
+            m_phase_basis.data() +
+            static_cast<std::size_t>(ray) * m_num_phase_moments;
+        for (std::size_t index = 0; index < weights.size(); ++index) {
+            const auto [atmosphere_index, weight] = weights[index];
+            if (weight == 0.0) {
+                continue;
+            }
+            native_gradient(atmosphere_index) += weight * extinction_cotangent;
+            native_gradient(m_atmosphere->ssa_deriv_start_index() +
+                            atmosphere_index) += weight * albedo_cotangent;
+            const int order =
+                std::min(storage.max_order(atmosphere_index, wavelength),
+                         m_num_phase_moments);
+            const int coefficient_offset =
+                atmosphere_index * m_num_phase_moments;
+            const double coefficient_cotangent = weight * phase_cotangent;
+            phase_axpy(coefficient_cotangent, basis, order,
+                       coefficient_gradient.data() + coefficient_offset);
+        }
+        solar_gradient(solar_index) += solar_cotangent;
+        (void)layer;
+        (void)entrance;
+    }
+
+    template <int NSTOKES>
+    void FirstOrderProvider<NSTOKES>::calculate_scalar(
+        int wavelength, int wavelength_thread,
+        Eigen::Ref<Eigen::VectorXd> forcing, TransportOperator* transport) {
+        if (transport != nullptr) {
+            if (m_use_lower_interpolation) {
+                calculate_scalar_impl<true, true>(wavelength, wavelength_thread,
+                                                  forcing, transport);
+            } else {
+                calculate_scalar_impl<true, false>(
+                    wavelength, wavelength_thread, forcing, transport);
+            }
+        } else if (m_use_lower_interpolation) {
+            calculate_scalar_impl<false, true>(wavelength, wavelength_thread,
+                                               forcing, nullptr);
+        } else {
+            calculate_scalar_impl<false, false>(wavelength, wavelength_thread,
+                                                forcing, nullptr);
+        }
+    }
+
+    template <int NSTOKES>
+    template <bool WITH_TRANSPORT>
+    void FirstOrderProvider<NSTOKES>::calculate_scalar_uniform_impl(
+        int wavelength, int wavelength_thread,
+        Eigen::Ref<Eigen::VectorXd> forcing, TransportOperator* transport) {
+        const auto& rays = m_source_geometry->incoming_rays();
+        const auto& interpolation = m_source_geometry->incoming_interpolation();
+        const auto& extinction = m_atmosphere->storage().total_extinction;
+        const auto& ssa = m_atmosphere->storage().ssa;
+        const auto& solar =
+            ensure_solar_transmission(wavelength, wavelength_thread);
+        ensure_endpoint_medium(wavelength);
+        const bool uniform_albedo = m_uniform_albedo_active[wavelength] != 0;
+        const double uniform_albedo_value =
+            uniform_albedo ? m_uniform_albedo_values[wavelength] : 0.0;
+        if constexpr (WITH_TRANSPORT) {
+            transport->values().setZero();
+        }
+        ScalarLayerCache* layer_cache = m_scalar_layer_cache.empty()
+                                            ? nullptr
+                                            : &m_scalar_layer_cache[wavelength];
+        if (layer_cache != nullptr) {
+            layer_cache->active = false;
+        }
+#pragma omp parallel for if (m_num_source_threads > 1)                         \
+    num_threads(m_num_source_threads) schedule(dynamic)
+        for (int ray = 0; ray < m_num_rays; ++ray) {
+            const auto& packed_ray = m_scalar_packed_rays[ray];
+            const auto& traced_ray = rays[ray];
+            const auto& ray_interpolation = interpolation[ray];
+            const double phase_scale =
+                m_uniform_phase_values[static_cast<std::size_t>(wavelength) *
+                                           m_num_rays +
+                                       ray] *
+                inverse_four_pi;
+            const auto endpoint_source = [&](int solar_index) {
+                const int slot = m_endpoint_slots[solar_index];
+                const auto& medium = m_endpoint_medium_cache[wavelength];
+                return medium.extinction(slot) * medium.albedo(slot) *
+                       solar(solar_index) * phase_scale;
+            };
+            double prefix = 1.0;
+            double radiance = 0.0;
+            double shared_endpoint = 0.0;
+            bool have_shared_endpoint = false;
+            for (std::uint32_t flat_layer = packed_ray.layer_end;
+                 flat_layer-- > packed_ray.layer_begin;) {
+                const auto& layer = m_scalar_packed_layers[flat_layer];
+                const auto local_layer = static_cast<std::size_t>(
+                    flat_layer - packed_ray.layer_begin);
+                const auto optical_depth_weights =
+                    traced_ray.optical_depth_weights(local_layer);
+                const auto atmosphere_weights =
+                    ray_interpolation.atmosphere_for_layer(local_layer);
+                double optical_depth = 0.0;
+                double albedo = uniform_albedo_value;
+                for (std::size_t index = 0;
+                     index < optical_depth_weights.size(); ++index) {
+                    const auto [atmosphere_index, weight] =
+                        optical_depth_weights[index];
+                    optical_depth +=
+                        weight * extinction(atmosphere_index, wavelength);
+                }
+                if (!uniform_albedo) {
+                    for (const auto& weight : atmosphere_weights) {
+                        albedo += weight.weight * ssa(weight.index, wavelength);
+                    }
+                }
+                const auto transfer = scalar_layer_transfer(optical_depth);
+                if (layer_cache != nullptr) {
+                    layer_cache->optical_depth(flat_layer) = optical_depth;
+                    layer_cache->source_factor(flat_layer) =
+                        transfer.source_factor;
+                }
+                if constexpr (WITH_TRANSPORT) {
+                    const double source_factor =
+                        prefix * albedo * (1.0 - transfer.attenuation);
+                    for (const auto& source :
+                         ray_interpolation.source_for_layer(local_layer)) {
+                        transport->values()(
+                            ray_interpolation.transport_value_offset +
+                            source.row_inner_index) +=
+                            source.weight * source_factor;
+                    }
+                }
+                const double layer_distance =
+                    layer.source_quad_start + layer.source_quad_end;
+                if (layer_distance < minimum_layer_distance_m) {
+                    have_shared_endpoint = false;
+                } else {
+                    const int exit_solar =
+                        m_solar_offsets[ray] + static_cast<int>(local_layer);
+                    const double start = have_shared_endpoint
+                                             ? shared_endpoint
+                                             : endpoint_source(exit_solar + 1);
+                    const double end = endpoint_source(exit_solar);
+                    radiance += prefix * transfer.source_factor *
+                                (start * layer.source_quad_start +
+                                 end * layer.source_quad_end);
+                    shared_endpoint = end;
+                    have_shared_endpoint = true;
+                }
+                prefix *= transfer.attenuation;
+            }
+            if constexpr (WITH_TRANSPORT) {
+                for (const auto& source : ray_interpolation.ground_weights) {
+                    transport->values()(
+                        ray_interpolation.transport_value_offset +
+                        source.row_inner_index) += source.weight * prefix;
+                }
+            }
+            if (traced_ray.ground_is_hit && !traced_ray.layers.empty()) {
+                const auto& ground_layer = traced_ray.layers.front();
+                const double mu_in = ground_layer.exit.cos_zenith_angle(
+                    m_geometry.coordinates().sun_unit());
+                if (mu_in > 0.0) {
+                    const double mu_out = -ground_layer.exit.cos_zenith_angle(
+                        ground_layer.average_look_away);
+                    const auto brdf = m_atmosphere->surface().brdf(
+                        wavelength, mu_in, mu_out, ground_layer.saz_exit);
+                    radiance += prefix * solar(m_solar_offsets[ray]) * mu_in *
+                                brdf(0, 0);
+                }
+            }
+            forcing(ray) = radiance;
+        }
+        if (layer_cache != nullptr) {
+            layer_cache->active = true;
+        }
+    }
+
+    template <int NSTOKES>
+    template <bool WITH_TRANSPORT, bool LOWER_INTERPOLATION>
+    void FirstOrderProvider<NSTOKES>::calculate_scalar_impl(
+        int wavelength, int wavelength_thread,
+        Eigen::Ref<Eigen::VectorXd> forcing, TransportOperator* transport) {
+        if constexpr (!LOWER_INTERPOLATION) {
+            if (m_uniform_phase_active[wavelength] != 0) {
+                calculate_scalar_uniform_impl<WITH_TRANSPORT>(
+                    wavelength, wavelength_thread, forcing, transport);
+                return;
+            }
+        }
+        const auto& rays = m_source_geometry->incoming_rays();
+        const auto& interpolation = m_source_geometry->incoming_interpolation();
+        const auto& extinction = m_atmosphere->storage().total_extinction;
+        const auto& ssa = m_atmosphere->storage().ssa;
+        const auto& solar =
+            ensure_solar_transmission(wavelength, wavelength_thread);
+        ensure_endpoint_medium(wavelength);
+        const bool uniform_albedo = m_uniform_albedo_active[wavelength] != 0;
+        const double uniform_albedo_value =
+            uniform_albedo ? m_uniform_albedo_values[wavelength] : 0.0;
+        if constexpr (WITH_TRANSPORT) {
+            transport->values().setZero();
+        }
+        ScalarLayerCache* layer_cache = m_scalar_layer_cache.empty()
+                                            ? nullptr
+                                            : &m_scalar_layer_cache[wavelength];
+        if (layer_cache != nullptr) {
+            layer_cache->active = false;
+        }
+#pragma omp parallel for if (m_num_source_threads > 1)                         \
+    num_threads(m_num_source_threads) schedule(dynamic)
+        for (int ray = 0; ray < m_num_rays; ++ray) {
+            const auto& traced_ray = rays[ray];
+            const auto& ray_interpolation = interpolation[ray];
+            const int flat_layer_offset = m_solar_offsets[ray] - ray;
+            double prefix = 1.0;
+            double radiance = 0.0;
+            ScalarEndpoint shared_endpoint;
+            bool have_shared_endpoint = false;
+            for (int layer = static_cast<int>(traced_ray.layers.size()) - 1;
+                 layer >= 0; --layer) {
+                const auto& traced_layer = traced_ray.layers[layer];
+                double optical_depth = 0.0;
+                double albedo = uniform_albedo_value;
+                const auto od_weights = traced_ray.optical_depth_weights(layer);
+                for (std::size_t index = 0; index < od_weights.size();
+                     ++index) {
+                    const auto [atmosphere_index, weight] = od_weights[index];
+                    optical_depth +=
+                        weight * extinction(atmosphere_index, wavelength);
+                }
+                if constexpr (WITH_TRANSPORT) {
+                    if (!uniform_albedo) {
+                        for (const auto& weight :
+                             ray_interpolation.atmosphere_for_layer(layer)) {
+                            albedo +=
+                                weight.weight * ssa(weight.index, wavelength);
+                        }
+                    }
+                }
+                const auto layer_transfer =
+                    scalar_layer_transfer(optical_depth);
+                const double attenuation = layer_transfer.attenuation;
+                const double factor = layer_transfer.source_factor;
+                if (layer_cache != nullptr) {
+                    const int flat_layer = flat_layer_offset + layer;
+                    layer_cache->optical_depth(flat_layer) = optical_depth;
+                    layer_cache->source_factor(flat_layer) = factor;
+                }
+                if constexpr (WITH_TRANSPORT) {
+                    const double source_factor =
+                        prefix * albedo * (1.0 - attenuation);
+                    for (const auto& source :
+                         ray_interpolation.source_for_layer(layer)) {
+                        transport->values()(
+                            ray_interpolation.transport_value_offset +
+                            source.row_inner_index) +=
+                            source.weight * source_factor;
+                    }
+                }
+                if (traced_layer.layer_distance < minimum_layer_distance_m) {
+                    have_shared_endpoint = false;
+                }
+                if (traced_layer.layer_distance >= minimum_layer_distance_m) {
+                    auto entrance_weights = traced_ray.entrance_weights(layer);
+                    auto exit_weights = traced_ray.exit_weights(layer);
+                    const auto* start_weights = &entrance_weights;
+                    const auto* end_weights = &exit_weights;
+                    bool start_entrance = true;
+                    bool end_entrance = false;
+                    if constexpr (LOWER_INTERPOLATION) {
+                        if (traced_layer.r_exit > traced_layer.r_entrance) {
+                            end_weights = &entrance_weights;
+                            end_entrance = true;
+                        } else {
+                            start_weights = &exit_weights;
+                            start_entrance = false;
+                        }
+                    }
+                    const int exit_solar = m_solar_offsets[ray] + layer;
+                    auto start =
+                        have_shared_endpoint && !LOWER_INTERPOLATION
+                            ? shared_endpoint
+                            : scalar_endpoint(wavelength, ray, layer,
+                                              start_entrance, exit_solar + 1,
+                                              *start_weights);
+                    auto end =
+                        scalar_endpoint(wavelength, ray, layer, end_entrance,
+                                        exit_solar, *end_weights);
+                    if (!(have_shared_endpoint && !LOWER_INTERPOLATION)) {
+                        start.solar_transmission = solar(exit_solar + 1);
+                        start.source = start.extinction * start.albedo *
+                                       start.solar_transmission * start.phase *
+                                       inverse_four_pi;
+                    }
+                    end.solar_transmission = solar(exit_solar);
+                    end.source = end.extinction * end.albedo *
+                                 end.solar_transmission * end.phase *
+                                 inverse_four_pi;
+                    radiance +=
+                        prefix * factor * traced_layer.layer_distance *
+                        (start.source * traced_layer.od_quad_start_fraction +
+                         end.source * traced_layer.od_quad_end_fraction);
+                    shared_endpoint = end;
+                    have_shared_endpoint = true;
+                }
+                prefix *= attenuation;
+            }
+            if constexpr (WITH_TRANSPORT) {
+                if (traced_ray.ground_is_hit) {
+                    for (const auto& source :
+                         ray_interpolation.ground_weights) {
+                        transport->values()(
+                            ray_interpolation.transport_value_offset +
+                            source.row_inner_index) += source.weight * prefix;
+                    }
+                }
+            }
+            if (traced_ray.ground_is_hit && !traced_ray.layers.empty()) {
+                const auto& ground_layer = traced_ray.layers.front();
+                const double mu_in = ground_layer.exit.cos_zenith_angle(
+                    m_geometry.coordinates().sun_unit());
+                if (mu_in > 0.0) {
+                    const double mu_out = -ground_layer.exit.cos_zenith_angle(
+                        ground_layer.average_look_away);
+                    const auto brdf = m_atmosphere->surface().brdf(
+                        wavelength, mu_in, mu_out, ground_layer.saz_exit);
+                    radiance += prefix * solar(m_solar_offsets[ray]) * mu_in *
+                                brdf(0, 0);
+                }
+            }
+            forcing(ray) = radiance;
+        }
+        if (layer_cache != nullptr) {
+            layer_cache->active = true;
+        }
+    }
+
+    template <int NSTOKES>
+    void FirstOrderProvider<NSTOKES>::calculate_scalar_jvp(
+        int wavelength, int wavelength_thread,
+        Eigen::Ref<const Eigen::VectorXd> native_tangent,
+        Eigen::Ref<Eigen::VectorXd> forcing,
+        Eigen::Ref<Eigen::VectorXd> forcing_tangent,
+        const Eigen::VectorXd* layer_state_projection,
+        const Eigen::VectorXd* ground_state_projection,
+        Eigen::VectorXd* direct_transport_tangent) {
+        if (direct_transport_tangent != nullptr) {
+            if (m_use_lower_interpolation) {
+                calculate_scalar_jvp_impl<true, true>(
+                    wavelength, wavelength_thread, native_tangent, forcing,
+                    forcing_tangent, layer_state_projection,
+                    ground_state_projection, direct_transport_tangent);
+            } else {
+                calculate_scalar_jvp_impl<true, false>(
+                    wavelength, wavelength_thread, native_tangent, forcing,
+                    forcing_tangent, layer_state_projection,
+                    ground_state_projection, direct_transport_tangent);
+            }
+        } else if (m_use_lower_interpolation) {
+            calculate_scalar_jvp_impl<false, true>(
+                wavelength, wavelength_thread, native_tangent, forcing,
+                forcing_tangent, nullptr, nullptr, nullptr);
+        } else {
+            calculate_scalar_jvp_impl<false, false>(
+                wavelength, wavelength_thread, native_tangent, forcing,
+                forcing_tangent, nullptr, nullptr, nullptr);
+        }
+    }
+
+    template <int NSTOKES>
+    void FirstOrderProvider<NSTOKES>::calculate_scalar_jvp_uniform_proportional(
+        int wavelength, Eigen::Ref<const Eigen::VectorXd> native_tangent,
+        const Eigen::VectorXd& solar_tangent, double extinction_direction_scale,
+        double albedo, double albedo_tangent,
+        const Eigen::VectorXd& layer_state_projection,
+        const Eigen::VectorXd& ground_state_projection,
+        Eigen::VectorXd& direct_transport_tangent,
+        Eigen::Ref<Eigen::VectorXd> forcing_tangent) {
+        const auto& rays = m_source_geometry->incoming_rays();
+        const auto& solar = m_cached_solar_transmission[wavelength];
+        const auto& endpoint_medium = m_endpoint_medium_cache[wavelength];
+        const auto& layer_cache = m_scalar_layer_cache[wavelength];
+        if (!layer_cache.active ||
+            layer_state_projection.size() != layer_cache.optical_depth.size() ||
+            ground_state_projection.size() != m_num_rays ||
+            direct_transport_tangent.size() != m_num_rays) {
+            throw std::invalid_argument(
+                "Invalid uniform scalar transport JVP storage");
+        }
+        direct_transport_tangent.setZero();
+#pragma omp parallel for if (m_num_source_threads > 1)                         \
+    num_threads(m_num_source_threads) schedule(dynamic)
+        for (int ray = 0; ray < m_num_rays; ++ray) {
+            const auto& packed_ray = m_scalar_packed_rays[ray];
+            const double phase_scale =
+                m_uniform_phase_values[static_cast<std::size_t>(wavelength) *
+                                           m_num_rays +
+                                       ray] *
+                inverse_four_pi;
+            const auto endpoint = [&](int solar_index) {
+                ScalarValueTangent result;
+                const int slot = m_endpoint_slots[solar_index];
+                const double extinction = endpoint_medium.extinction(slot);
+                const double endpoint_albedo = endpoint_medium.albedo(slot);
+                const double extinction_tangent =
+                    extinction_direction_scale * extinction;
+                const double extinction_albedo = extinction * endpoint_albedo;
+                result.value =
+                    extinction_albedo * solar(solar_index) * phase_scale;
+                result.tangent =
+                    ((extinction_tangent * endpoint_albedo +
+                      extinction * albedo_tangent) *
+                         solar(solar_index) +
+                     extinction_albedo * solar_tangent(solar_index)) *
+                    phase_scale;
+                return result;
+            };
+            double prefix = 1.0;
+            double prefix_tangent = 0.0;
+            double radiance_tangent = 0.0;
+            ScalarValueTangent shared_endpoint;
+            bool have_shared_endpoint = false;
+            for (std::uint32_t flat_layer = packed_ray.layer_end;
+                 flat_layer-- > packed_ray.layer_begin;) {
+                const auto& layer = m_scalar_packed_layers[flat_layer];
+                const double optical_depth =
+                    layer_cache.optical_depth(flat_layer);
+                const double optical_depth_tangent =
+                    extinction_direction_scale * optical_depth;
+                const double factor = layer_cache.source_factor(flat_layer);
+                const double attenuation = 1.0 - factor * optical_depth;
+                const double attenuation_tangent =
+                    -attenuation * optical_depth_tangent;
+                const double source_factor_tangent =
+                    prefix_tangent * albedo * (1.0 - attenuation) +
+                    prefix * albedo_tangent * (1.0 - attenuation) -
+                    prefix * albedo * attenuation_tangent;
+                direct_transport_tangent(ray) +=
+                    layer_state_projection(flat_layer) * source_factor_tangent;
+
+                const double layer_distance =
+                    layer.source_quad_start + layer.source_quad_end;
+                if (layer_distance < minimum_layer_distance_m) {
+                    have_shared_endpoint = false;
+                } else {
+                    const int local_layer =
+                        static_cast<int>(flat_layer - packed_ray.layer_begin);
+                    const int exit_solar = m_solar_offsets[ray] + local_layer;
+                    const auto start = have_shared_endpoint
+                                           ? shared_endpoint
+                                           : endpoint(exit_solar + 1);
+                    const auto end = endpoint(exit_solar);
+                    const double factor_tangent =
+                        constant_source_factor_derivative(optical_depth,
+                                                          factor) *
+                        optical_depth_tangent;
+                    const double endpoint_value =
+                        start.value * layer.source_quad_start +
+                        end.value * layer.source_quad_end;
+                    const double endpoint_tangent =
+                        start.tangent * layer.source_quad_start +
+                        end.tangent * layer.source_quad_end;
+                    const double optical_endpoint_value =
+                        start.value * layer.source_quad_start +
+                        end.value * layer.source_quad_end;
+                    radiance_tangent +=
+                        prefix_tangent * factor * endpoint_value +
+                        prefix * (factor * endpoint_tangent +
+                                  factor_tangent * optical_endpoint_value);
+                    shared_endpoint = end;
+                    have_shared_endpoint = true;
+                }
+                prefix_tangent =
+                    prefix_tangent * attenuation + prefix * attenuation_tangent;
+                prefix *= attenuation;
+            }
+            const auto& traced_ray = rays[ray];
+            if (traced_ray.ground_is_hit) {
+                direct_transport_tangent(ray) +=
+                    ground_state_projection(ray) * prefix_tangent;
+            }
+            if (traced_ray.ground_is_hit && !traced_ray.layers.empty()) {
+                const auto& ground_layer = traced_ray.layers.front();
+                const double mu_in = ground_layer.exit.cos_zenith_angle(
+                    m_geometry.coordinates().sun_unit());
+                if (mu_in > 0.0) {
+                    const double mu_out = -ground_layer.exit.cos_zenith_angle(
+                        ground_layer.average_look_away);
+                    const double phi = ground_layer.saz_exit;
+                    const auto brdf = m_atmosphere->surface().brdf(
+                        wavelength, mu_in, mu_out, phi);
+                    double brdf_tangent = 0.0;
+                    for (int derivative = 0;
+                         derivative < m_atmosphere->surface().num_deriv();
+                         ++derivative) {
+                        brdf_tangent +=
+                            native_tangent(
+                                m_atmosphere->surface_deriv_start_index() +
+                                derivative) *
+                            m_atmosphere->surface().d_brdf(wavelength, mu_in,
+                                                           mu_out, phi,
+                                                           derivative)(0, 0);
+                    }
+                    const double ground_source =
+                        solar(m_solar_offsets[ray]) * mu_in * brdf(0, 0);
+                    const double ground_tangent =
+                        mu_in *
+                        (solar_tangent(m_solar_offsets[ray]) * brdf(0, 0) +
+                         solar(m_solar_offsets[ray]) * brdf_tangent);
+                    radiance_tangent += prefix_tangent * ground_source +
+                                        prefix * ground_tangent;
+                }
+            }
+            forcing_tangent(ray) = radiance_tangent;
+        }
+    }
+
+    template <int NSTOKES>
+    template <bool WITH_TRANSPORT, bool LOWER_INTERPOLATION>
+    void FirstOrderProvider<NSTOKES>::calculate_scalar_jvp_impl(
+        int wavelength, int wavelength_thread,
+        Eigen::Ref<const Eigen::VectorXd> native_tangent,
+        Eigen::Ref<Eigen::VectorXd> forcing,
+        Eigen::Ref<Eigen::VectorXd> forcing_tangent,
+        const Eigen::VectorXd* layer_state_projection,
+        const Eigen::VectorXd* ground_state_projection,
+        Eigen::VectorXd* direct_transport_tangent) {
+        if constexpr (!LOWER_INTERPOLATION) {
+            ensure_endpoint_medium(wavelength);
+        }
+        const auto& solar =
+            ensure_solar_transmission(wavelength, wavelength_thread);
+        auto& solar_tangent = m_solar_product_scratch[wavelength_thread];
+        auto& table_tangent = m_solar_table_product_scratch[wavelength_thread];
+        const Eigen::Index solar_columns =
+            m_solar_table.geometry_matrix().cols();
+        table_tangent.noalias() = m_solar_table.geometry_matrix() *
+                                  native_tangent.head(solar_columns);
+        solar_tangent.noalias() = m_solar_interpolation * table_tangent;
+        solar_tangent.array() *= -solar.array();
+        auto& coefficient_tangent = m_phase_product_scratch[wavelength_thread];
+        auto& tangent_orders = m_phase_order_scratch[wavelength_thread];
+        coefficient_tangent.setZero();
+        std::fill(tangent_orders.begin(), tangent_orders.end(), 0);
+        const auto& storage = m_atmosphere->storage();
+        const int locations = storage.total_extinction.rows();
+        for (int group = 0; group < m_atmosphere->num_scattering_deriv_groups();
+             ++group) {
+            const int native_offset =
+                m_atmosphere->scat_deriv_start_index() + group * locations;
+            for (int location = 0; location < locations; ++location) {
+                const double direction =
+                    native_tangent(native_offset + location);
+                if (direction == 0.0) {
+                    continue;
+                }
+                const int order =
+                    std::min(storage.d_max_order[group](location, wavelength),
+                             m_num_phase_moments);
+                const int coefficient_offset = location * m_num_phase_moments;
+                for (int degree = 0; degree < order; ++degree) {
+                    coefficient_tangent(coefficient_offset + degree) +=
+                        direction * storage.d_leg_coeff(degree, location,
+                                                        wavelength, group);
+                }
+            }
+        }
+        bool phase_tangent_active = false;
+        for (int location = 0; location < locations; ++location) {
+            int order = m_num_phase_moments;
+            const int coefficient_offset = location * m_num_phase_moments;
+            while (order > 0 &&
+                   coefficient_tangent(coefficient_offset + order - 1) == 0.0) {
+                --order;
+            }
+            tangent_orders[location] = order;
+            phase_tangent_active = phase_tangent_active || order > 0;
+        }
+        const auto& rays = m_source_geometry->incoming_rays();
+        const auto& interpolation = m_source_geometry->incoming_interpolation();
+        const auto& ssa = m_atmosphere->storage().ssa;
+        const double* __restrict albedo_values = ssa.col(wavelength).data();
+        const double* __restrict extinction_direction = native_tangent.data();
+        const double* __restrict albedo_direction =
+            native_tangent.data() + m_atmosphere->ssa_deriv_start_index();
+        const double* __restrict solar_direction = solar_tangent.data();
+        const double* __restrict extinction_values =
+            storage.total_extinction.col(wavelength).data();
+        bool proportional_extinction_direction = locations > 0;
+        double extinction_direction_scale = 0.0;
+        int proportional_reference = 0;
+        while (proportional_reference < locations &&
+               extinction_values[proportional_reference] == 0.0) {
+            proportional_extinction_direction =
+                proportional_extinction_direction &&
+                extinction_direction[proportional_reference] == 0.0;
+            ++proportional_reference;
+        }
+        if (proportional_reference < locations &&
+            proportional_extinction_direction) {
+            extinction_direction_scale =
+                extinction_direction[proportional_reference] /
+                extinction_values[proportional_reference];
+        }
+        constexpr double proportional_tolerance =
+            32.0 * std::numeric_limits<double>::epsilon();
+        for (int location = proportional_reference + 1;
+             location < locations && proportional_extinction_direction;
+             ++location) {
+            const double expected =
+                extinction_direction_scale * extinction_values[location];
+            const double scale = std::max(
+                {std::abs(extinction_direction[location]), std::abs(expected),
+                 std::numeric_limits<double>::min()});
+            proportional_extinction_direction =
+                std::abs(extinction_direction[location] - expected) <=
+                proportional_tolerance * scale;
+        }
+        const bool uniform_albedo = m_uniform_albedo_active[wavelength] != 0;
+        const double uniform_albedo_value =
+            uniform_albedo ? m_uniform_albedo_values[wavelength] : 0.0;
+        bool uniform_albedo_direction = locations > 0;
+        const double uniform_albedo_tangent =
+            uniform_albedo_direction ? albedo_direction[0] : 0.0;
+        for (int location = 1; location < locations && uniform_albedo_direction;
+             ++location) {
+            uniform_albedo_direction =
+                albedo_direction[location] == uniform_albedo_tangent;
+        }
+        if constexpr (WITH_TRANSPORT && !LOWER_INTERPOLATION) {
+            if (m_uniform_phase_active[wavelength] != 0 &&
+                !phase_tangent_active && proportional_extinction_direction &&
+                uniform_albedo && uniform_albedo_direction) {
+                if (layer_state_projection == nullptr ||
+                    ground_state_projection == nullptr ||
+                    direct_transport_tangent == nullptr) {
+                    throw std::invalid_argument(
+                        "Missing uniform scalar transport JVP storage");
+                }
+                calculate_scalar_jvp_uniform_proportional(
+                    wavelength, native_tangent, solar_tangent,
+                    extinction_direction_scale, uniform_albedo_value,
+                    uniform_albedo_tangent, *layer_state_projection,
+                    *ground_state_projection, *direct_transport_tangent,
+                    forcing_tangent);
+                return;
+            }
+        }
+        auto& endpoint_extinction_tangent =
+            m_endpoint_extinction_tangent_scratch[wavelength_thread];
+        auto& endpoint_albedo_tangent =
+            m_endpoint_albedo_tangent_scratch[wavelength_thread];
+        for (int slot = 0; slot < endpoint_extinction_tangent.size(); ++slot) {
+            double extinction_value =
+                proportional_extinction_direction
+                    ? extinction_direction_scale *
+                          m_endpoint_medium_cache[wavelength].extinction(slot)
+                    : 0.0;
+            double albedo_value = 0.0;
+            for (int index = m_unique_endpoint_offsets[slot];
+                 index < m_unique_endpoint_offsets[slot + 1]; ++index) {
+                const auto& weight = m_unique_endpoint_weights[index];
+                if (!proportional_extinction_direction) {
+                    extinction_value +=
+                        weight.weight * extinction_direction[weight.index];
+                }
+                if (!uniform_albedo_direction) {
+                    albedo_value +=
+                        weight.weight * albedo_direction[weight.index];
+                }
+            }
+            endpoint_extinction_tangent(slot) = extinction_value;
+            endpoint_albedo_tangent(slot) = uniform_albedo_direction
+                                                ? uniform_albedo_tangent
+                                                : albedo_value;
+        }
+        const double* __restrict layer_state =
+            layer_state_projection == nullptr ? nullptr
+                                              : layer_state_projection->data();
+        const double* __restrict ground_state =
+            ground_state_projection == nullptr
+                ? nullptr
+                : ground_state_projection->data();
+        double* __restrict direct_transport_direction =
+            direct_transport_tangent == nullptr
+                ? nullptr
+                : direct_transport_tangent->data();
+        if (m_scalar_layer_cache.empty() ||
+            !m_scalar_layer_cache[wavelength].active) {
+            throw std::logic_error(
+                "Successive-orders scalar JVP requires a prepared primal");
+        }
+        const auto& layer_cache = m_scalar_layer_cache[wavelength];
+        if constexpr (WITH_TRANSPORT) {
+            if (layer_state_projection == nullptr ||
+                layer_state_projection->size() !=
+                    layer_cache.optical_depth.size() ||
+                ground_state_projection == nullptr ||
+                ground_state_projection->size() != m_num_rays ||
+                direct_transport_tangent == nullptr ||
+                direct_transport_tangent->size() != m_num_rays) {
+                throw std::invalid_argument(
+                    "Invalid direct scalar transport JVP storage");
+            }
+            direct_transport_tangent->setZero();
+        }
+
+#pragma omp parallel for if (m_num_source_threads > 1)                         \
+    num_threads(m_num_source_threads) schedule(dynamic)
+        for (int ray = 0; ray < m_num_rays; ++ray) {
+            const auto& traced_ray = rays[ray];
+            const auto& ray_interpolation = interpolation[ray];
+            const int flat_layer_offset = m_solar_offsets[ray] - ray;
+            double prefix = 1.0;
+            double prefix_tangent = 0.0;
+            double radiance_tangent = 0.0;
+            ScalarValueTangent shared_endpoint;
+            bool have_shared_endpoint = false;
+            for (int layer = static_cast<int>(traced_ray.layers.size()) - 1;
+                 layer >= 0; --layer) {
+                const auto& traced_layer = traced_ray.layers[layer];
+                const int flat_layer = flat_layer_offset + layer;
+                const double optical_depth =
+                    layer_cache.optical_depth(flat_layer);
+                double optical_depth_tangent =
+                    proportional_extinction_direction
+                        ? extinction_direction_scale * optical_depth
+                        : 0.0;
+                double albedo = uniform_albedo_value;
+                double albedo_tangent =
+                    uniform_albedo_direction ? uniform_albedo_tangent : 0.0;
+                const auto od_weights = traced_ray.optical_depth_weights(layer);
+                if (!proportional_extinction_direction) {
+                    for (std::size_t index = 0; index < od_weights.size();
+                         ++index) {
+                        const auto [atmosphere_index, weight] =
+                            od_weights[index];
+                        optical_depth_tangent +=
+                            weight * extinction_direction[atmosphere_index];
+                    }
+                }
+                if constexpr (WITH_TRANSPORT) {
+                    if (!uniform_albedo || !uniform_albedo_direction) {
+                        for (const auto& weight :
+                             ray_interpolation.atmosphere_for_layer(layer)) {
+                            if (!uniform_albedo) {
+                                albedo +=
+                                    weight.weight * albedo_values[weight.index];
+                            }
+                            if (!uniform_albedo_direction) {
+                                albedo_tangent +=
+                                    weight.weight *
+                                    albedo_direction[weight.index];
+                            }
+                        }
+                    }
+                }
+                const double factor = layer_cache.source_factor(flat_layer);
+                const double attenuation = 1.0 - factor * optical_depth;
+                const double attenuation_tangent =
+                    -attenuation * optical_depth_tangent;
+                if constexpr (WITH_TRANSPORT) {
+                    const double source_factor_tangent =
+                        prefix_tangent * albedo * (1.0 - attenuation) +
+                        prefix * albedo_tangent * (1.0 - attenuation) -
+                        prefix * albedo * attenuation_tangent;
+                    direct_transport_direction[ray] +=
+                        layer_state[flat_layer] * source_factor_tangent;
+                }
+                if (traced_layer.layer_distance < minimum_layer_distance_m) {
+                    have_shared_endpoint = false;
+                }
+                if (traced_layer.layer_distance >= minimum_layer_distance_m) {
+                    auto entrance_weights = traced_ray.entrance_weights(layer);
+                    auto exit_weights = traced_ray.exit_weights(layer);
+                    const auto* start_weights = &entrance_weights;
+                    const auto* end_weights = &exit_weights;
+                    bool start_entrance = true;
+                    bool end_entrance = false;
+                    if constexpr (LOWER_INTERPOLATION) {
+                        if (traced_layer.r_exit > traced_layer.r_entrance) {
+                            end_weights = &entrance_weights;
+                            end_entrance = true;
+                        } else {
+                            start_weights = &exit_weights;
+                            start_entrance = false;
+                        }
+                    }
+                    const int exit_solar = m_solar_offsets[ray] + layer;
+                    const auto start =
+                        have_shared_endpoint && !LOWER_INTERPOLATION
+                            ? shared_endpoint
+                            : scalar_endpoint_jvp<!LOWER_INTERPOLATION>(
+                                  wavelength, wavelength_thread, ray, layer,
+                                  start_entrance, exit_solar + 1,
+                                  *start_weights, extinction_direction,
+                                  albedo_direction, solar_direction,
+                                  uniform_albedo_direction,
+                                  uniform_albedo_tangent, phase_tangent_active);
+                    const auto end = scalar_endpoint_jvp<!LOWER_INTERPOLATION>(
+                        wavelength, wavelength_thread, ray, layer, end_entrance,
+                        exit_solar, *end_weights, extinction_direction,
+                        albedo_direction, solar_direction,
+                        uniform_albedo_direction, uniform_albedo_tangent,
+                        phase_tangent_active);
+                    const double factor_tangent =
+                        constant_source_factor_derivative(optical_depth,
+                                                          factor) *
+                        optical_depth_tangent;
+                    const double endpoint_value =
+                        (start.value * traced_layer.od_quad_start_fraction +
+                         end.value * traced_layer.od_quad_end_fraction) *
+                        traced_layer.layer_distance;
+                    const double endpoint_tangent =
+                        start.tangent * traced_layer.od_quad_start +
+                        end.tangent * traced_layer.od_quad_end;
+                    const double optical_endpoint_value =
+                        start.value * traced_layer.od_quad_start +
+                        end.value * traced_layer.od_quad_end;
+                    radiance_tangent +=
+                        prefix_tangent * factor * endpoint_value +
+                        prefix * (factor * endpoint_tangent +
+                                  factor_tangent * optical_endpoint_value);
+                    shared_endpoint = end;
+                    have_shared_endpoint = true;
+                }
+                prefix_tangent =
+                    prefix_tangent * attenuation + prefix * attenuation_tangent;
+                prefix *= attenuation;
+            }
+            if constexpr (WITH_TRANSPORT) {
+                if (traced_ray.ground_is_hit) {
+                    direct_transport_direction[ray] +=
+                        ground_state[ray] * prefix_tangent;
+                }
+            }
+            if (traced_ray.ground_is_hit && !traced_ray.layers.empty()) {
+                const auto& ground_layer = traced_ray.layers.front();
+                const double mu_in = ground_layer.exit.cos_zenith_angle(
+                    m_geometry.coordinates().sun_unit());
+                if (mu_in > 0.0) {
+                    const double mu_out = -ground_layer.exit.cos_zenith_angle(
+                        ground_layer.average_look_away);
+                    const double phi = ground_layer.saz_exit;
+                    const auto brdf = m_atmosphere->surface().brdf(
+                        wavelength, mu_in, mu_out, phi);
+                    double brdf_tangent = 0.0;
+                    for (int derivative = 0;
+                         derivative < m_atmosphere->surface().num_deriv();
+                         ++derivative) {
+                        brdf_tangent +=
+                            native_tangent(
+                                m_atmosphere->surface_deriv_start_index() +
+                                derivative) *
+                            m_atmosphere->surface().d_brdf(wavelength, mu_in,
+                                                           mu_out, phi,
+                                                           derivative)(0, 0);
+                    }
+                    const double ground_source =
+                        solar(m_solar_offsets[ray]) * mu_in * brdf(0, 0);
+                    const double ground_tangent =
+                        mu_in *
+                        (solar_tangent(m_solar_offsets[ray]) * brdf(0, 0) +
+                         solar(m_solar_offsets[ray]) * brdf_tangent);
+                    radiance_tangent += prefix_tangent * ground_source +
+                                        prefix * ground_tangent;
+                }
+            }
+            forcing_tangent(ray) = radiance_tangent;
+        }
+        (void)forcing;
+    }
+
+    template <int NSTOKES>
+    void FirstOrderProvider<NSTOKES>::accumulate_scalar_vjp(
+        int wavelength, int wavelength_thread,
+        Eigen::Ref<const Eigen::VectorXd> forcing_cotangent,
+        Eigen::Ref<Eigen::VectorXd> native_gradient,
+        const Eigen::VectorXd* transport_state,
+        const Eigen::VectorXd* layer_state_projection,
+        const Eigen::VectorXd* ground_state_projection) {
+        if (transport_state != nullptr || layer_state_projection != nullptr) {
+            if (m_use_lower_interpolation) {
+                accumulate_scalar_vjp_impl<true, true>(
+                    wavelength, wavelength_thread, forcing_cotangent,
+                    native_gradient, transport_state, layer_state_projection,
+                    ground_state_projection);
+            } else {
+                accumulate_scalar_vjp_impl<true, false>(
+                    wavelength, wavelength_thread, forcing_cotangent,
+                    native_gradient, transport_state, layer_state_projection,
+                    ground_state_projection);
+            }
+        } else if (m_use_lower_interpolation) {
+            accumulate_scalar_vjp_impl<false, true>(
+                wavelength, wavelength_thread, forcing_cotangent,
+                native_gradient, nullptr, nullptr, nullptr);
+        } else {
+            accumulate_scalar_vjp_impl<false, false>(
+                wavelength, wavelength_thread, forcing_cotangent,
+                native_gradient, nullptr, nullptr, nullptr);
+        }
+    }
+
+    template <int NSTOKES>
+    template <bool WITH_TRANSPORT, bool LOWER_INTERPOLATION>
+    void FirstOrderProvider<NSTOKES>::accumulate_scalar_vjp_impl(
+        int wavelength, int wavelength_thread,
+        Eigen::Ref<const Eigen::VectorXd> forcing_cotangent,
+        Eigen::Ref<Eigen::VectorXd> native_gradient,
+        const Eigen::VectorXd* transport_state,
+        const Eigen::VectorXd* layer_state_projection,
+        const Eigen::VectorXd* ground_state_projection) {
+        const int first_thread = wavelength_thread;
+        const int last_thread = first_thread + m_num_source_threads;
+        if (last_thread > static_cast<int>(m_gradient_scratch.size())) {
+            throw std::logic_error(
+                "Successive-orders compact scalar thread layout is invalid");
+        }
+        for (int thread = first_thread; thread < last_thread; ++thread) {
+            m_gradient_scratch[thread].setZero();
+            m_solar_product_scratch[thread].setZero();
+            m_phase_product_scratch[thread].setZero();
+        }
+        const auto& rays = m_source_geometry->incoming_rays();
+        const auto& interpolation = m_source_geometry->incoming_interpolation();
+        const auto& extinction = m_atmosphere->storage().total_extinction;
+        const auto& ssa = m_atmosphere->storage().ssa;
+        const auto& solar =
+            ensure_solar_transmission(wavelength, wavelength_thread);
+        ensure_endpoint_medium(wavelength);
+        const bool uniform_phase = m_uniform_phase_active[wavelength] != 0;
+        const bool uniform_albedo = m_uniform_albedo_active[wavelength] != 0;
+        const double uniform_albedo_value =
+            uniform_albedo ? m_uniform_albedo_values[wavelength] : 0.0;
+        const ScalarEndpointMediumCache* endpoint_medium =
+            m_endpoint_medium_cache.empty()
+                ? nullptr
+                : &m_endpoint_medium_cache[wavelength];
+        const ScalarLayerCache* layer_cache =
+            m_scalar_layer_cache.empty() ? nullptr
+                                         : &m_scalar_layer_cache[wavelength];
+        const bool use_layer_cache =
+            layer_cache != nullptr && layer_cache->active;
+        const double* __restrict layer_state =
+            layer_state_projection == nullptr ? nullptr
+                                              : layer_state_projection->data();
+        const double* __restrict ground_state =
+            ground_state_projection == nullptr
+                ? nullptr
+                : ground_state_projection->data();
+#pragma omp parallel for if (m_num_source_threads > 1)                         \
+    num_threads(m_num_source_threads) schedule(dynamic)
+        for (int ray = 0; ray < m_num_rays; ++ray) {
+            const int thread = ray_thread_index(wavelength_thread);
+            auto thread_gradient = m_gradient_scratch[thread].col(0);
+            auto& solar_gradient = m_solar_product_scratch[thread];
+            auto& coefficient_gradient = m_phase_product_scratch[thread];
+            auto& scratch = m_scalar_vjp_scratch[thread];
+            const auto& traced_ray = rays[ray];
+            const auto& ray_interpolation = interpolation[ray];
+            const ScalarPackedRay* packed_ray = nullptr;
+            if constexpr (!LOWER_INTERPOLATION) {
+                packed_ray = &m_scalar_packed_rays[ray];
+            }
+            const int flat_layer_offset =
+                LOWER_INTERPOLATION ? m_solar_offsets[ray] - ray
+                                    : static_cast<int>(packed_ray->layer_begin);
+            const auto transport_columns =
+                transport_state == nullptr
+                    ? InterpolationView<int>{}
+                    : m_source_geometry->transport_columns_for_ray(ray);
+            const int* transport_column_data = transport_columns.data();
+            const int num_layers =
+                LOWER_INTERPOLATION ? static_cast<int>(traced_ray.layers.size())
+                                    : static_cast<int>(packed_ray->layer_end -
+                                                       packed_ray->layer_begin);
+            double prefix = 1.0;
+            for (int layer = num_layers - 1; layer >= 0; --layer) {
+                double optical_depth = 0.0;
+                double attenuation = 0.0;
+                double factor = 1.0;
+                if (use_layer_cache) {
+                    const int flat_layer = flat_layer_offset + layer;
+                    optical_depth = layer_cache->optical_depth(flat_layer);
+                    factor = layer_cache->source_factor(flat_layer);
+                    attenuation = 1.0 - factor * optical_depth;
+                } else {
+                    const auto od_weights =
+                        traced_ray.optical_depth_weights(layer);
+                    for (std::size_t index = 0; index < od_weights.size();
+                         ++index) {
+                        const auto [atmosphere_index, weight] =
+                            od_weights[index];
+                        optical_depth +=
+                            weight * extinction(atmosphere_index, wavelength);
+                    }
+                    const auto layer_transfer =
+                        scalar_layer_transfer(optical_depth);
+                    attenuation = layer_transfer.attenuation;
+                    factor = layer_transfer.source_factor;
+                }
+                if (!use_layer_cache) {
+                    scratch.optical_depth(layer) = optical_depth;
+                    scratch.attenuation(layer) = attenuation;
+                    scratch.source_factor(layer) = factor;
+                }
+                scratch.prefix_attenuation(layer) = prefix;
+                prefix *= attenuation;
+            }
+            if (!uniform_albedo) {
+                for (int layer = 0; layer < num_layers; ++layer) {
+                    double albedo = 0.0;
+                    for (const auto& weight :
+                         ray_interpolation.atmosphere_for_layer(layer)) {
+                        albedo += weight.weight * ssa(weight.index, wavelength);
+                    }
+                    scratch.albedo(layer) = albedo;
+                }
+            }
+            if constexpr (!LOWER_INTERPOLATION) {
+                if (num_layers > 0) {
+                    scratch.endpoint_cotangent.head(num_layers + 1).setZero();
+                    const double phase =
+                        uniform_phase
+                            ? m_uniform_phase_values[static_cast<std::size_t>(
+                                                         wavelength) *
+                                                         m_num_rays +
+                                                     ray]
+                            : 0.0;
+                    for (int endpoint = 0; endpoint <= num_layers; ++endpoint) {
+                        const int solar_index = m_solar_offsets[ray] + endpoint;
+                        auto& value = scratch.endpoints[endpoint];
+                        if (uniform_phase) {
+                            const int slot = m_endpoint_slots[solar_index];
+                            value.extinction =
+                                endpoint_medium->extinction(slot);
+                            value.albedo = endpoint_medium->albedo(slot);
+                            value.phase = phase;
+                        } else {
+                            const auto weights =
+                                endpoint == 0
+                                    ? traced_ray.exit_weights(0)
+                                    : traced_ray.entrance_weights(endpoint - 1);
+                            value = scalar_endpoint(
+                                wavelength, ray,
+                                endpoint == 0 ? 0 : endpoint - 1, endpoint != 0,
+                                solar_index, weights);
+                        }
+                        value.solar_transmission = solar(solar_index);
+                        value.source = value.extinction * value.albedo *
+                                       value.solar_transmission * value.phase *
+                                       inverse_four_pi;
+                    }
+                }
+            }
+            const double forcing_gradient = forcing_cotangent(ray);
+            double prefix_cotangent = 0.0;
+            if (traced_ray.ground_is_hit && !traced_ray.layers.empty()) {
+                const auto& ground_layer = traced_ray.layers.front();
+                const double mu_in = ground_layer.exit.cos_zenith_angle(
+                    m_geometry.coordinates().sun_unit());
+                if (mu_in > 0.0) {
+                    const double mu_out = -ground_layer.exit.cos_zenith_angle(
+                        ground_layer.average_look_away);
+                    const double phi = ground_layer.saz_exit;
+                    const auto brdf = m_atmosphere->surface().brdf(
+                        wavelength, mu_in, mu_out, phi);
+                    const double ground_source =
+                        solar(m_solar_offsets[ray]) * mu_in * brdf(0, 0);
+                    prefix_cotangent = forcing_gradient * ground_source;
+                    solar_gradient(m_solar_offsets[ray]) +=
+                        prefix * forcing_gradient * mu_in * brdf(0, 0);
+                    for (int derivative = 0;
+                         derivative < m_atmosphere->surface().num_deriv();
+                         ++derivative) {
+                        thread_gradient(
+                            m_atmosphere->surface_deriv_start_index() +
+                            derivative) += prefix * forcing_gradient *
+                                           solar(m_solar_offsets[ray]) * mu_in *
+                                           m_atmosphere->surface().d_brdf(
+                                               wavelength, mu_in, mu_out, phi,
+                                               derivative)(0, 0);
+                    }
+                }
+            }
+            if constexpr (WITH_TRANSPORT) {
+                if (traced_ray.ground_is_hit) {
+                    if (ground_state != nullptr) {
+                        prefix_cotangent +=
+                            ground_state[ray] * forcing_gradient;
+                    } else {
+                        for (const auto& source :
+                             ray_interpolation.ground_weights) {
+                            prefix_cotangent +=
+                                source.weight * forcing_gradient *
+                                (*transport_state)(
+                                    transport_column_data
+                                        [source.row_inner_index]);
+                        }
+                    }
+                }
+            }
+
+            for (int layer = 0; layer < num_layers; ++layer) {
+                const sasktran2::raytracing::TracedLayer* traced_layer =
+                    nullptr;
+                double layer_distance;
+                double source_quad_start;
+                double source_quad_end;
+                if constexpr (LOWER_INTERPOLATION) {
+                    traced_layer = &traced_ray.layers[layer];
+                    layer_distance = traced_layer->layer_distance;
+                    source_quad_start = traced_layer->od_quad_start;
+                    source_quad_end = traced_layer->od_quad_end;
+                } else {
+                    const auto& packed_layer =
+                        m_scalar_packed_layers[packed_ray->layer_begin + layer];
+                    source_quad_start = packed_layer.source_quad_start;
+                    source_quad_end = packed_layer.source_quad_end;
+                    layer_distance = source_quad_start + source_quad_end;
+                }
+                const int flat_layer = flat_layer_offset + layer;
+                const double optical_depth =
+                    use_layer_cache ? layer_cache->optical_depth(flat_layer)
+                                    : scratch.optical_depth(layer);
+                const double factor =
+                    use_layer_cache ? layer_cache->source_factor(flat_layer)
+                                    : scratch.source_factor(layer);
+                const double attenuation = use_layer_cache
+                                               ? 1.0 - factor * optical_depth
+                                               : scratch.attenuation(layer);
+                const double layer_prefix = scratch.prefix_attenuation(layer);
+                double layer_prefix_cotangent = 0.0;
+                double optical_depth_cotangent = 0.0;
+                double attenuation_cotangent = 0.0;
+                if constexpr (WITH_TRANSPORT) {
+                    double source_factor_cotangent = 0.0;
+                    if (layer_state != nullptr) {
+                        source_factor_cotangent =
+                            layer_state[flat_layer] * forcing_gradient;
+                    } else {
+                        for (const auto& source :
+                             ray_interpolation.source_for_layer(layer)) {
+                            source_factor_cotangent +=
+                                source.weight * forcing_gradient *
+                                (*transport_state)(
+                                    transport_column_data
+                                        [source.row_inner_index]);
+                        }
+                    }
+                    const double albedo = uniform_albedo
+                                              ? uniform_albedo_value
+                                              : scratch.albedo(layer);
+                    const double albedo_cotangent = source_factor_cotangent *
+                                                    (1.0 - attenuation) *
+                                                    layer_prefix;
+                    attenuation_cotangent -=
+                        source_factor_cotangent * albedo * layer_prefix;
+                    layer_prefix_cotangent +=
+                        source_factor_cotangent * albedo * (1.0 - attenuation);
+                    for (const auto& weight :
+                         ray_interpolation.atmosphere_for_layer(layer)) {
+                        thread_gradient(m_atmosphere->ssa_deriv_start_index() +
+                                        weight.index) +=
+                            weight.weight * albedo_cotangent;
+                    }
+                }
+                if (layer_distance >= minimum_layer_distance_m &&
+                    forcing_gradient != 0.0) {
+                    const auto entrance_weights =
+                        traced_ray.entrance_weights(layer);
+                    const auto exit_weights = traced_ray.exit_weights(layer);
+                    const auto* start_weights = &entrance_weights;
+                    const auto* end_weights = &exit_weights;
+                    bool start_entrance = true;
+                    bool end_entrance = false;
+                    if constexpr (LOWER_INTERPOLATION) {
+                        if (traced_layer->r_exit > traced_layer->r_entrance) {
+                            end_weights = &entrance_weights;
+                            end_entrance = true;
+                        } else {
+                            start_weights = &exit_weights;
+                            start_entrance = false;
+                        }
+                    }
+                    const int exit_solar = m_solar_offsets[ray] + layer;
+                    auto start =
+                        !LOWER_INTERPOLATION
+                            ? scratch.endpoints[layer + 1]
+                            : scalar_endpoint(wavelength, ray, layer,
+                                              start_entrance, exit_solar + 1,
+                                              *start_weights);
+                    auto end = !LOWER_INTERPOLATION
+                                   ? scratch.endpoints[layer]
+                                   : scalar_endpoint(wavelength, ray, layer,
+                                                     end_entrance, exit_solar,
+                                                     *end_weights);
+                    if constexpr (LOWER_INTERPOLATION) {
+                        start.solar_transmission = solar(exit_solar + 1);
+                        start.source = start.extinction * start.albedo *
+                                       start.solar_transmission * start.phase *
+                                       inverse_four_pi;
+                        end.solar_transmission = solar(exit_solar);
+                        end.source = end.extinction * end.albedo *
+                                     end.solar_transmission * end.phase *
+                                     inverse_four_pi;
+                    }
+                    const double factor_derivative =
+                        constant_source_factor_derivative(optical_depth,
+                                                          factor);
+                    const double endpoint_value = [&]() {
+                        if constexpr (LOWER_INTERPOLATION) {
+                            return (start.source *
+                                        traced_layer->od_quad_start_fraction +
+                                    end.source *
+                                        traced_layer->od_quad_end_fraction) *
+                                   layer_distance;
+                        } else {
+                            return start.source * source_quad_start +
+                                   end.source * source_quad_end;
+                        }
+                    }();
+                    layer_prefix_cotangent +=
+                        forcing_gradient * factor * endpoint_value;
+                    optical_depth_cotangent +=
+                        forcing_gradient * layer_prefix * factor_derivative *
+                        (start.source * source_quad_start +
+                         end.source * source_quad_end);
+                    const double start_cotangent = forcing_gradient *
+                                                   layer_prefix * factor *
+                                                   source_quad_start;
+                    const double end_cotangent = forcing_gradient *
+                                                 layer_prefix * factor *
+                                                 source_quad_end;
+                    if constexpr (!LOWER_INTERPOLATION) {
+                        scratch.endpoint_cotangent(layer + 1) +=
+                            start_cotangent;
+                        scratch.endpoint_cotangent(layer) += end_cotangent;
+                    } else {
+                        accumulate_scalar_endpoint_vjp(
+                            wavelength, ray, layer, start_entrance,
+                            exit_solar + 1, *start_weights, start,
+                            start_cotangent, thread_gradient, solar_gradient,
+                            coefficient_gradient);
+                        accumulate_scalar_endpoint_vjp(
+                            wavelength, ray, layer, end_entrance, exit_solar,
+                            *end_weights, end, end_cotangent, thread_gradient,
+                            solar_gradient, coefficient_gradient);
+                    }
+                }
+                layer_prefix_cotangent += prefix_cotangent * attenuation;
+                attenuation_cotangent += prefix_cotangent * layer_prefix;
+                optical_depth_cotangent -= attenuation * attenuation_cotangent;
+                const auto od_weights = traced_ray.optical_depth_weights(layer);
+                for (std::size_t index = 0; index < od_weights.size();
+                     ++index) {
+                    const auto [atmosphere_index, weight] = od_weights[index];
+                    thread_gradient(atmosphere_index) +=
+                        weight * optical_depth_cotangent;
+                }
+                prefix_cotangent = layer_prefix_cotangent;
+            }
+            if constexpr (!LOWER_INTERPOLATION) {
+                if (num_layers > 0) {
+                    const auto exit_weights = traced_ray.exit_weights(0);
+                    accumulate_scalar_endpoint_vjp(
+                        wavelength, ray, 0, false, m_solar_offsets[ray],
+                        exit_weights, scratch.endpoints[0],
+                        scratch.endpoint_cotangent(0), thread_gradient,
+                        solar_gradient, coefficient_gradient);
+                    for (int endpoint = 1; endpoint <= num_layers; ++endpoint) {
+                        const auto entrance_weights =
+                            traced_ray.entrance_weights(endpoint - 1);
+                        accumulate_scalar_endpoint_vjp(
+                            wavelength, ray, endpoint - 1, true,
+                            m_solar_offsets[ray] + endpoint, entrance_weights,
+                            scratch.endpoints[endpoint],
+                            scratch.endpoint_cotangent(endpoint),
+                            thread_gradient, solar_gradient,
+                            coefficient_gradient);
+                    }
+                }
+            }
+        }
+
+        for (int thread = first_thread; thread < last_thread; ++thread) {
+            auto thread_gradient = m_gradient_scratch[thread].col(0);
+            const auto& coefficient_gradient = m_phase_product_scratch[thread];
+            const int locations =
+                m_atmosphere->storage().total_extinction.rows();
+            for (int group = 0;
+                 group < m_atmosphere->num_scattering_deriv_groups(); ++group) {
+                const int native_offset =
+                    m_atmosphere->scat_deriv_start_index() + group * locations;
+                for (int location = 0; location < locations; ++location) {
+                    const int order =
+                        std::min(m_atmosphere->storage().d_max_order[group](
+                                     location, wavelength),
+                                 m_num_phase_moments);
+                    double value = 0.0;
+                    const int coefficient_offset =
+                        location * m_num_phase_moments;
+                    for (int degree = 0; degree < order; ++degree) {
+                        value += coefficient_gradient(coefficient_offset +
+                                                      degree) *
+                                 m_atmosphere->storage().d_leg_coeff(
+                                     degree, location, wavelength, group);
+                    }
+                    thread_gradient(native_offset + location) += value;
+                }
+            }
+            auto& solar_gradient = m_solar_product_scratch[thread];
+            auto& table_gradient = m_solar_table_product_scratch[thread];
+            solar_gradient.array() *= solar.array();
+            table_gradient.noalias() =
+                m_solar_interpolation.transpose() * solar_gradient;
+            const Eigen::Index solar_columns =
+                m_solar_table.geometry_matrix().cols();
+            thread_gradient.head(solar_columns).noalias() -=
+                m_solar_table.geometry_matrix().transpose() * table_gradient;
+            native_gradient += thread_gradient;
+        }
+    }
+
+    template <int NSTOKES>
+    void FirstOrderProvider<NSTOKES>::calculate_with_transport(
+        int wavelength, int wavelength_thread, TransportOperator& transport,
+        Eigen::Ref<Eigen::VectorXd> forcing) {
+        validate_ready(wavelength, wavelength_thread);
+        if (!m_use_compact_scalar || forcing.size() != size()) {
+            throw std::invalid_argument(
+                "Fused successive-orders assembly requires the compact "
+                "scalar kernel");
+        }
+        calculate_scalar(wavelength, wavelength_thread, forcing, &transport);
+    }
+
+    template <int NSTOKES>
+    void FirstOrderProvider<NSTOKES>::project_transport_state(
+        Eigen::Ref<const Eigen::VectorXd> transport_state,
+        Eigen::VectorXd& layer_state_projection,
+        Eigen::VectorXd& ground_state_projection) const {
+        if (!m_use_compact_scalar ||
+            transport_state.size() != m_source_geometry->total_num_outgoing()) {
+            throw std::invalid_argument(
+                "Invalid compact scalar transport state projection");
+        }
+        const int layer_count = m_solar_offsets.back() - m_num_rays;
+        layer_state_projection.setZero(layer_count);
+        ground_state_projection.setZero(m_num_rays);
+        const auto& interpolation = m_source_geometry->incoming_interpolation();
+        if (!m_use_lower_interpolation) {
+#pragma omp parallel for if (m_num_source_threads > 1)                         \
+    num_threads(m_num_source_threads) schedule(dynamic)
+            for (int ray = 0; ray < m_num_rays; ++ray) {
+                const auto& packed_ray = m_scalar_packed_rays[ray];
+                const auto& ray_interpolation = interpolation[ray];
+                for (std::uint32_t flat_layer = packed_ray.layer_begin;
+                     flat_layer < packed_ray.layer_end; ++flat_layer) {
+                    const auto local_layer = static_cast<std::size_t>(
+                        flat_layer - packed_ray.layer_begin);
+                    double value = 0.0;
+                    for (const auto& source :
+                         ray_interpolation.source_for_layer(local_layer)) {
+                        value += source.weight *
+                                 transport_state(source.source_index);
+                    }
+                    layer_state_projection(flat_layer) = value;
+                }
+                double ground_value = 0.0;
+                for (const auto& source : ray_interpolation.ground_weights) {
+                    ground_value +=
+                        source.weight * transport_state(source.source_index);
+                }
+                ground_state_projection(ray) = ground_value;
+            }
+            return;
+        }
+#pragma omp parallel for if (m_num_source_threads > 1)                         \
+    num_threads(m_num_source_threads) schedule(dynamic)
+        for (int ray = 0; ray < m_num_rays; ++ray) {
+            const auto& ray_interpolation = interpolation[ray];
+            const int flat_layer_offset = m_solar_offsets[ray] - ray;
+            for (int layer = 0;
+                 layer < static_cast<int>(ray_interpolation.layers.size());
+                 ++layer) {
+                const auto& interpolation_layer =
+                    ray_interpolation.layers[layer];
+                const auto* source = ray_interpolation.source_weights.data() +
+                                     interpolation_layer.source_offset;
+                const auto* source_end =
+                    source + interpolation_layer.source_count;
+                double value = 0.0;
+                for (; source != source_end; ++source) {
+                    value +=
+                        source->weight * transport_state(source->source_index);
+                }
+                layer_state_projection(flat_layer_offset + layer) = value;
+            }
+            double ground_value = 0.0;
+            for (const auto& source : ray_interpolation.ground_weights) {
+                ground_value +=
+                    source.weight * transport_state(source.source_index);
+            }
+            ground_state_projection(ray) = ground_value;
+        }
+    }
+
+    template <int NSTOKES>
+    void FirstOrderProvider<NSTOKES>::calculate_jvp_with_transport(
+        int wavelength, int wavelength_thread,
+        Eigen::Ref<const Eigen::VectorXd> native_tangent,
+        const Eigen::VectorXd& layer_state_projection,
+        const Eigen::VectorXd& ground_state_projection,
+        Eigen::VectorXd& direct_transport_tangent,
+        Eigen::Ref<Eigen::VectorXd> forcing,
+        Eigen::Ref<Eigen::VectorXd> forcing_tangent) {
+        validate_ready(wavelength, wavelength_thread);
+        if (!m_use_compact_scalar ||
+            native_tangent.size() != m_atmosphere->num_deriv() ||
+            layer_state_projection.size() !=
+                m_solar_offsets.back() - m_num_rays ||
+            ground_state_projection.size() != m_num_rays ||
+            direct_transport_tangent.size() != m_num_rays ||
+            forcing.size() != size() || forcing_tangent.size() != size()) {
+            throw std::invalid_argument(
+                "Fused successive-orders JVP requires the compact scalar "
+                "kernel");
+        }
+        calculate_scalar_jvp(wavelength, wavelength_thread, native_tangent,
+                             forcing, forcing_tangent, &layer_state_projection,
+                             &ground_state_projection,
+                             &direct_transport_tangent);
+    }
+
+    template <int NSTOKES>
+    void FirstOrderProvider<NSTOKES>::accumulate_vjp_with_transport(
+        int wavelength, int wavelength_thread,
+        const Eigen::VectorXd& transport_state,
+        Eigen::Ref<const Eigen::VectorXd> forcing_cotangent,
+        Eigen::Ref<Eigen::VectorXd> native_gradient) {
+        validate_ready(wavelength, wavelength_thread);
+        if (!m_use_compact_scalar || forcing_cotangent.size() != size() ||
+            native_gradient.size() != m_atmosphere->num_deriv() ||
+            transport_state.size() != m_source_geometry->total_num_outgoing()) {
+            throw std::invalid_argument(
+                "Fused successive-orders VJP requires the compact scalar "
+                "kernel");
+        }
+        accumulate_scalar_vjp(wavelength, wavelength_thread, forcing_cotangent,
+                              native_gradient, &transport_state, nullptr,
+                              nullptr);
+    }
+
+    template <int NSTOKES>
+    void FirstOrderProvider<NSTOKES>::accumulate_vjp_with_projected_transport(
+        int wavelength, int wavelength_thread,
+        const Eigen::VectorXd& layer_state_projection,
+        const Eigen::VectorXd& ground_state_projection,
+        Eigen::Ref<const Eigen::VectorXd> forcing_cotangent,
+        Eigen::Ref<Eigen::VectorXd> native_gradient) {
+        validate_ready(wavelength, wavelength_thread);
+        if (!m_use_compact_scalar || forcing_cotangent.size() != size() ||
+            native_gradient.size() != m_atmosphere->num_deriv() ||
+            layer_state_projection.size() !=
+                m_solar_offsets.back() - m_num_rays ||
+            ground_state_projection.size() != m_num_rays) {
+            throw std::invalid_argument(
+                "Fused successive-orders VJP requires the compact scalar "
+                "kernel");
+        }
+        accumulate_scalar_vjp(wavelength, wavelength_thread, forcing_cotangent,
+                              native_gradient, nullptr, &layer_state_projection,
+                              &ground_state_projection);
+    }
+
+    template <int NSTOKES>
+    void FirstOrderProvider<NSTOKES>::calculate(
+        int wavelength, int wavelength_thread,
+        Eigen::Ref<Eigen::VectorXd> forcing) {
+        validate_ready(wavelength, wavelength_thread);
+        if (forcing.size() != size()) {
+            throw std::invalid_argument(
+                "Invalid successive-orders first-order forcing size");
+        }
+        if (m_use_compact_scalar) {
+            calculate_scalar(wavelength, wavelength_thread, forcing);
+            return;
+        }
+        const sasktran2::WavelengthBlock<> block{wavelength, 1};
+        m_source.calculate(block, wavelength_thread);
+
+#pragma omp parallel for if (m_num_source_threads > 1)                         \
+    num_threads(m_num_source_threads) schedule(dynamic)
+        for (int ray = 0; ray < m_num_rays; ++ray) {
+            const int thread = ray_thread_index(wavelength_thread);
+            auto& result = m_primal_scratch[thread];
+            result.set_zero(1);
+            m_integrator.integrate(result, m_source_terms, block, ray,
+                                   wavelength_thread, thread);
+            forcing.template segment<NSTOKES>(ray * NSTOKES) =
+                result.value.col(0);
+        }
+    }
+
+    template <int NSTOKES>
+    void FirstOrderProvider<NSTOKES>::calculate_jvp(
+        int wavelength, int wavelength_thread,
+        Eigen::Ref<const Eigen::VectorXd> native_tangent,
+        Eigen::Ref<Eigen::VectorXd> forcing,
+        Eigen::Ref<Eigen::VectorXd> forcing_tangent) {
+        validate_ready(wavelength, wavelength_thread);
+        if (native_tangent.size() != m_atmosphere->num_deriv() ||
+            forcing.size() != size() || forcing_tangent.size() != size()) {
+            throw std::invalid_argument(
+                "Invalid successive-orders first-order JVP dimensions");
+        }
+        if (m_use_compact_scalar) {
+            calculate_scalar_jvp(wavelength, wavelength_thread, native_tangent,
+                                 forcing, forcing_tangent);
+            return;
+        }
+        const sasktran2::WavelengthBlock<> block{wavelength, 1};
+        m_source.calculate_jvp(block, wavelength_thread, native_tangent);
+
+#pragma omp parallel for if (m_num_source_threads > 1)                         \
+    num_threads(m_num_source_threads) schedule(dynamic)
+        for (int ray = 0; ray < m_num_rays; ++ray) {
+            const int thread = ray_thread_index(wavelength_thread);
+            sasktran2::RadianceJVP<NSTOKES> result;
+            m_integrator.integrate_jvp(result, m_source_terms, wavelength, ray,
+                                       wavelength_thread, thread,
+                                       native_tangent);
+            forcing.template segment<NSTOKES>(ray * NSTOKES) = result.value;
+            forcing_tangent.template segment<NSTOKES>(ray * NSTOKES) =
+                result.jvp;
+        }
+    }
+
+    template <int NSTOKES>
+    void FirstOrderProvider<NSTOKES>::accumulate_vjp(
+        int wavelength, int wavelength_thread,
+        Eigen::Ref<const Eigen::VectorXd> forcing_cotangent,
+        Eigen::Ref<Eigen::VectorXd> native_gradient) {
+        validate_ready(wavelength, wavelength_thread);
+        if (forcing_cotangent.size() != size() ||
+            native_gradient.size() != m_atmosphere->num_deriv()) {
+            throw std::invalid_argument(
+                "Invalid successive-orders first-order VJP dimensions");
+        }
+        // `prepare_primal` may return a cached wavelength state while the
+        // exact source's wavelength-thread slot has since been reused. Refresh
+        // its solar transmission before every reverse product.
+        if (m_use_compact_scalar) {
+            accumulate_scalar_vjp(wavelength, wavelength_thread,
+                                  forcing_cotangent, native_gradient, nullptr,
+                                  nullptr, nullptr);
+            return;
+        }
+        m_source.calculate_vjp(sasktran2::WavelengthBlock<>{wavelength, 1},
+                               wavelength_thread);
+        // The engine uses disjoint scratch slots for simultaneous wavelength
+        // workers.  Clearing the whole vector here would race another
+        // wavelength's reverse pass and could erase a partially accumulated
+        // gradient.  A call owns only its wavelength slot when source
+        // threading is disabled, or the contiguous source-thread slots that
+        // start at that wavelength slot otherwise.
+        const int first_thread = wavelength_thread;
+        const int last_thread = first_thread + m_num_source_threads;
+        if (last_thread > static_cast<int>(m_gradient_scratch.size())) {
+            throw std::logic_error(
+                "Successive-orders first-order thread layout is invalid");
+        }
+        for (int thread = first_thread; thread < last_thread; ++thread) {
+            m_gradient_scratch[thread].setZero();
+        }
+
+#pragma omp parallel for if (m_num_source_threads > 1)                         \
+    num_threads(m_num_source_threads) schedule(dynamic)
+        for (int ray = 0; ray < m_num_rays; ++ray) {
+            const int thread = ray_thread_index(wavelength_thread);
+            auto& radiance = m_vjp_radiance_scratch[thread];
+            auto& cotangent = m_vjp_cotangent_scratch[thread];
+            cotangent.col(0) =
+                forcing_cotangent.template segment<NSTOKES>(ray * NSTOKES);
+            m_integrator.integrate_vjp_block(
+                radiance, m_source_terms,
+                sasktran2::WavelengthBlock<>{wavelength, 1}, ray,
+                wavelength_thread, thread, cotangent,
+                m_gradient_scratch[thread]);
+        }
+
+        for (int thread = first_thread; thread < last_thread; ++thread) {
+            native_gradient += m_gradient_scratch[thread].col(0);
+        }
+    }
+
+    template <int NSTOKES>
+    std::size_t FirstOrderProvider<NSTOKES>::workspace_bytes() const {
+        std::size_t result = 0;
+        for (const auto& scratch : m_primal_scratch) {
+            result += static_cast<std::size_t>(scratch.value.size() +
+                                               scratch.deriv.size()) *
+                      sizeof(double);
+        }
+        for (const auto& gradient : m_gradient_scratch) {
+            result +=
+                static_cast<std::size_t>(gradient.size()) * sizeof(double);
+        }
+        for (const auto& scratch : m_vjp_radiance_scratch) {
+            result += static_cast<std::size_t>(scratch.size()) * sizeof(double);
+        }
+        for (const auto& scratch : m_vjp_cotangent_scratch) {
+            result += static_cast<std::size_t>(scratch.size()) * sizeof(double);
+        }
+        for (const auto& scratch : m_solar_product_scratch) {
+            result += static_cast<std::size_t>(scratch.size()) * sizeof(double);
+        }
+        for (const auto& scratch : m_solar_table_product_scratch) {
+            result += static_cast<std::size_t>(scratch.size()) * sizeof(double);
+        }
+        for (const auto& scratch : m_phase_product_scratch) {
+            result += static_cast<std::size_t>(scratch.size()) * sizeof(double);
+        }
+        for (const auto& scratch : m_phase_order_scratch) {
+            result += scratch.capacity() * sizeof(int);
+        }
+        for (const auto& scratch : m_endpoint_extinction_tangent_scratch) {
+            result += static_cast<std::size_t>(scratch.size()) * sizeof(double);
+        }
+        for (const auto& scratch : m_endpoint_albedo_tangent_scratch) {
+            result += static_cast<std::size_t>(scratch.size()) * sizeof(double);
+        }
+        result += m_scalar_phase_orders.capacity() * sizeof(int);
+        result += m_uniform_phase_active.capacity() * sizeof(unsigned char);
+        result += m_uniform_phase_values.capacity() * sizeof(double);
+        result += m_uniform_albedo_active.capacity() * sizeof(unsigned char);
+        result += m_uniform_albedo_values.capacity() * sizeof(double);
+        result += m_scalar_packed_rays.capacity() * sizeof(ScalarPackedRay) +
+                  m_scalar_packed_layers.capacity() * sizeof(ScalarPackedLayer);
+        for (const auto& transmission : m_cached_solar_transmission) {
+            result +=
+                static_cast<std::size_t>(transmission.size()) * sizeof(double);
+        }
+        result += m_cached_solar_active.size() * sizeof(unsigned char);
+        for (const auto& cache : m_scalar_layer_cache) {
+            result += static_cast<std::size_t>(cache.optical_depth.size() +
+                                               cache.source_factor.size()) *
+                      sizeof(double);
+        }
+        for (const auto& cache : m_endpoint_medium_cache) {
+            result += static_cast<std::size_t>(cache.extinction.size() +
+                                               cache.albedo.size()) *
+                      sizeof(double);
+        }
+        for (const auto& scratch : m_scalar_vjp_scratch) {
+            result +=
+                static_cast<std::size_t>(
+                    scratch.optical_depth.size() + scratch.attenuation.size() +
+                    scratch.source_factor.size() +
+                    scratch.prefix_attenuation.size() + scratch.albedo.size() +
+                    scratch.endpoint_cotangent.size()) *
+                sizeof(double);
+            result += scratch.endpoints.size() * sizeof(ScalarEndpoint);
+        }
+        return result;
+    }
+
+    template class FirstOrderProvider<1>;
+    template class FirstOrderProvider<3>;
+
+} // namespace sasktran2::successive_orders

--- a/cpp/lib/successive_orders/first_order.cpp
+++ b/cpp/lib/successive_orders/first_order.cpp
@@ -2134,10 +2134,10 @@ namespace sasktran2::successive_orders {
                     const int coefficient_offset =
                         location * m_num_phase_moments;
                     for (int degree = 0; degree < order; ++degree) {
-                        value += coefficient_gradient(coefficient_offset +
-                                                      degree) *
-                                 m_atmosphere->storage().d_leg_coeff(
-                                     degree, location, wavelength, group);
+                        value +=
+                            coefficient_gradient(coefficient_offset + degree) *
+                            m_atmosphere->storage().d_leg_coeff(
+                                degree, location, wavelength, group);
                     }
                     thread_gradient(native_offset + location) += value;
                 }

--- a/cpp/lib/successive_orders/first_order.h
+++ b/cpp/lib/successive_orders/first_order.h
@@ -1,0 +1,275 @@
+#pragma once
+
+#include "geometry.h"
+#include "transport.h"
+
+#include <sasktran2/solartransmission.h>
+#include <sasktran2/source_integrator.h>
+
+#include <Eigen/Core>
+#include <Eigen/SparseCore>
+
+#include <cstddef>
+#include <vector>
+
+namespace sasktran2::successive_orders {
+
+    /** Exact single-scatter illumination on the source's incoming rays.
+     *
+     * This is an implementation detail of the successive-orders source.  It
+     * deliberately owns its source and integrator so no engine source needs to
+     * be exposed or shared.  Ordinary integration is derivative-free; native
+     * directional and reverse products use the exact source hooks directly.
+     */
+    template <int NSTOKES> class FirstOrderProvider {
+      public:
+        FirstOrderProvider(
+            const sasktran2::Geometry1D& geometry,
+            const sasktran2::raytracing::RayTracerBase& raytracer);
+
+        void initialize_config(const sasktran2::Config& config);
+        void initialize_geometry(const SourceGeometry1D& source_geometry);
+        void initialize_atmosphere(
+            const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere);
+
+        int size() const { return m_num_rays * NSTOKES; }
+
+        /** Calculates the first-order incoming radiance. */
+        void calculate(int wavelength, int wavelength_thread,
+                       Eigen::Ref<Eigen::VectorXd> forcing);
+
+        bool uses_compact_scalar_kernel() const { return m_use_compact_scalar; }
+
+        void calculate_with_transport(int wavelength, int wavelength_thread,
+                                      TransportOperator& transport,
+                                      Eigen::Ref<Eigen::VectorXd> forcing);
+
+        /** Calculates the first-order radiance and one native JVP. */
+        void calculate_jvp(int wavelength, int wavelength_thread,
+                           Eigen::Ref<const Eigen::VectorXd> native_tangent,
+                           Eigen::Ref<Eigen::VectorXd> forcing,
+                           Eigen::Ref<Eigen::VectorXd> forcing_tangent);
+
+        void calculate_jvp_with_transport(
+            int wavelength, int wavelength_thread,
+            Eigen::Ref<const Eigen::VectorXd> native_tangent,
+            const Eigen::VectorXd& layer_state_projection,
+            const Eigen::VectorXd& ground_state_projection,
+            Eigen::VectorXd& direct_transport_tangent,
+            Eigen::Ref<Eigen::VectorXd> forcing,
+            Eigen::Ref<Eigen::VectorXd> forcing_tangent);
+
+        void project_transport_state(
+            Eigen::Ref<const Eigen::VectorXd> transport_state,
+            Eigen::VectorXd& layer_state_projection,
+            Eigen::VectorXd& ground_state_projection) const;
+
+        /** Accumulates the VJP of the first-order radiance. */
+        void accumulate_vjp(int wavelength, int wavelength_thread,
+                            Eigen::Ref<const Eigen::VectorXd> forcing_cotangent,
+                            Eigen::Ref<Eigen::VectorXd> native_gradient);
+
+        void accumulate_vjp_with_transport(
+            int wavelength, int wavelength_thread,
+            const Eigen::VectorXd& transport_state,
+            Eigen::Ref<const Eigen::VectorXd> forcing_cotangent,
+            Eigen::Ref<Eigen::VectorXd> native_gradient);
+
+        void accumulate_vjp_with_projected_transport(
+            int wavelength, int wavelength_thread,
+            const Eigen::VectorXd& layer_state_projection,
+            const Eigen::VectorXd& ground_state_projection,
+            Eigen::Ref<const Eigen::VectorXd> forcing_cotangent,
+            Eigen::Ref<Eigen::VectorXd> native_gradient);
+
+        std::size_t workspace_bytes() const;
+
+      private:
+        using ExactSource = sasktran2::solartransmission::SingleScatterSource<
+            sasktran2::solartransmission::SolarTransmissionExact, NSTOKES>;
+        void validate_ready(int wavelength, int wavelength_thread) const;
+        int ray_thread_index(int wavelength_thread) const;
+        const Eigen::VectorXd& ensure_solar_transmission(int wavelength,
+                                                         int wavelength_thread);
+        void ensure_endpoint_medium(int wavelength);
+
+        struct ScalarEndpoint {
+            double extinction = 0.0;
+            double albedo = 0.0;
+            double phase = 0.0;
+            double solar_transmission = 0.0;
+            double source = 0.0;
+        };
+
+        struct ScalarValueTangent {
+            double value = 0.0;
+            double tangent = 0.0;
+        };
+
+        struct ScalarVjpScratch {
+            Eigen::VectorXd optical_depth;
+            Eigen::VectorXd attenuation;
+            Eigen::VectorXd source_factor;
+            Eigen::VectorXd prefix_attenuation;
+            Eigen::VectorXd albedo;
+            std::vector<ScalarEndpoint> endpoints;
+            Eigen::VectorXd endpoint_cotangent;
+        };
+
+        struct ScalarLayerCache {
+            Eigen::VectorXd optical_depth;
+            Eigen::VectorXd source_factor;
+            bool active = false;
+        };
+
+        struct ScalarEndpointMediumCache {
+            Eigen::VectorXd extinction;
+            Eigen::VectorXd albedo;
+            bool active = false;
+        };
+
+        struct ScalarPackedLayer {
+            // Keep only owned scalar metadata here. Geometry stencil views are
+            // reacquired from SourceGeometry1D so their backing storage and
+            // bounds remain authoritative across repeated engine evaluations.
+            double source_quad_start = 0.0;
+            double source_quad_end = 0.0;
+        };
+
+        struct ScalarPackedRay {
+            std::uint32_t layer_begin = 0;
+            std::uint32_t layer_end = 0;
+        };
+
+        void calculate_scalar(int wavelength, int wavelength_thread,
+                              Eigen::Ref<Eigen::VectorXd> forcing,
+                              TransportOperator* transport = nullptr);
+        template <bool WITH_TRANSPORT, bool LOWER_INTERPOLATION>
+        void calculate_scalar_impl(int wavelength, int wavelength_thread,
+                                   Eigen::Ref<Eigen::VectorXd> forcing,
+                                   TransportOperator* transport);
+        template <bool WITH_TRANSPORT>
+        void calculate_scalar_uniform_impl(int wavelength,
+                                           int wavelength_thread,
+                                           Eigen::Ref<Eigen::VectorXd> forcing,
+                                           TransportOperator* transport);
+        void calculate_scalar_jvp(
+            int wavelength, int wavelength_thread,
+            Eigen::Ref<const Eigen::VectorXd> native_tangent,
+            Eigen::Ref<Eigen::VectorXd> forcing,
+            Eigen::Ref<Eigen::VectorXd> forcing_tangent,
+            const Eigen::VectorXd* layer_state_projection = nullptr,
+            const Eigen::VectorXd* ground_state_projection = nullptr,
+            Eigen::VectorXd* direct_transport_tangent = nullptr);
+        template <bool WITH_TRANSPORT, bool LOWER_INTERPOLATION>
+        void calculate_scalar_jvp_impl(
+            int wavelength, int wavelength_thread,
+            Eigen::Ref<const Eigen::VectorXd> native_tangent,
+            Eigen::Ref<Eigen::VectorXd> forcing,
+            Eigen::Ref<Eigen::VectorXd> forcing_tangent,
+            const Eigen::VectorXd* layer_state_projection,
+            const Eigen::VectorXd* ground_state_projection,
+            Eigen::VectorXd* direct_transport_tangent);
+        void calculate_scalar_jvp_uniform_proportional(
+            int wavelength, Eigen::Ref<const Eigen::VectorXd> native_tangent,
+            const Eigen::VectorXd& solar_tangent,
+            double extinction_direction_scale, double albedo,
+            double albedo_tangent,
+            const Eigen::VectorXd& layer_state_projection,
+            const Eigen::VectorXd& ground_state_projection,
+            Eigen::VectorXd& direct_transport_tangent,
+            Eigen::Ref<Eigen::VectorXd> forcing_tangent);
+        void accumulate_scalar_vjp(
+            int wavelength, int wavelength_thread,
+            Eigen::Ref<const Eigen::VectorXd> forcing_cotangent,
+            Eigen::Ref<Eigen::VectorXd> native_gradient,
+            const Eigen::VectorXd* transport_state,
+            const Eigen::VectorXd* layer_state_projection,
+            const Eigen::VectorXd* ground_state_projection);
+        template <bool WITH_TRANSPORT, bool LOWER_INTERPOLATION>
+        void accumulate_scalar_vjp_impl(
+            int wavelength, int wavelength_thread,
+            Eigen::Ref<const Eigen::VectorXd> forcing_cotangent,
+            Eigen::Ref<Eigen::VectorXd> native_gradient,
+            const Eigen::VectorXd* transport_state,
+            const Eigen::VectorXd* layer_state_projection,
+            const Eigen::VectorXd* ground_state_projection);
+
+        ScalarEndpoint scalar_endpoint(
+            int wavelength, int ray, int layer, bool entrance, int solar_index,
+            const sasktran2::raytracing::GridWeightStencilView& weights) const;
+        template <bool USE_ENDPOINT_MEDIUM>
+        ScalarValueTangent scalar_endpoint_jvp(
+            int wavelength, int wavelength_thread, int ray, int layer,
+            bool entrance, int solar_index,
+            const sasktran2::raytracing::GridWeightStencilView& weights,
+            const double* extinction_direction, const double* albedo_direction,
+            const double* solar_tangent, bool uniform_albedo_direction,
+            double uniform_albedo_tangent, bool phase_tangent_active) const;
+        void accumulate_scalar_endpoint_vjp(
+            int wavelength, int ray, int layer, bool entrance, int solar_index,
+            const sasktran2::raytracing::GridWeightStencilView& weights,
+            const ScalarEndpoint& endpoint, double source_cotangent,
+            Eigen::Ref<Eigen::VectorXd> native_gradient,
+            Eigen::Ref<Eigen::VectorXd> solar_gradient,
+            Eigen::Ref<Eigen::VectorXd> coefficient_gradient) const;
+
+        const sasktran2::Geometry1D& m_geometry;
+        ExactSource m_source;
+        sasktran2::solartransmission::SolarTransmissionTable m_solar_table;
+        Eigen::SparseMatrix<double, Eigen::RowMajor> m_solar_interpolation;
+        std::vector<bool> m_solar_ground_hit;
+        sasktran2::SourceIntegrator<NSTOKES> m_integrator;
+        std::vector<SourceTermInterface<NSTOKES>*> m_source_terms;
+        const sasktran2::atmosphere::Atmosphere<NSTOKES>* m_atmosphere =
+            nullptr;
+        const SourceGeometry1D* m_source_geometry = nullptr;
+        int m_num_rays = 0;
+        int m_num_phase_moments = 0;
+        int m_num_threads = 1;
+        int m_num_source_threads = 1;
+        int m_num_wavelength_threads = 1;
+        bool m_geometry_initialized = false;
+        bool m_compact_scalar_requested = false;
+        bool m_use_compact_scalar = false;
+        bool m_use_lower_interpolation = false;
+
+        std::vector<int> m_solar_offsets;
+        std::vector<double> m_phase_basis;
+        std::vector<int> m_endpoint_slots;
+        std::vector<int> m_unique_endpoint_offsets;
+        std::vector<InterpolationWeight> m_unique_endpoint_weights;
+        std::vector<ScalarPackedRay> m_scalar_packed_rays;
+        std::vector<ScalarPackedLayer> m_scalar_packed_layers;
+        mutable std::vector<sasktran2::WavelengthBlockDual<NSTOKES>>
+            m_primal_scratch;
+        mutable std::vector<Eigen::MatrixXd> m_gradient_scratch;
+        mutable std::vector<
+            Eigen::Matrix<double, NSTOKES, Eigen::Dynamic, Eigen::RowMajor>>
+            m_vjp_radiance_scratch;
+        mutable std::vector<
+            Eigen::Matrix<double, NSTOKES, Eigen::Dynamic, Eigen::RowMajor>>
+            m_vjp_cotangent_scratch;
+        mutable std::vector<Eigen::VectorXd> m_solar_product_scratch;
+        mutable std::vector<Eigen::VectorXd> m_solar_table_product_scratch;
+        mutable std::vector<Eigen::VectorXd> m_phase_product_scratch;
+        mutable std::vector<std::vector<int>> m_phase_order_scratch;
+        mutable std::vector<Eigen::VectorXd>
+            m_endpoint_extinction_tangent_scratch;
+        mutable std::vector<Eigen::VectorXd> m_endpoint_albedo_tangent_scratch;
+        std::vector<int> m_scalar_phase_orders;
+        std::vector<unsigned char> m_uniform_phase_active;
+        std::vector<double> m_uniform_phase_values;
+        std::vector<unsigned char> m_uniform_albedo_active;
+        std::vector<double> m_uniform_albedo_values;
+        std::vector<Eigen::VectorXd> m_cached_solar_transmission;
+        std::vector<unsigned char> m_cached_solar_active;
+        std::vector<ScalarLayerCache> m_scalar_layer_cache;
+        std::vector<ScalarEndpointMediumCache> m_endpoint_medium_cache;
+        mutable std::vector<ScalarVjpScratch> m_scalar_vjp_scratch;
+    };
+
+    extern template class FirstOrderProvider<1>;
+    extern template class FirstOrderProvider<3>;
+
+} // namespace sasktran2::successive_orders

--- a/cpp/lib/successive_orders/fixed_point.h
+++ b/cpp/lib/successive_orders/fixed_point.h
@@ -1,0 +1,263 @@
+#pragma once
+
+#include <Eigen/Core>
+#include <Eigen/Cholesky>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+
+namespace sasktran2::successive_orders {
+
+    struct FixedPointSettings {
+        int maximum_iterations = 50;
+        double relative_tolerance = 1.0e-6;
+        double absolute_tolerance = 1.0e-12;
+        double damping = 1.0;
+        int anderson_depth = 3;
+
+        void validate() const {
+            if (maximum_iterations < 0) {
+                throw std::invalid_argument("successive-orders maximum "
+                                            "iterations must be non-negative");
+            }
+            if (!std::isfinite(relative_tolerance) ||
+                relative_tolerance < 0.0 ||
+                !std::isfinite(absolute_tolerance) ||
+                absolute_tolerance < 0.0) {
+                throw std::invalid_argument("successive-orders tolerances must "
+                                            "be finite and non-negative");
+            }
+            if (!std::isfinite(damping) || damping <= 0.0 || damping > 1.0) {
+                throw std::invalid_argument(
+                    "successive-orders damping must lie in (0, 1]");
+            }
+            if (anderson_depth < 0) {
+                throw std::invalid_argument(
+                    "successive-orders Anderson depth must be non-negative");
+            }
+        }
+
+        bool convergence_enabled() const {
+            return relative_tolerance > 0.0 || absolute_tolerance > 0.0;
+        }
+    };
+
+    enum class FixedPointTermination { tolerance, maximum_iterations };
+
+    struct FixedPointDiagnostics {
+        FixedPointTermination termination =
+            FixedPointTermination::maximum_iterations;
+        int iterations = 0;
+        double residual_norm = std::numeric_limits<double>::infinity();
+        double convergence_threshold = 0.0;
+
+        bool converged() const {
+            return termination == FixedPointTermination::tolerance;
+        }
+    };
+
+    /** Reusable Type-II Anderson workspace.
+     *
+     * Storage scales as O(n * depth), rather than retaining the complete
+     * fixed-point history. The small normal equation is regularized relative
+     * to its diagonal scale; if it is singular or produces a non-finite step,
+     * the solver safely falls back to a damped Picard update.
+     */
+    class FixedPointWorkspace {
+      public:
+        void resize(Eigen::Index state_size, int depth) {
+            if (state_size < 0 || depth < 0) {
+                throw std::invalid_argument(
+                    "invalid successive-orders solver workspace dimensions");
+            }
+            if (m_mapped.size() != state_size) {
+                m_mapped.resize(state_size);
+                m_residual.resize(state_size);
+                m_previous_state.resize(state_size);
+                m_previous_residual.resize(state_size);
+            }
+            if (m_delta_states.rows() != state_size ||
+                m_delta_states.cols() != depth) {
+                m_delta_states.resize(state_size, depth);
+                m_delta_residuals.resize(state_size, depth);
+            }
+            if (m_gram.rows() != depth) {
+                m_gram.resize(depth, depth);
+                m_rhs.resize(depth);
+                m_coefficients.resize(depth);
+            }
+            m_depth = depth;
+            reset_history();
+        }
+
+        void reset_history() {
+            m_history_size = 0;
+            m_history_start = 0;
+            m_have_previous = false;
+        }
+
+        Eigen::VectorXd& mapped() { return m_mapped; }
+        Eigen::VectorXd& residual() { return m_residual; }
+
+      private:
+        friend class FixedPointSolver;
+
+        Eigen::VectorXd m_mapped;
+        Eigen::VectorXd m_residual;
+        Eigen::VectorXd m_previous_state;
+        Eigen::VectorXd m_previous_residual;
+        Eigen::MatrixXd m_delta_states;
+        Eigen::MatrixXd m_delta_residuals;
+        Eigen::MatrixXd m_gram;
+        Eigen::VectorXd m_rhs;
+        Eigen::VectorXd m_coefficients;
+        int m_depth = 0;
+        int m_history_size = 0;
+        int m_history_start = 0;
+        bool m_have_previous = false;
+    };
+
+    class FixedPointSolver {
+      public:
+        /** Solves x = map(x).
+         *
+         * `map` must have the signature `void(const Eigen::VectorXd&,
+         * Eigen::VectorXd&)`. It may reuse external scratch, but must support
+         * distinct input/output vectors. When the iteration limit is reached,
+         * the returned state is the last damped or Anderson iterate.
+         */
+        template <typename Map>
+        static FixedPointDiagnostics solve(Eigen::VectorXd& state, Map&& map,
+                                           const FixedPointSettings& settings,
+                                           FixedPointWorkspace& workspace) {
+            settings.validate();
+            workspace.resize(state.size(), settings.anderson_depth);
+
+            FixedPointDiagnostics diagnostics;
+            if (settings.maximum_iterations == 0) {
+                diagnostics.residual_norm = 0.0;
+                return diagnostics;
+            }
+
+            for (int iteration = 0; iteration < settings.maximum_iterations;
+                 ++iteration) {
+                map(state, workspace.m_mapped);
+                if (workspace.m_mapped.size() != state.size()) {
+                    throw std::logic_error(
+                        "successive-orders fixed-point map changed state size");
+                }
+                workspace.m_residual.noalias() = workspace.m_mapped - state;
+
+                const double state_scale =
+                    std::max(state.lpNorm<Eigen::Infinity>(),
+                             workspace.m_mapped.lpNorm<Eigen::Infinity>());
+                diagnostics.residual_norm =
+                    workspace.m_residual.lpNorm<Eigen::Infinity>();
+                diagnostics.convergence_threshold =
+                    settings.absolute_tolerance +
+                    settings.relative_tolerance * state_scale;
+                diagnostics.iterations = iteration + 1;
+
+                if (!std::isfinite(diagnostics.residual_norm) ||
+                    !workspace.m_mapped.allFinite()) {
+                    throw std::runtime_error(
+                        "non-finite successive-orders fixed-point iterate");
+                }
+
+                if (settings.convergence_enabled() &&
+                    diagnostics.residual_norm <=
+                        diagnostics.convergence_threshold) {
+                    state = workspace.m_mapped;
+                    diagnostics.termination = FixedPointTermination::tolerance;
+                    return diagnostics;
+                }
+
+                update_history(state, workspace.m_residual, workspace);
+                if (!anderson_update(state, settings.damping, workspace)) {
+                    state.noalias() += settings.damping * workspace.m_residual;
+                }
+            }
+
+            return diagnostics;
+        }
+
+      private:
+        static void update_history(const Eigen::VectorXd& state,
+                                   const Eigen::VectorXd& residual,
+                                   FixedPointWorkspace& workspace) {
+            if (workspace.m_have_previous && workspace.m_depth > 0) {
+                int slot;
+                if (workspace.m_history_size < workspace.m_depth) {
+                    slot =
+                        (workspace.m_history_start + workspace.m_history_size) %
+                        workspace.m_depth;
+                    ++workspace.m_history_size;
+                } else {
+                    slot = workspace.m_history_start;
+                    workspace.m_history_start =
+                        (workspace.m_history_start + 1) % workspace.m_depth;
+                }
+                workspace.m_delta_states.col(slot).noalias() =
+                    state - workspace.m_previous_state;
+                workspace.m_delta_residuals.col(slot).noalias() =
+                    residual - workspace.m_previous_residual;
+            }
+            workspace.m_previous_state = state;
+            workspace.m_previous_residual = residual;
+            workspace.m_have_previous = true;
+        }
+
+        static bool anderson_update(Eigen::VectorXd& state, double damping,
+                                    FixedPointWorkspace& workspace) {
+            const int history = workspace.m_history_size;
+            if (history == 0) {
+                return false;
+            }
+
+            for (int row = 0; row < history; ++row) {
+                const int row_slot =
+                    (workspace.m_history_start + row) % workspace.m_depth;
+                const auto delta_residual_row =
+                    workspace.m_delta_residuals.col(row_slot);
+                workspace.m_rhs(row) =
+                    delta_residual_row.dot(workspace.m_residual);
+                for (int col = 0; col <= row; ++col) {
+                    const int col_slot =
+                        (workspace.m_history_start + col) % workspace.m_depth;
+                    const double value = delta_residual_row.dot(
+                        workspace.m_delta_residuals.col(col_slot));
+                    workspace.m_gram(row, col) = value;
+                    workspace.m_gram(col, row) = value;
+                }
+            }
+
+            auto gram = workspace.m_gram.topLeftCorner(history, history);
+            const double scale = std::max(1.0, gram.diagonal().maxCoeff());
+            gram.diagonal().array() += 1.0e-14 * scale;
+            workspace.m_coefficients.head(history) =
+                gram.ldlt().solve(workspace.m_rhs.head(history));
+            if (!workspace.m_coefficients.head(history).allFinite()) {
+                return false;
+            }
+
+            workspace.m_mapped.noalias() =
+                state + damping * workspace.m_residual;
+            for (int column = 0; column < history; ++column) {
+                const int slot =
+                    (workspace.m_history_start + column) % workspace.m_depth;
+                workspace.m_mapped.noalias() -=
+                    workspace.m_coefficients(column) *
+                    (workspace.m_delta_states.col(slot) +
+                     damping * workspace.m_delta_residuals.col(slot));
+            }
+            if (!workspace.m_mapped.allFinite()) {
+                return false;
+            }
+            state = workspace.m_mapped;
+            return true;
+        }
+    };
+
+} // namespace sasktran2::successive_orders

--- a/cpp/lib/successive_orders/geometry.cpp
+++ b/cpp/lib/successive_orders/geometry.cpp
@@ -1,0 +1,410 @@
+#include "geometry.h"
+
+#include <sasktran2/grids.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cmath>
+#include <exception>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+#ifdef SKTRAN_OPENMP_SUPPORT
+#include <omp.h>
+#endif
+
+namespace sasktran2::successive_orders {
+    namespace {
+        std::vector<InterpolationWeight>
+        sorted_weights(const std::vector<std::pair<int, double>>& weights) {
+            std::vector<InterpolationWeight> result;
+            result.reserve(weights.size());
+            for (const auto& [index, weight] : weights) {
+                if (index < 0 || !std::isfinite(weight)) {
+                    throw std::runtime_error(
+                        "Invalid successive-orders point interpolation");
+                }
+                if (weight != 0.0) {
+                    result.push_back({index, weight});
+                }
+            }
+            std::stable_sort(result.begin(), result.end(),
+                             [](const auto& left, const auto& right) {
+                                 return left.index < right.index;
+                             });
+            std::size_t write = 0;
+            for (const auto& value : result) {
+                if (write != 0 && result[write - 1].index == value.index) {
+                    result[write - 1].weight += value.weight;
+                } else {
+                    result[write++] = value;
+                }
+            }
+            result.resize(write);
+            result.erase(std::remove_if(result.begin(), result.end(),
+                                        [](const auto& value) {
+                                            return value.weight == 0.0;
+                                        }),
+                         result.end());
+            return result;
+        }
+
+        int checked_add(int left, int right, const char* description) {
+            if (right < 0 || left > std::numeric_limits<int>::max() - right) {
+                throw std::length_error(std::string(description) +
+                                        " exceeds the supported index range");
+            }
+            return left + right;
+        }
+    } // namespace
+
+    void SourceGeometrySettings::validate() const {
+        if (num_incoming <= 0 || num_outgoing <= 0) {
+            throw std::invalid_argument(
+                "Successive-orders angular grids must be non-empty");
+        }
+        if (num_sza <= 0) {
+            throw std::invalid_argument(
+                "Successive-orders SZA grid must be non-empty");
+        }
+        if (num_threads <= 0) {
+            throw std::invalid_argument(
+                "Successive-orders geometry requires at least one thread");
+        }
+    }
+
+    SourceGeometry1D::SourceGeometry1D(
+        const sasktran2::raytracing::RayTracerBase& raytracer,
+        const sasktran2::Geometry1D& geometry)
+        : m_raytracer(raytracer), m_geometry(geometry) {}
+
+    SourceGeometry1D::~SourceGeometry1D() = default;
+
+    sasktran2::grids::AltitudeGrid SourceGeometry1D::make_altitude_grid() {
+        const auto& atmosphere_altitudes = m_geometry.altitude_grid().grid();
+        Eigen::VectorXd altitudes;
+        // Atmosphere layer midpoints inherit arbitrary spacing from the
+        // atmosphere grid. Let Grid retain the constant fast path only when
+        // those midpoints are actually uniform.
+        const auto spacing = sasktran2::grids::gridspacing::automatic;
+
+        if (m_settings.altitude_grid_m.empty()) {
+            altitudes = 0.5 * (atmosphere_altitudes(Eigen::seq(
+                                   0, Eigen::placeholders::last - 1)) +
+                               atmosphere_altitudes(
+                                   Eigen::seq(1, Eigen::placeholders::last)));
+        } else {
+            altitudes.resize(
+                static_cast<Eigen::Index>(m_settings.altitude_grid_m.size()));
+            const double minimum_altitude = atmosphere_altitudes[0];
+            const double maximum_altitude =
+                atmosphere_altitudes[atmosphere_altitudes.size() - 1];
+            for (std::size_t index = 0;
+                 index < m_settings.altitude_grid_m.size(); ++index) {
+                const double altitude = m_settings.altitude_grid_m[index];
+                if (!std::isfinite(altitude) ||
+                    (index != 0 &&
+                     altitude <= m_settings.altitude_grid_m[index - 1])) {
+                    throw std::invalid_argument(
+                        "Successive-orders source altitudes must be finite "
+                        "and strictly increasing");
+                }
+                if (altitude <= minimum_altitude ||
+                    altitude >= maximum_altitude) {
+                    throw std::invalid_argument(
+                        "Successive-orders source altitudes must lie strictly "
+                        "inside the atmosphere altitude range");
+                }
+                altitudes[static_cast<Eigen::Index>(index)] = altitude;
+            }
+        }
+
+        m_source_altitudes_m.assign(altitudes.data(),
+                                    altitudes.data() + altitudes.size());
+        return sasktran2::grids::AltitudeGrid(
+            std::move(altitudes), spacing,
+            sasktran2::grids::outofbounds::extend,
+            sasktran2::grids::interpolation::linear);
+    }
+
+    sasktran2::grids::Grid SourceGeometry1D::make_cos_sza_grid(
+        const sasktran2::viewinggeometry::InternalViewingGeometry&
+            internal_viewing) {
+        Eigen::VectorXd cos_sza;
+        const auto geometry_type = m_geometry.coordinates().geometry_type();
+        const auto bounds = sasktran2::raytracing::min_max_cos_sza_of_all_rays(
+            internal_viewing.traced_rays);
+        // Plane-parallel and pseudospherical Geometry1D source locations both
+        // occupy one invariant reference column. Multiple SZA entries would
+        // therefore duplicate the same physical source points, so retain one
+        // point for those geometries even when num_sza is greater than one.
+        const bool usable_range =
+            geometry_type == sasktran2::geometrytype::spherical &&
+            m_settings.num_sza > 1 && std::isfinite(bounds.first) &&
+            std::isfinite(bounds.second) && bounds.first <= bounds.second &&
+            bounds.second - bounds.first > 1.0e-14;
+
+        if (usable_range) {
+            cos_sza.setLinSpaced(m_settings.num_sza, bounds.first,
+                                 bounds.second);
+        } else {
+            cos_sza.resize(1);
+            cos_sza[0] = m_geometry.coordinates().cos_sza_at_reference();
+        }
+
+        m_source_cos_sza.assign(cos_sza.data(),
+                                cos_sza.data() + cos_sza.size());
+        return sasktran2::grids::Grid(std::move(cos_sza),
+                                      sasktran2::grids::gridspacing::constant,
+                                      sasktran2::grids::outofbounds::extend,
+                                      sasktran2::grids::interpolation::linear);
+    }
+
+    void SourceGeometry1D::construct_source_points() {
+        m_num_interior_points = m_location_interpolator->num_interior_points();
+        m_num_ground_points = m_location_interpolator->num_ground_points();
+        const int total_points =
+            checked_add(m_num_interior_points, m_num_ground_points,
+                        "Successive-orders source point count");
+
+        m_angular_grids.clear();
+        m_angular_grids.reserve(static_cast<std::size_t>(m_num_ground_points) +
+                                1);
+        auto volume_grid = std::make_unique<AngularGridPair>();
+        volume_grid->incoming =
+            std::make_unique<sasktran2::math::LebedevSphere>(
+                m_settings.num_incoming);
+        volume_grid->outgoing =
+            std::make_unique<sasktran2::math::LebedevSphere>(
+                m_settings.num_outgoing);
+        m_angular_grids.push_back(std::move(volume_grid));
+
+        for (int ground_index = 0; ground_index < m_num_ground_points;
+             ++ground_index) {
+            const Eigen::Vector3d location =
+                m_location_interpolator->ground_location(
+                    m_geometry.coordinates(), ground_index);
+            auto ground_grid = std::make_unique<AngularGridPair>();
+            ground_grid->incoming =
+                std::make_unique<sasktran2::math::UnitSphereGround>(
+                    std::make_unique<sasktran2::math::LebedevSphere>(
+                        m_settings.num_incoming),
+                    location);
+            ground_grid->outgoing =
+                std::make_unique<sasktran2::math::UnitSphereGround>(
+                    std::make_unique<sasktran2::math::LebedevSphere>(
+                        m_settings.num_outgoing),
+                    location);
+            m_angular_grids.push_back(std::move(ground_grid));
+        }
+
+        m_source_points.clear();
+        m_source_points.resize(total_points);
+        for (int point_index = 0; point_index < m_num_interior_points;
+             ++point_index) {
+            auto& point = m_source_points[point_index];
+            point.m_location.position = m_location_interpolator->grid_location(
+                m_geometry.coordinates(), point_index);
+            point.m_incoming_sphere = m_angular_grids[0]->incoming.get();
+            point.m_outgoing_sphere = m_angular_grids[0]->outgoing.get();
+            point.m_is_ground = false;
+        }
+        for (int ground_index = 0; ground_index < m_num_ground_points;
+             ++ground_index) {
+            auto& point = m_source_points[m_num_interior_points + ground_index];
+            point.m_location.position =
+                m_location_interpolator->ground_location(
+                    m_geometry.coordinates(), ground_index);
+            // Avoid tracing a nominal ground point to the wrong side of the
+            // lower boundary because of Cartesian roundoff.
+            point.m_location.position +=
+                0.01 * point.m_location.position.normalized();
+            point.m_incoming_sphere =
+                m_angular_grids[ground_index + 1]->incoming.get();
+            point.m_outgoing_sphere =
+                m_angular_grids[ground_index + 1]->outgoing.get();
+            point.m_is_ground = true;
+        }
+
+        m_incoming_point_offsets.assign(
+            static_cast<std::size_t>(total_points) + 1, 0);
+        m_outgoing_point_offsets.assign(
+            static_cast<std::size_t>(total_points) + 1, 0);
+        std::vector<std::pair<int, double>> atmosphere_weights;
+        for (int point_index = 0; point_index < total_points; ++point_index) {
+            auto& point = m_source_points[point_index];
+            point.m_incoming_offset = m_incoming_point_offsets[point_index];
+            point.m_outgoing_offset = m_outgoing_point_offsets[point_index];
+            m_incoming_point_offsets[point_index + 1] =
+                checked_add(point.m_incoming_offset, point.num_incoming(),
+                            "Successive-orders incoming direction count");
+            m_outgoing_point_offsets[point_index + 1] =
+                checked_add(point.m_outgoing_offset, point.num_outgoing(),
+                            "Successive-orders outgoing direction count");
+
+            m_geometry.assign_interpolation_weights(point.location(),
+                                                    atmosphere_weights);
+            point.m_atmosphere_weights = sorted_weights(atmosphere_weights);
+        }
+    }
+
+    void SourceGeometry1D::trace_and_compile_incoming() {
+        const int num_rays = total_num_incoming();
+        m_incoming_viewing.traced_rays.clear();
+        m_incoming_viewing.flux_observers.clear();
+        m_incoming_viewing.traced_rays.resize(num_rays);
+        m_incoming_interpolation.clear();
+        m_incoming_interpolation.resize(num_rays);
+
+        std::vector<sasktran2::viewinggeometry::ViewingRay> viewing_rays(
+            m_settings.num_threads);
+        std::vector<InterpolationScratch> interpolation_scratch(
+            m_settings.num_threads);
+        std::vector<std::exception_ptr> thread_exceptions(
+            m_settings.num_threads);
+        std::atomic<bool> failed{false};
+
+#pragma omp parallel for num_threads(m_settings.num_threads) schedule(dynamic)
+        for (int point_index = 0;
+             point_index < static_cast<int>(m_source_points.size());
+             ++point_index) {
+#ifdef SKTRAN_OPENMP_SUPPORT
+            const int thread_index = omp_get_thread_num();
+#else
+            const int thread_index = 0;
+#endif
+            if (failed.load(std::memory_order_relaxed)) {
+                continue;
+            }
+            try {
+                const auto& point = m_source_points[point_index];
+                auto& viewing_ray = viewing_rays[thread_index];
+                viewing_ray.observer = point.location();
+                for (int direction_index = 0;
+                     direction_index < point.num_incoming();
+                     ++direction_index) {
+                    viewing_ray.look_away =
+                        point.incoming_sphere().get_quad_position(
+                            direction_index);
+                    const int ray_index =
+                        point.incoming_offset() + direction_index;
+                    auto& traced_ray =
+                        m_incoming_viewing.traced_rays[ray_index];
+                    m_raytracer.trace_ray(viewing_ray, traced_ray,
+                                          m_settings.include_refraction);
+                    compile_ray_interpolation(
+                        traced_ray, m_geometry, *m_location_interpolator,
+                        m_source_points, m_incoming_interpolation[ray_index],
+                        interpolation_scratch[thread_index]);
+                }
+            } catch (...) {
+                thread_exceptions[thread_index] = std::current_exception();
+                failed.store(true, std::memory_order_relaxed);
+            }
+        }
+
+        for (const auto& exception : thread_exceptions) {
+            if (exception) {
+                std::rethrow_exception(exception);
+            }
+        }
+    }
+
+    void SourceGeometry1D::compile_los_interpolation(
+        const sasktran2::viewinggeometry::InternalViewingGeometry&
+            internal_viewing) {
+        const int num_rays =
+            static_cast<int>(internal_viewing.traced_rays.size());
+        m_los_interpolation.clear();
+        m_los_interpolation.resize(num_rays);
+        std::vector<InterpolationScratch> interpolation_scratch(
+            m_settings.num_threads);
+        std::vector<std::exception_ptr> thread_exceptions(
+            m_settings.num_threads);
+        std::atomic<bool> failed{false};
+
+#pragma omp parallel for num_threads(m_settings.num_threads) schedule(dynamic)
+        for (int ray_index = 0; ray_index < num_rays; ++ray_index) {
+#ifdef SKTRAN_OPENMP_SUPPORT
+            const int thread_index = omp_get_thread_num();
+#else
+            const int thread_index = 0;
+#endif
+            if (failed.load(std::memory_order_relaxed)) {
+                continue;
+            }
+            try {
+                compile_ray_interpolation(
+                    internal_viewing.traced_rays[ray_index], m_geometry,
+                    *m_location_interpolator, m_source_points,
+                    m_los_interpolation[ray_index],
+                    interpolation_scratch[thread_index]);
+            } catch (...) {
+                thread_exceptions[thread_index] = std::current_exception();
+                failed.store(true, std::memory_order_relaxed);
+            }
+        }
+
+        for (const auto& exception : thread_exceptions) {
+            if (exception) {
+                std::rethrow_exception(exception);
+            }
+        }
+    }
+
+    void SourceGeometry1D::compile_transport_topology(
+        std::vector<RayInterpolation>& interpolation,
+        std::vector<int>& row_offsets, std::vector<int>& column_indices) {
+        row_offsets.assign(interpolation.size() + 1, 0);
+        std::vector<int> columns;
+        std::size_t num_columns = 0;
+        for (std::size_t ray_index = 0; ray_index < interpolation.size();
+             ++ray_index) {
+            auto& ray = interpolation[ray_index];
+            compile_transport_row(ray, columns);
+            ray.transport_value_offset = num_columns;
+            num_columns += columns.size();
+            if (num_columns >
+                static_cast<std::size_t>(std::numeric_limits<int>::max())) {
+                throw std::length_error(
+                    "Successive-orders transport topology exceeds the "
+                    "supported index range");
+            }
+            row_offsets[ray_index + 1] = static_cast<int>(num_columns);
+        }
+
+        column_indices.clear();
+        column_indices.reserve(num_columns);
+        for (auto& ray : interpolation) {
+            compile_transport_row(ray, columns);
+            column_indices.insert(column_indices.end(), columns.begin(),
+                                  columns.end());
+        }
+    }
+
+    void SourceGeometry1D::initialize(
+        const sasktran2::viewinggeometry::InternalViewingGeometry&
+            internal_viewing,
+        const SourceGeometrySettings& settings) {
+        settings.validate();
+        m_settings = settings;
+
+        auto altitude_grid = make_altitude_grid();
+        auto cos_sza_grid = make_cos_sza_grid(internal_viewing);
+        m_location_interpolator = std::make_unique<
+            sasktran2::grids::AltitudeSZASourceLocationInterpolator>(
+            std::move(altitude_grid), std::move(cos_sza_grid));
+
+        construct_source_points();
+        trace_and_compile_incoming();
+        compile_los_interpolation(internal_viewing);
+        compile_transport_topology(m_incoming_interpolation,
+                                   m_transport_row_offsets,
+                                   m_transport_column_indices);
+        compile_transport_topology(m_los_interpolation,
+                                   m_los_transport_row_offsets,
+                                   m_los_transport_column_indices);
+    }
+
+} // namespace sasktran2::successive_orders

--- a/cpp/lib/successive_orders/geometry.h
+++ b/cpp/lib/successive_orders/geometry.h
@@ -1,0 +1,219 @@
+#pragma once
+
+#include "interpolation.h"
+
+#include <sasktran2/geometry.h>
+#include <sasktran2/math/unitsphere.h>
+#include <sasktran2/viewinggeometry_internal.h>
+
+#include <memory>
+#include <vector>
+
+namespace sasktran2::grids {
+    class SourceLocationInterpolator;
+}
+
+namespace sasktran2::successive_orders {
+    /** Geometry-only configuration for the one-dimensional source grid. */
+    struct SourceGeometrySettings {
+        int num_incoming = 110;
+        int num_outgoing = 110;
+        int num_sza = 1;
+        int num_threads = 1;
+        bool include_refraction = false;
+
+        /** Empty selects one source altitude at each atmosphere-layer
+         * midpoint. */
+        std::vector<double> altitude_grid_m;
+
+        void validate() const;
+    };
+
+    /** One location on the successive-orders source grid. */
+    class SourcePoint {
+      public:
+        const sasktran2::Location& location() const { return m_location; }
+        bool is_ground() const { return m_is_ground; }
+
+        const sasktran2::math::UnitSphere& incoming_sphere() const {
+            return *m_incoming_sphere;
+        }
+        const sasktran2::math::UnitSphere& outgoing_sphere() const {
+            return *m_outgoing_sphere;
+        }
+
+        int num_incoming() const { return m_incoming_sphere->num_points(); }
+        int num_outgoing() const { return m_outgoing_sphere->num_points(); }
+        int incoming_offset() const { return m_incoming_offset; }
+        int outgoing_offset() const { return m_outgoing_offset; }
+
+        const std::vector<InterpolationWeight>& atmosphere_weights() const {
+            return m_atmosphere_weights;
+        }
+
+      private:
+        friend class SourceGeometry1D;
+
+        sasktran2::Location m_location;
+        const sasktran2::math::UnitSphere* m_incoming_sphere = nullptr;
+        const sasktran2::math::UnitSphere* m_outgoing_sphere = nullptr;
+        std::vector<InterpolationWeight> m_atmosphere_weights;
+        int m_incoming_offset = 0;
+        int m_outgoing_offset = 0;
+        bool m_is_ground = false;
+    };
+
+    /** Immutable one-dimensional source geometry and interpolation topology.
+     *
+     * Atmospheric optical properties are intentionally absent. Incoming rays
+     * are traced once and both incoming-ray and LOS source interpolation are
+     * compiled into deterministic metadata suitable for a changing
+     * atmosphere and either scalar or vector radiance storage.
+     */
+    class SourceGeometry1D {
+      public:
+        SourceGeometry1D(const sasktran2::raytracing::RayTracerBase& raytracer,
+                         const sasktran2::Geometry1D& geometry);
+        ~SourceGeometry1D();
+
+        SourceGeometry1D(const SourceGeometry1D&) = delete;
+        SourceGeometry1D& operator=(const SourceGeometry1D&) = delete;
+        SourceGeometry1D(SourceGeometry1D&&) = delete;
+        SourceGeometry1D& operator=(SourceGeometry1D&&) = delete;
+
+        void
+        initialize(const sasktran2::viewinggeometry::InternalViewingGeometry&
+                       internal_viewing,
+                   const SourceGeometrySettings& settings);
+
+        const SourceGeometrySettings& settings() const { return m_settings; }
+        const std::vector<double>& source_altitudes_m() const {
+            return m_source_altitudes_m;
+        }
+        const std::vector<double>& source_cos_sza() const {
+            return m_source_cos_sza;
+        }
+
+        int num_interior_points() const { return m_num_interior_points; }
+        int num_ground_points() const { return m_num_ground_points; }
+        int num_points() const {
+            return static_cast<int>(m_source_points.size());
+        }
+        int total_num_incoming() const {
+            return m_incoming_point_offsets.empty()
+                       ? 0
+                       : m_incoming_point_offsets.back();
+        }
+        int total_num_outgoing() const {
+            return m_outgoing_point_offsets.empty()
+                       ? 0
+                       : m_outgoing_point_offsets.back();
+        }
+
+        const std::vector<SourcePoint>& source_points() const {
+            return m_source_points;
+        }
+        const SourcePoint& source_point(int index) const {
+            return m_source_points.at(index);
+        }
+        const std::vector<int>& incoming_point_offsets() const {
+            return m_incoming_point_offsets;
+        }
+        const std::vector<int>& outgoing_point_offsets() const {
+            return m_outgoing_point_offsets;
+        }
+
+        const sasktran2::viewinggeometry::InternalViewingGeometry&
+        incoming_viewing_geometry() const {
+            return m_incoming_viewing;
+        }
+        const std::vector<sasktran2::raytracing::TracedRay>&
+        incoming_rays() const {
+            return m_incoming_viewing.traced_rays;
+        }
+        const std::vector<RayInterpolation>& incoming_interpolation() const {
+            return m_incoming_interpolation;
+        }
+        const std::vector<RayInterpolation>& los_interpolation() const {
+            return m_los_interpolation;
+        }
+
+        /** CSR topology for outgoing-source transport to incoming rays. */
+        const std::vector<int>& transport_row_offsets() const {
+            return m_transport_row_offsets;
+        }
+        const std::vector<int>& transport_column_indices() const {
+            return m_transport_column_indices;
+        }
+        InterpolationView<int>
+        transport_columns_for_ray(std::size_t ray_index) const {
+            if (ray_index >= m_incoming_interpolation.size()) {
+                throw std::out_of_range(
+                    "Successive-orders transport ray is out of range");
+            }
+            const auto& ray = m_incoming_interpolation[ray_index];
+            return {m_transport_column_indices, ray.transport_value_offset,
+                    ray.transport_row_nnz};
+        }
+        const std::vector<int>& los_transport_row_offsets() const {
+            return m_los_transport_row_offsets;
+        }
+        const std::vector<int>& los_transport_column_indices() const {
+            return m_los_transport_column_indices;
+        }
+        InterpolationView<int>
+        los_transport_columns_for_ray(std::size_t ray_index) const {
+            if (ray_index >= m_los_interpolation.size()) {
+                throw std::out_of_range(
+                    "Successive-orders LOS ray is out of range");
+            }
+            const auto& ray = m_los_interpolation[ray_index];
+            return {m_los_transport_column_indices, ray.transport_value_offset,
+                    ray.transport_row_nnz};
+        }
+
+      private:
+        struct AngularGridPair {
+            std::unique_ptr<const sasktran2::math::UnitSphere> incoming;
+            std::unique_ptr<const sasktran2::math::UnitSphere> outgoing;
+        };
+
+        sasktran2::grids::AltitudeGrid make_altitude_grid();
+        sasktran2::grids::Grid make_cos_sza_grid(
+            const sasktran2::viewinggeometry::InternalViewingGeometry&
+                internal_viewing);
+        void construct_source_points();
+        void trace_and_compile_incoming();
+        void compile_los_interpolation(
+            const sasktran2::viewinggeometry::InternalViewingGeometry&
+                internal_viewing);
+        void
+        compile_transport_topology(std::vector<RayInterpolation>& interpolation,
+                                   std::vector<int>& row_offsets,
+                                   std::vector<int>& column_indices);
+
+        const sasktran2::raytracing::RayTracerBase& m_raytracer;
+        const sasktran2::Geometry1D& m_geometry;
+        SourceGeometrySettings m_settings;
+
+        std::unique_ptr<sasktran2::grids::SourceLocationInterpolator>
+            m_location_interpolator;
+        std::vector<std::unique_ptr<AngularGridPair>> m_angular_grids;
+        std::vector<SourcePoint> m_source_points;
+        std::vector<int> m_incoming_point_offsets;
+        std::vector<int> m_outgoing_point_offsets;
+        std::vector<double> m_source_altitudes_m;
+        std::vector<double> m_source_cos_sza;
+        int m_num_interior_points = 0;
+        int m_num_ground_points = 0;
+
+        sasktran2::viewinggeometry::InternalViewingGeometry m_incoming_viewing;
+        std::vector<RayInterpolation> m_incoming_interpolation;
+        std::vector<RayInterpolation> m_los_interpolation;
+        std::vector<int> m_transport_row_offsets{0};
+        std::vector<int> m_transport_column_indices;
+        std::vector<int> m_los_transport_row_offsets{0};
+        std::vector<int> m_los_transport_column_indices;
+    };
+
+} // namespace sasktran2::successive_orders

--- a/cpp/lib/successive_orders/interpolation.cpp
+++ b/cpp/lib/successive_orders/interpolation.cpp
@@ -1,0 +1,348 @@
+#include "interpolation.h"
+
+#include "geometry.h"
+
+#include <sasktran2/grids.h>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+namespace sasktran2::successive_orders {
+    namespace {
+        std::uint32_t checked_u32(std::size_t value, const char* description) {
+            if (value > std::numeric_limits<std::uint32_t>::max()) {
+                throw std::length_error(std::string(description) +
+                                        " exceeds the compact offset range");
+            }
+            return static_cast<std::uint32_t>(value);
+        }
+
+        void sort_and_combine(const std::vector<std::pair<int, double>>& input,
+                              std::vector<InterpolationWeight>& output) {
+            output.clear();
+            output.reserve(input.size());
+            for (const auto& [index, weight] : input) {
+                if (index < 0 || !std::isfinite(weight)) {
+                    throw std::runtime_error(
+                        "Invalid successive-orders interpolation weight");
+                }
+                if (weight != 0.0) {
+                    output.push_back({index, weight});
+                }
+            }
+            std::stable_sort(output.begin(), output.end(),
+                             [](const auto& left, const auto& right) {
+                                 return left.index < right.index;
+                             });
+
+            std::size_t write = 0;
+            for (const auto& weight : output) {
+                if (write != 0 && output[write - 1].index == weight.index) {
+                    output[write - 1].weight += weight.weight;
+                } else {
+                    output[write++] = weight;
+                }
+            }
+            output.resize(write);
+            output.erase(std::remove_if(output.begin(), output.end(),
+                                        [](const auto& weight) {
+                                            return weight.weight == 0.0;
+                                        }),
+                         output.end());
+        }
+
+        void sort_and_combine(std::vector<SourceInterpolationWeight>& values) {
+            std::stable_sort(values.begin(), values.end(),
+                             [](const auto& left, const auto& right) {
+                                 return left.source_index < right.source_index;
+                             });
+
+            std::size_t write = 0;
+            for (const auto& value : values) {
+                if (value.source_index < 0 || !std::isfinite(value.weight)) {
+                    throw std::runtime_error(
+                        "Invalid successive-orders source interpolation");
+                }
+                if (value.weight == 0.0) {
+                    continue;
+                }
+                if (write != 0 &&
+                    values[write - 1].source_index == value.source_index) {
+                    values[write - 1].weight += value.weight;
+                } else {
+                    values[write++] = value;
+                }
+            }
+            values.resize(write);
+            values.erase(std::remove_if(values.begin(), values.end(),
+                                        [](const auto& value) {
+                                            return value.weight == 0.0;
+                                        }),
+                         values.end());
+        }
+
+        Eigen::Vector3d
+        deterministic_horizontal(const Eigen::Vector3d& local_up,
+                                 const sasktran2::Geometry1D& geometry) {
+            constexpr double singular_squared_tolerance = 1.0e-24;
+            Eigen::Vector3d horizontal =
+                geometry.coordinates().reference_x() -
+                local_up * local_up.dot(geometry.coordinates().reference_x());
+            if (horizontal.squaredNorm() <= singular_squared_tolerance) {
+                horizontal =
+                    geometry.coordinates().reference_y() -
+                    local_up *
+                        local_up.dot(geometry.coordinates().reference_y());
+            }
+            if (horizontal.squaredNorm() <= singular_squared_tolerance) {
+                horizontal = local_up.unitOrthogonal();
+            }
+            return horizontal.normalized();
+        }
+
+        Eigen::Vector3d
+        horizontal_solar_reference(const Eigen::Vector3d& local_up,
+                                   const sasktran2::Geometry1D& geometry) {
+            constexpr double singular_squared_tolerance = 1.0e-24;
+            Eigen::Vector3d horizontal =
+                geometry.coordinates().sun_unit() -
+                local_up * local_up.dot(geometry.coordinates().sun_unit());
+            if (horizontal.squaredNorm() <= singular_squared_tolerance) {
+                return deterministic_horizontal(local_up, geometry);
+            }
+            return horizontal.normalized();
+        }
+
+        Eigen::Vector3d
+        rotate_unit_vector(const Eigen::Vector3d& vector,
+                           const Eigen::Vector3d& initial_position,
+                           const Eigen::Vector3d& new_position,
+                           const sasktran2::Geometry1D& geometry) {
+            const double vector_norm = vector.norm();
+            const double initial_norm = initial_position.norm();
+            const double new_norm = new_position.norm();
+            if (!std::isfinite(vector_norm) || vector_norm == 0.0 ||
+                !std::isfinite(initial_norm) || initial_norm == 0.0 ||
+                !std::isfinite(new_norm) || new_norm == 0.0) {
+                throw std::runtime_error(
+                    "Cannot rotate a non-finite successive-orders direction "
+                    "or position");
+            }
+
+            const Eigen::Vector3d initial_up = initial_position / initial_norm;
+            const Eigen::Vector3d new_up = new_position / new_norm;
+            const Eigen::Vector3d unit_vector = vector / vector_norm;
+            const double mu =
+                std::clamp(initial_up.dot(unit_vector), -1.0, 1.0);
+
+            // Azimuth is undefined at exact zenith and nadir. Preserve the
+            // radial direction directly instead of allowing a normalized zero
+            // horizontal projection to introduce NaNs.
+            constexpr double radial_tolerance = 1.0e-12;
+            if (std::abs(mu) >= 1.0 - radial_tolerance) {
+                return std::copysign(1.0, mu) * new_up;
+            }
+
+            const Eigen::Vector3d initial_horizontal =
+                (unit_vector - mu * initial_up).normalized();
+            const Eigen::Vector3d initial_solar =
+                horizontal_solar_reference(initial_up, geometry);
+            const double solar_azimuth = std::atan2(
+                initial_up.cross(initial_solar).dot(initial_horizontal),
+                initial_solar.dot(initial_horizontal));
+
+            const Eigen::Vector3d new_solar =
+                horizontal_solar_reference(new_up, geometry);
+            const Eigen::Vector3d new_horizontal =
+                Eigen::AngleAxis<double>(solar_azimuth, new_up) * new_solar;
+            const double sin_zenith = std::sqrt(std::max(0.0, 1.0 - mu * mu));
+            return (mu * new_up + sin_zenith * new_horizontal).normalized();
+        }
+
+        void compile_source_weights(
+            const Eigen::Vector3d& direction,
+            const sasktran2::Location& interpolation_location, bool ground,
+            const sasktran2::Geometry1D& geometry,
+            sasktran2::grids::SourceLocationInterpolator& location_interpolator,
+            const std::vector<SourcePoint>& source_points,
+            std::vector<SourceInterpolationWeight>& result,
+            InterpolationScratch& scratch) {
+            int num_locations = 0;
+            if (ground) {
+                location_interpolator.ground_interpolation_weights(
+                    geometry.coordinates(), interpolation_location,
+                    scratch.location, num_locations);
+            } else {
+                location_interpolator.interior_interpolation_weights(
+                    geometry.coordinates(), interpolation_location,
+                    scratch.location, num_locations);
+            }
+
+            result.clear();
+            for (int location_index = 0; location_index < num_locations;
+                 ++location_index) {
+                const auto& location_weight = scratch.location[location_index];
+                if (location_weight.first < 0 ||
+                    location_weight.first >=
+                        static_cast<int>(source_points.size())) {
+                    throw std::runtime_error(
+                        "Source-location interpolation returned an invalid "
+                        "point index");
+                }
+
+                const auto& point = source_points[location_weight.first];
+                Eigen::Vector3d rotated_direction;
+                if (geometry.coordinates().geometry_type() ==
+                    sasktran2::geometrytype::spherical) {
+                    rotated_direction = rotate_unit_vector(
+                        direction, interpolation_location.position,
+                        point.location().position, geometry);
+                } else {
+                    rotated_direction = direction;
+                }
+
+                int num_directions = 0;
+                point.outgoing_sphere().interpolate(
+                    rotated_direction, scratch.direction, num_directions);
+                for (int direction_index = 0; direction_index < num_directions;
+                     ++direction_index) {
+                    const auto& direction_weight =
+                        scratch.direction[direction_index];
+                    if (direction_weight.first < 0 ||
+                        direction_weight.first >= point.num_outgoing()) {
+                        throw std::runtime_error(
+                            "Unit-sphere interpolation returned an invalid "
+                            "direction index");
+                    }
+                    result.push_back(
+                        {point.outgoing_offset() + direction_weight.first,
+                         location_weight.second * direction_weight.second, 0});
+                }
+            }
+            sort_and_combine(result);
+        }
+
+        void compile_column_map(RayInterpolation& result,
+                                std::vector<int>& columns) {
+            const std::size_t num_weights =
+                result.source_weights.size() + result.ground_weights.size();
+            columns.clear();
+            columns.reserve(num_weights);
+            for (const auto& weight : result.source_weights) {
+                columns.push_back(weight.source_index);
+            }
+            for (const auto& weight : result.ground_weights) {
+                columns.push_back(weight.source_index);
+            }
+            std::sort(columns.begin(), columns.end());
+            columns.erase(std::unique(columns.begin(), columns.end()),
+                          columns.end());
+
+            if (columns.size() > std::numeric_limits<std::uint32_t>::max()) {
+                throw std::length_error(
+                    "Successive-orders transport row exceeds its compact "
+                    "index range");
+            }
+            const auto assign_inner_index = [&](auto& weights) {
+                for (auto& weight : weights) {
+                    const auto iterator = std::lower_bound(
+                        columns.begin(), columns.end(), weight.source_index);
+                    if (iterator == columns.end() ||
+                        *iterator != weight.source_index) {
+                        throw std::logic_error(
+                            "Successive-orders transport column map is "
+                            "inconsistent");
+                    }
+                    weight.row_inner_index =
+                        static_cast<std::uint32_t>(iterator - columns.begin());
+                }
+            };
+            assign_inner_index(result.source_weights);
+            assign_inner_index(result.ground_weights);
+            result.transport_row_nnz =
+                checked_u32(columns.size(), "Transport row size");
+        }
+
+        const Eigen::Vector3d&
+        usable_layer_direction(const Eigen::Vector3d& average_direction,
+                               const sasktran2::raytracing::TracedRay& ray) {
+            if (average_direction.allFinite() &&
+                average_direction.squaredNorm() > 0.0) {
+                return average_direction;
+            }
+            // A ray tracer can emit a zero-length tangent segment whose
+            // endpoint-derived average direction is undefined. Its transport
+            // contribution is zero, but compiling deterministic topology is
+            // still useful; the unrefracted viewing direction is the natural
+            // limiting direction for that segment.
+            return ray.observer_and_look.look_away;
+        }
+    } // namespace
+
+    void compile_ray_interpolation(
+        const sasktran2::raytracing::TracedRay& ray,
+        const sasktran2::Geometry1D& geometry,
+        sasktran2::grids::SourceLocationInterpolator& location_interpolator,
+        const std::vector<SourcePoint>& source_points, RayInterpolation& result,
+        InterpolationScratch& scratch) {
+        result = {};
+        result.traced_ray = &ray;
+        result.layers.resize(ray.layers.size());
+        result.atmosphere_weights.reserve(ray.layers.size() * 2);
+        // The common one-SZA grid uses at most two altitude locations and
+        // three Lebedev interpolation directions. Multi-SZA grids can grow
+        // this vector naturally when their four-location stencil is needed.
+        result.source_weights.reserve(ray.layers.size() * 6);
+
+        for (std::size_t layer_index = 0; layer_index < ray.layers.size();
+             ++layer_index) {
+            const auto& traced_layer = ray.layers[layer_index];
+            auto& interpolation = result.layers[layer_index];
+
+            sasktran2::Location midpoint;
+            midpoint.position = 0.5 * (traced_layer.entrance.position +
+                                       traced_layer.exit.position);
+            geometry.assign_interpolation_weights(midpoint, scratch.atmosphere);
+            sort_and_combine(scratch.atmosphere, scratch.compiled_atmosphere);
+            interpolation.atmosphere_offset = checked_u32(
+                result.atmosphere_weights.size(), "Atmosphere weight offset");
+            interpolation.atmosphere_count = checked_u32(
+                scratch.compiled_atmosphere.size(), "Atmosphere weight count");
+            result.atmosphere_weights.insert(
+                result.atmosphere_weights.end(),
+                scratch.compiled_atmosphere.begin(),
+                scratch.compiled_atmosphere.end());
+
+            compile_source_weights(
+                usable_layer_direction(traced_layer.average_look_away, ray),
+                midpoint, false, geometry, location_interpolator, source_points,
+                scratch.compiled_source, scratch);
+            interpolation.source_offset = checked_u32(
+                result.source_weights.size(), "Source weight offset");
+            interpolation.source_count = checked_u32(
+                scratch.compiled_source.size(), "Source weight count");
+            result.source_weights.insert(result.source_weights.end(),
+                                         scratch.compiled_source.begin(),
+                                         scratch.compiled_source.end());
+        }
+
+        if (ray.ground_is_hit && !ray.layers.empty()) {
+            const auto& ground_layer = ray.layers.front();
+            sasktran2::Location ground_location;
+            ground_location.position = ground_layer.exit.position;
+            compile_source_weights(
+                -usable_layer_direction(ground_layer.average_look_away, ray),
+                ground_location, true, geometry, location_interpolator,
+                source_points, result.ground_weights, scratch);
+        }
+    }
+
+    void compile_transport_row(RayInterpolation& interpolation,
+                               std::vector<int>& columns) {
+        compile_column_map(interpolation, columns);
+    }
+
+} // namespace sasktran2::successive_orders

--- a/cpp/lib/successive_orders/interpolation.h
+++ b/cpp/lib/successive_orders/interpolation.h
@@ -1,0 +1,150 @@
+#pragma once
+
+#include <sasktran2/raytracing.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace sasktran2 {
+    class Geometry1D;
+}
+
+namespace sasktran2::grids {
+    class SourceLocationInterpolator;
+}
+
+namespace sasktran2::successive_orders {
+    class SourcePoint;
+
+    /** Small C++17-compatible view over immutable packed interpolation data. */
+    template <typename T> class InterpolationView {
+      public:
+        InterpolationView() = default;
+        explicit InterpolationView(const std::vector<T>& values)
+            : InterpolationView(values, 0, values.size()) {}
+        InterpolationView(const std::vector<T>& values, std::size_t offset,
+                          std::size_t size) {
+            if (offset > values.size() || size > values.size() - offset) {
+                throw std::out_of_range(
+                    "Successive-orders interpolation view is out of range");
+            }
+            m_data = size == 0 ? nullptr : values.data() + offset;
+            m_size = size;
+        }
+
+        const T* data() const { return m_data; }
+        const T* begin() const { return m_data; }
+        const T* end() const {
+            return m_data == nullptr ? nullptr : m_data + m_size;
+        }
+        std::size_t size() const { return m_size; }
+        bool empty() const { return m_size == 0; }
+        const T& operator[](std::size_t index) const {
+            if (index >= m_size) {
+                throw std::out_of_range(
+                    "Successive-orders interpolation index is out of range");
+            }
+            return m_data[index];
+        }
+
+      private:
+        const T* m_data = nullptr;
+        std::size_t m_size = 0;
+    };
+
+    /** One geometry-only interpolation coefficient. */
+    struct InterpolationWeight {
+        int index = 0;
+        double weight = 0.0;
+    };
+
+    /** Interpolation from the global outgoing-source vector.
+     *
+     * `row_inner_index` is the position of `source_index` in the owning ray's
+     * sorted `transport_columns` array. It lets the atmosphere-dependent
+     * transport assembler accumulate directly into an existing CSR row.
+     */
+    struct SourceInterpolationWeight {
+        double weight = 0.0;
+        int source_index = 0;
+        std::uint32_t row_inner_index = 0;
+
+        SourceInterpolationWeight() = default;
+        SourceInterpolationWeight(int index, double interpolation_weight,
+                                  std::uint32_t inner_index = 0)
+            : weight(interpolation_weight), source_index(index),
+              row_inner_index(inner_index) {}
+    };
+
+    /** Geometry metadata required to integrate one traced layer. */
+    struct LayerInterpolation {
+        std::uint32_t atmosphere_offset = 0;
+        std::uint32_t atmosphere_count = 0;
+        std::uint32_t source_offset = 0;
+        std::uint32_t source_count = 0;
+    };
+
+    /** Compiled source interpolation for one traced ray.
+     *
+     * The pointed-to ray owns the optical-depth, entrance, and exit stencils.
+     * Incoming diffuse rays are owned by SourceGeometry1D; LOS rays remain
+     * owned by the engine's InternalViewingGeometry. Both owners must outlive
+     * this metadata.
+     */
+    struct RayInterpolation {
+        const sasktran2::raytracing::TracedRay* traced_ray = nullptr;
+        std::vector<LayerInterpolation> layers;
+        std::vector<InterpolationWeight> atmosphere_weights;
+        std::vector<SourceInterpolationWeight> source_weights;
+        std::vector<SourceInterpolationWeight> ground_weights;
+
+        /** Offset of this row in SourceGeometry1D::transport_column_indices. */
+        std::size_t transport_value_offset = 0;
+        std::uint32_t transport_row_nnz = 0;
+
+        InterpolationView<InterpolationWeight>
+        atmosphere_for_layer(std::size_t layer_index) const {
+            const auto& layer = layers[layer_index];
+            return {atmosphere_weights, layer.atmosphere_offset,
+                    layer.atmosphere_count};
+        }
+        InterpolationView<SourceInterpolationWeight>
+        source_for_layer(std::size_t layer_index) const {
+            const auto& layer = layers[layer_index];
+            return {source_weights, layer.source_offset, layer.source_count};
+        }
+        InterpolationView<SourceInterpolationWeight> ground() const {
+            return InterpolationView<SourceInterpolationWeight>(ground_weights);
+        }
+
+        bool ground_is_hit() const {
+            return traced_ray != nullptr && traced_ray->ground_is_hit;
+        }
+    };
+
+    /** Reusable temporary storage for compiling ray interpolation. */
+    struct InterpolationScratch {
+        std::vector<std::pair<int, double>> location;
+        std::vector<std::pair<int, double>> direction;
+        std::vector<std::pair<int, double>> atmosphere;
+        std::vector<InterpolationWeight> compiled_atmosphere;
+        std::vector<SourceInterpolationWeight> compiled_source;
+    };
+
+    /** Compiles deterministic interpolation metadata for one traced ray. */
+    void compile_ray_interpolation(
+        const sasktran2::raytracing::TracedRay& ray,
+        const sasktran2::Geometry1D& geometry,
+        sasktran2::grids::SourceLocationInterpolator& location_interpolator,
+        const std::vector<SourcePoint>& source_points, RayInterpolation& result,
+        InterpolationScratch& scratch);
+
+    /** Builds one sorted unique CSR row and assigns local slots to its source
+     * interpolation entries. */
+    void compile_transport_row(RayInterpolation& interpolation,
+                               std::vector<int>& columns);
+
+} // namespace sasktran2::successive_orders

--- a/cpp/lib/successive_orders/problem.cpp
+++ b/cpp/lib/successive_orders/problem.cpp
@@ -1,0 +1,148 @@
+#include "problem.h"
+
+namespace sasktran2::successive_orders {
+    namespace {
+        std::size_t vector_bytes(const Eigen::VectorXd& vector) {
+            return static_cast<std::size_t>(vector.size()) * sizeof(double);
+        }
+        std::size_t matrix_bytes(const Eigen::MatrixXd& matrix) {
+            return static_cast<std::size_t>(matrix.size()) * sizeof(double);
+        }
+    } // namespace
+
+    void
+    ProblemParameterData<1>::resize(const TransportOperator& transport,
+                                    const ScatteringOperator<1>& scattering,
+                                    bool include_transport) {
+        forcing.resize(scattering.input_size());
+        transport_values.resize(include_transport ? transport.values().size()
+                                                  : 0);
+        atmospheric_coefficients.resize(
+            scattering.atmospheric_coefficients().rows(),
+            scattering.atmospheric_coefficients().cols());
+        ground_values.resize(scattering.ground_values().size());
+    }
+
+    void ProblemParameterData<1>::set_zero() {
+        forcing.setZero();
+        transport_values.setZero();
+        atmospheric_coefficients.setZero();
+        ground_values.setZero();
+    }
+
+    std::size_t ProblemParameterData<1>::storage_bytes() const {
+        return vector_bytes(forcing) + vector_bytes(transport_values) +
+               matrix_bytes(atmospheric_coefficients) +
+               vector_bytes(ground_values);
+    }
+
+    void
+    ProblemParameterData<3>::resize(const TransportOperator& transport,
+                                    const ScatteringOperator<3>& scattering,
+                                    bool include_transport) {
+        forcing.resize(scattering.input_size());
+        transport_values.resize(include_transport ? transport.values().size()
+                                                  : 0);
+        atmospheric_coefficients.resize(
+            scattering.atmospheric_coefficients().rows(),
+            scattering.atmospheric_coefficients().cols());
+        ground_values.resize(scattering.ground_values().size());
+    }
+
+    void ProblemParameterData<3>::set_zero() {
+        forcing.setZero();
+        transport_values.setZero();
+        atmospheric_coefficients.setZero();
+        ground_values.setZero();
+    }
+
+    std::size_t ProblemParameterData<3>::storage_bytes() const {
+        return vector_bytes(forcing) + vector_bytes(transport_values) +
+               matrix_bytes(atmospheric_coefficients) +
+               vector_bytes(ground_values);
+    }
+
+    template <>
+    void Problem<1>::validate_parameter_data(
+        const ProblemParameterData<1>& data) const {
+        if (data.forcing.size() != incoming_size() ||
+            (data.transport_values.size() != 0 &&
+             data.transport_values.size() != m_transport->values().size()) ||
+            data.atmospheric_coefficients.rows() !=
+                m_scattering->atmospheric_coefficients().rows() ||
+            data.atmospheric_coefficients.cols() !=
+                m_scattering->atmospheric_coefficients().cols() ||
+            data.ground_values.size() != m_scattering->ground_values().size()) {
+            throw std::invalid_argument("invalid scalar successive-orders "
+                                        "parameter product dimensions");
+        }
+    }
+
+    template <>
+    void Problem<3>::validate_parameter_data(
+        const ProblemParameterData<3>& data) const {
+        if (data.forcing.size() != incoming_size() ||
+            (data.transport_values.size() != 0 &&
+             data.transport_values.size() != m_transport->values().size()) ||
+            data.atmospheric_coefficients.rows() !=
+                m_scattering->atmospheric_coefficients().rows() ||
+            data.atmospheric_coefficients.cols() !=
+                m_scattering->atmospheric_coefficients().cols() ||
+            data.ground_values.size() != m_scattering->ground_values().size()) {
+            throw std::invalid_argument("invalid vector successive-orders "
+                                        "parameter product dimensions");
+        }
+    }
+
+    template <>
+    void Problem<1>::scattering_jvp(
+        Eigen::Ref<const Eigen::VectorXd> incoming,
+        Eigen::Ref<const Eigen::VectorXd> incoming_tangent,
+        const ProblemParameterData<1>& tangent,
+        Eigen::Ref<Eigen::VectorXd> state_tangent,
+        ProblemWorkspace<1>& workspace) const {
+        m_scattering->apply_jvp(
+            incoming, incoming_tangent, tangent.atmospheric_coefficients,
+            tangent.ground_values, state_tangent, workspace.scattering);
+    }
+
+    template <>
+    void Problem<3>::scattering_jvp(
+        Eigen::Ref<const Eigen::VectorXd> incoming,
+        Eigen::Ref<const Eigen::VectorXd> incoming_tangent,
+        const ProblemParameterData<3>& tangent,
+        Eigen::Ref<Eigen::VectorXd> state_tangent,
+        ProblemWorkspace<3>& workspace) const {
+        m_scattering->apply_jvp(
+            incoming, incoming_tangent, tangent.atmospheric_coefficients,
+            tangent.ground_values, state_tangent, workspace.scattering);
+    }
+
+    template <>
+    void Problem<1>::scattering_vjp(
+        Eigen::Ref<const Eigen::VectorXd> incoming,
+        Eigen::Ref<const Eigen::VectorXd> state_cotangent,
+        Eigen::Ref<Eigen::VectorXd> incoming_cotangent,
+        ProblemParameterData<1>& gradient,
+        ProblemWorkspace<1>& workspace) const {
+        m_scattering->apply_vjp(incoming, state_cotangent, incoming_cotangent,
+                                gradient.atmospheric_coefficients,
+                                gradient.ground_values, workspace.scattering);
+    }
+
+    template <>
+    void Problem<3>::scattering_vjp(
+        Eigen::Ref<const Eigen::VectorXd> incoming,
+        Eigen::Ref<const Eigen::VectorXd> state_cotangent,
+        Eigen::Ref<Eigen::VectorXd> incoming_cotangent,
+        ProblemParameterData<3>& gradient,
+        ProblemWorkspace<3>& workspace) const {
+        m_scattering->apply_vjp(incoming, state_cotangent, incoming_cotangent,
+                                gradient.atmospheric_coefficients,
+                                gradient.ground_values, workspace.scattering);
+    }
+
+    template class Problem<1>;
+    template class Problem<3>;
+
+} // namespace sasktran2::successive_orders

--- a/cpp/lib/successive_orders/problem.h
+++ b/cpp/lib/successive_orders/problem.h
@@ -1,0 +1,328 @@
+#pragma once
+
+#include "fixed_point.h"
+#include "scattering.h"
+#include "transport.h"
+
+#include <Eigen/Core>
+
+#include <cstddef>
+
+namespace sasktran2::successive_orders {
+
+    template <int NSTOKES> struct ProblemParameterData;
+
+    template <> struct ProblemParameterData<1> {
+        Eigen::VectorXd forcing;
+        Eigen::VectorXd transport_values;
+        Eigen::MatrixXd atmospheric_coefficients;
+        Eigen::VectorXd ground_values;
+
+        void resize(const TransportOperator& transport,
+                    const ScatteringOperator<1>& scattering,
+                    bool include_transport = true);
+        void set_zero();
+        std::size_t storage_bytes() const;
+    };
+
+    template <> struct ProblemParameterData<3> {
+        Eigen::VectorXd forcing;
+        Eigen::VectorXd transport_values;
+        Eigen::MatrixXd atmospheric_coefficients;
+        Eigen::VectorXd ground_values;
+
+        void resize(const TransportOperator& transport,
+                    const ScatteringOperator<3>& scattering,
+                    bool include_transport = true);
+        void set_zero();
+        std::size_t storage_bytes() const;
+    };
+
+    template <int NSTOKES> struct ProblemWorkspace {
+        Eigen::VectorXd incoming;
+        Eigen::VectorXd auxiliary_incoming;
+        Eigen::VectorXd auxiliary_state;
+        Eigen::VectorXd direct_state;
+        ScatteringWorkspace<NSTOKES> scattering;
+        FixedPointWorkspace fixed_point;
+
+        void resize(const TransportOperator&,
+                    const ScatteringOperator<NSTOKES>& scattering_operator) {
+            incoming.resize(scattering_operator.input_size());
+            auxiliary_incoming.resize(scattering_operator.input_size());
+            auxiliary_state.resize(scattering_operator.output_size());
+            direct_state.resize(scattering_operator.output_size());
+            scattering = scattering_operator.make_workspace();
+        }
+
+        std::size_t storage_bytes() const {
+            return static_cast<std::size_t>(
+                       incoming.size() + auxiliary_incoming.size() +
+                       auxiliary_state.size() + direct_state.size()) *
+                       sizeof(double) +
+                   scattering.storage_bytes();
+        }
+    };
+
+    /** Matrix-free successive-orders system
+     *
+     *     x = S (b + T x).
+     *
+     * The transport and scattering objects own only the current atmosphere's
+     * values. This class owns no large matrices and uses the same operations
+     * for the primal, implicit forward product, and implicit adjoint product.
+     */
+    template <int NSTOKES> class Problem {
+      public:
+        Problem(TransportOperator& transport,
+                ScatteringOperator<NSTOKES>& scattering)
+            : m_transport(&transport), m_scattering(&scattering) {
+            if (transport.sparsity().rows() * NSTOKES !=
+                    scattering.input_size() ||
+                transport.sparsity().columns() * NSTOKES !=
+                    scattering.output_size()) {
+                throw std::invalid_argument(
+                    "successive-orders transport/scattering dimensions do not "
+                    "match");
+            }
+        }
+
+        int state_size() const { return m_scattering->output_size(); }
+        int incoming_size() const { return m_scattering->input_size(); }
+
+        void apply(Eigen::Ref<const Eigen::VectorXd> state,
+                   Eigen::Ref<const Eigen::VectorXd> forcing,
+                   Eigen::Ref<Eigen::VectorXd> result,
+                   ProblemWorkspace<NSTOKES>& workspace) const {
+            validate_state_and_forcing(state, forcing, result);
+            m_transport->template apply_stokes<NSTOKES>(state,
+                                                        workspace.incoming);
+            workspace.incoming += forcing;
+            m_scattering->apply(workspace.incoming, result,
+                                workspace.scattering);
+        }
+
+        void apply_linear(Eigen::Ref<const Eigen::VectorXd> state,
+                          Eigen::Ref<Eigen::VectorXd> result,
+                          ProblemWorkspace<NSTOKES>& workspace) const {
+            if (state.size() != state_size() || result.size() != state_size()) {
+                throw std::invalid_argument(
+                    "invalid successive-orders linear operator dimensions");
+            }
+            m_transport->template apply_stokes<NSTOKES>(state,
+                                                        workspace.incoming);
+            m_scattering->apply(workspace.incoming, result,
+                                workspace.scattering);
+        }
+
+        void
+        apply_linear_transpose(Eigen::Ref<const Eigen::VectorXd> state,
+                               Eigen::Ref<Eigen::VectorXd> result,
+                               ProblemWorkspace<NSTOKES>& workspace) const {
+            if (state.size() != state_size() || result.size() != state_size()) {
+                throw std::invalid_argument(
+                    "invalid successive-orders transpose operator dimensions");
+            }
+            m_scattering->apply_transpose(state, workspace.incoming,
+                                          workspace.scattering);
+            m_transport->template apply_transpose_stokes<NSTOKES>(
+                workspace.incoming, result);
+        }
+
+        FixedPointDiagnostics
+        solve(Eigen::Ref<const Eigen::VectorXd> forcing, Eigen::VectorXd& state,
+              const FixedPointSettings& settings,
+              ProblemWorkspace<NSTOKES>& workspace) const {
+            prepare_workspace(workspace);
+            if (state.size() != state_size()) {
+                state.setZero(state_size());
+            }
+            return FixedPointSolver::solve(
+                state,
+                [&](const Eigen::VectorXd& input, Eigen::VectorXd& output) {
+                    apply(input, forcing, output, workspace);
+                },
+                settings, workspace.fixed_point);
+        }
+
+        FixedPointDiagnostics solve_jvp(
+            Eigen::Ref<const Eigen::VectorXd> forcing,
+            Eigen::Ref<const Eigen::VectorXd> state,
+            const ProblemParameterData<NSTOKES>& tangent,
+            Eigen::VectorXd& state_tangent, const FixedPointSettings& settings,
+            ProblemWorkspace<NSTOKES>& workspace,
+            const Eigen::VectorXd* direct_transport_tangent = nullptr) const {
+            prepare_workspace(workspace);
+            validate_parameter_data(tangent);
+            if (state.size() != state_size() ||
+                forcing.size() != incoming_size()) {
+                throw std::invalid_argument(
+                    "invalid successive-orders JVP primal dimensions");
+            }
+
+            // Direct parameter effect: S_p(b + T x) + S(db + dT x).
+            m_transport->template apply_stokes<NSTOKES>(state,
+                                                        workspace.incoming);
+            workspace.incoming += forcing;
+            if (direct_transport_tangent != nullptr) {
+                if (direct_transport_tangent->size() != incoming_size()) {
+                    throw std::invalid_argument(
+                        "invalid direct successive-orders transport JVP "
+                        "size");
+                }
+                workspace.auxiliary_incoming = *direct_transport_tangent;
+            } else {
+                if (tangent.transport_values.size() !=
+                    m_transport->values().size()) {
+                    throw std::invalid_argument(
+                        "missing successive-orders transport JVP values");
+                }
+                m_transport->template apply_value_jvp_stokes<NSTOKES>(
+                    state, tangent.transport_values,
+                    workspace.auxiliary_incoming);
+            }
+            workspace.auxiliary_incoming += tangent.forcing;
+            scattering_jvp(workspace.incoming, workspace.auxiliary_incoming,
+                           tangent, workspace.direct_state, workspace);
+
+            if (workspace.direct_state.isZero(0.0)) {
+                state_tangent.setZero(state_size());
+                FixedPointDiagnostics diagnostics;
+                diagnostics.termination = FixedPointTermination::tolerance;
+                diagnostics.residual_norm = 0.0;
+                return diagnostics;
+            }
+            // The first fixed-point image of a zero tangent is exactly the
+            // direct parameter response. Start there and avoid spending an
+            // iteration rediscovering a value already available.
+            state_tangent = workspace.direct_state;
+            return FixedPointSolver::solve(
+                state_tangent,
+                [&](const Eigen::VectorXd& input, Eigen::VectorXd& output) {
+                    apply_linear(input, output, workspace);
+                    output += workspace.direct_state;
+                },
+                settings, workspace.fixed_point);
+        }
+
+        FixedPointDiagnostics
+        solve_vjp(Eigen::Ref<const Eigen::VectorXd> forcing,
+                  Eigen::Ref<const Eigen::VectorXd> state,
+                  Eigen::Ref<const Eigen::VectorXd> state_cotangent,
+                  ProblemParameterData<NSTOKES>& gradient,
+                  const FixedPointSettings& settings,
+                  ProblemWorkspace<NSTOKES>& workspace,
+                  Eigen::VectorXd& adjoint,
+                  bool materialize_transport_gradient = true) const {
+            prepare_workspace(workspace);
+            gradient.resize(*m_transport, *m_scattering,
+                            materialize_transport_gradient);
+            gradient.set_zero();
+            if (state.size() != state_size() ||
+                state_cotangent.size() != state_size() ||
+                forcing.size() != incoming_size()) {
+                throw std::invalid_argument(
+                    "invalid successive-orders VJP primal dimensions");
+            }
+
+            // As in the forward product, the adjoint right-hand side is the
+            // first image of a zero initial iterate.
+            adjoint = state_cotangent;
+            const auto diagnostics = FixedPointSolver::solve(
+                adjoint,
+                [&](const Eigen::VectorXd& input, Eigen::VectorXd& output) {
+                    apply_linear_transpose(input, output, workspace);
+                    output += state_cotangent;
+                },
+                settings, workspace.fixed_point);
+
+            m_transport->template apply_stokes<NSTOKES>(state,
+                                                        workspace.incoming);
+            workspace.incoming += forcing;
+            scattering_vjp(workspace.incoming, adjoint,
+                           workspace.auxiliary_incoming, gradient, workspace);
+            if (materialize_transport_gradient) {
+                m_transport->template apply_vjp_stokes<NSTOKES>(
+                    state, workspace.auxiliary_incoming,
+                    workspace.auxiliary_state, gradient.transport_values);
+            }
+            gradient.forcing = workspace.auxiliary_incoming;
+            return diagnostics;
+        }
+
+      private:
+        void prepare_workspace(ProblemWorkspace<NSTOKES>& workspace) const {
+            if (workspace.incoming.size() != incoming_size() ||
+                workspace.direct_state.size() != state_size()) {
+                workspace.resize(*m_transport, *m_scattering);
+            }
+        }
+
+        void validate_state_and_forcing(
+            Eigen::Ref<const Eigen::VectorXd> state,
+            Eigen::Ref<const Eigen::VectorXd> forcing,
+            Eigen::Ref<const Eigen::VectorXd> result) const {
+            if (state.size() != state_size() ||
+                forcing.size() != incoming_size() ||
+                result.size() != state_size()) {
+                throw std::invalid_argument(
+                    "invalid successive-orders problem dimensions");
+            }
+        }
+
+        void validate_parameter_data(
+            const ProblemParameterData<NSTOKES>& data) const;
+        void scattering_jvp(Eigen::Ref<const Eigen::VectorXd> incoming,
+                            Eigen::Ref<const Eigen::VectorXd> incoming_tangent,
+                            const ProblemParameterData<NSTOKES>& tangent,
+                            Eigen::Ref<Eigen::VectorXd> state_tangent,
+                            ProblemWorkspace<NSTOKES>& workspace) const;
+        void scattering_vjp(Eigen::Ref<const Eigen::VectorXd> incoming,
+                            Eigen::Ref<const Eigen::VectorXd> state_cotangent,
+                            Eigen::Ref<Eigen::VectorXd> incoming_cotangent,
+                            ProblemParameterData<NSTOKES>& gradient,
+                            ProblemWorkspace<NSTOKES>& workspace) const;
+
+        TransportOperator* m_transport;
+        ScatteringOperator<NSTOKES>* m_scattering;
+    };
+
+    template <>
+    void Problem<1>::validate_parameter_data(
+        const ProblemParameterData<1>& data) const;
+    template <>
+    void Problem<3>::validate_parameter_data(
+        const ProblemParameterData<3>& data) const;
+    template <>
+    void Problem<1>::scattering_jvp(
+        Eigen::Ref<const Eigen::VectorXd> incoming,
+        Eigen::Ref<const Eigen::VectorXd> incoming_tangent,
+        const ProblemParameterData<1>& tangent,
+        Eigen::Ref<Eigen::VectorXd> state_tangent,
+        ProblemWorkspace<1>& workspace) const;
+    template <>
+    void Problem<3>::scattering_jvp(
+        Eigen::Ref<const Eigen::VectorXd> incoming,
+        Eigen::Ref<const Eigen::VectorXd> incoming_tangent,
+        const ProblemParameterData<3>& tangent,
+        Eigen::Ref<Eigen::VectorXd> state_tangent,
+        ProblemWorkspace<3>& workspace) const;
+    template <>
+    void Problem<1>::scattering_vjp(
+        Eigen::Ref<const Eigen::VectorXd> incoming,
+        Eigen::Ref<const Eigen::VectorXd> state_cotangent,
+        Eigen::Ref<Eigen::VectorXd> incoming_cotangent,
+        ProblemParameterData<1>& gradient,
+        ProblemWorkspace<1>& workspace) const;
+    template <>
+    void Problem<3>::scattering_vjp(
+        Eigen::Ref<const Eigen::VectorXd> incoming,
+        Eigen::Ref<const Eigen::VectorXd> state_cotangent,
+        Eigen::Ref<Eigen::VectorXd> incoming_cotangent,
+        ProblemParameterData<3>& gradient,
+        ProblemWorkspace<3>& workspace) const;
+
+    extern template class Problem<1>;
+    extern template class Problem<3>;
+
+} // namespace sasktran2::successive_orders

--- a/cpp/lib/successive_orders/ray_transport.cpp
+++ b/cpp/lib/successive_orders/ray_transport.cpp
@@ -1,0 +1,381 @@
+#include "ray_transport.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+
+namespace sasktran2::successive_orders {
+    namespace {
+        template <typename Weights, typename Values>
+        double interpolate(const Weights& weights, const Values& values,
+                           int wavelength) {
+            double result = 0.0;
+            for (const auto& weight : weights) {
+                result += weight.weight * values(weight.index, wavelength);
+            }
+            return result;
+        }
+
+        template <typename Weights>
+        double interpolate_tangent(const Weights& weights, int tangent_offset,
+                                   Eigen::Ref<const Eigen::VectorXd> tangent) {
+            double result = 0.0;
+            for (const auto& weight : weights) {
+                result +=
+                    weight.weight * tangent(tangent_offset + weight.index);
+            }
+            return result;
+        }
+
+        double optical_depth(const sasktran2::raytracing::TracedRay& ray,
+                             int layer_index,
+                             Eigen::Ref<const Eigen::VectorXd> extinction) {
+            double result = 0.0;
+            const auto weights = ray.optical_depth_weights(layer_index);
+            for (std::size_t index = 0; index < weights.size(); ++index) {
+                const auto [atmosphere_index, weight] = weights[index];
+                result += weight * extinction(atmosphere_index);
+            }
+            return result;
+        }
+
+        double
+        optical_depth_tangent(const sasktran2::raytracing::TracedRay& ray,
+                              int layer_index,
+                              Eigen::Ref<const Eigen::VectorXd> tangent) {
+            double result = 0.0;
+            const auto weights = ray.optical_depth_weights(layer_index);
+            for (std::size_t index = 0; index < weights.size(); ++index) {
+                const auto [atmosphere_index, weight] = weights[index];
+                result += weight * tangent(atmosphere_index);
+            }
+            return result;
+        }
+    } // namespace
+
+    void RayTransportWorkspace::resize(int maximum_layers) {
+        optical_depth.resize(maximum_layers);
+        albedo.resize(maximum_layers);
+        transmission_before.resize(maximum_layers);
+        source_fraction.resize(maximum_layers);
+        factor_cotangent.resize(maximum_layers);
+    }
+
+    std::size_t RayTransportWorkspace::storage_bytes() const {
+        return static_cast<std::size_t>(optical_depth.size() + albedo.size() +
+                                        transmission_before.size() +
+                                        source_fraction.size() +
+                                        factor_cotangent.size()) *
+               sizeof(double);
+    }
+
+    RayTransportMap::RayTransportMap(const std::vector<RayInterpolation>& rays,
+                                     int num_source_columns,
+                                     const std::vector<int>& row_offsets,
+                                     const std::vector<int>& column_indices)
+        : m_rays(&rays),
+          m_sparsity(num_source_columns, row_offsets, column_indices) {
+        if (m_sparsity.rows() != static_cast<int>(rays.size())) {
+            throw std::invalid_argument(
+                "successive-orders transport row count does not match rays");
+        }
+        for (std::size_t row = 0; row < rays.size(); ++row) {
+            const auto& ray = rays[row];
+            if (ray.traced_ray == nullptr ||
+                ray.layers.size() != ray.traced_ray->layers.size()) {
+                throw std::invalid_argument(
+                    "invalid successive-orders compiled ray interpolation");
+            }
+            const int row_start = row_offsets[row];
+            const int row_nnz = row_offsets[row + 1] - row_start;
+            if (ray.transport_value_offset !=
+                    static_cast<std::size_t>(row_start) ||
+                ray.transport_row_nnz != static_cast<std::uint32_t>(row_nnz)) {
+                throw std::invalid_argument(
+                    "successive-orders ray CSR metadata is inconsistent");
+            }
+            const auto validate_weights = [&](const auto& weights) {
+                for (const auto& weight : weights) {
+                    if (weight.row_inner_index >=
+                            static_cast<std::uint32_t>(row_nnz) ||
+                        column_indices[row_start + weight.row_inner_index] !=
+                            weight.source_index) {
+                        throw std::invalid_argument(
+                            "successive-orders source interpolation does not "
+                            "match its CSR row");
+                    }
+                }
+            };
+            validate_weights(ray.source_weights);
+            validate_weights(ray.ground_weights);
+            m_maximum_layers =
+                std::max(m_maximum_layers, static_cast<int>(ray.layers.size()));
+        }
+    }
+
+    std::size_t RayTransportMap::storage_bytes() const {
+        return m_sparsity.storage_bytes();
+    }
+
+    void RayTransportMap::validate_operator(
+        const TransportOperator& transport) const {
+        if (&transport.sparsity() != &m_sparsity ||
+            transport.values().size() != m_sparsity.nonzeros()) {
+            throw std::invalid_argument(
+                "successive-orders transport operator has the wrong topology");
+        }
+    }
+
+    void RayTransportMap::validate_wavelength(int wavelength,
+                                              int num_wavelengths) const {
+        if (wavelength < 0 || wavelength >= num_wavelengths) {
+            throw std::out_of_range(
+                "successive-orders wavelength index is out of range");
+        }
+    }
+
+    template <int NSTOKES>
+    void RayTransportMap::assemble_values(
+        const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere,
+        int wavelength, TransportOperator& transport) const {
+        validate_operator(transport);
+        validate_wavelength(wavelength, atmosphere.num_wavel());
+        auto& values = transport.values();
+        values.setZero();
+        const auto extinction =
+            atmosphere.storage().total_extinction.col(wavelength);
+        const auto& ssa = atmosphere.storage().ssa;
+        const auto& offsets = m_sparsity.row_offsets();
+
+        for (int row = 0; row < num_rays(); ++row) {
+            const auto& interpolation = (*m_rays)[row];
+            const auto& ray = *interpolation.traced_ray;
+            double transmission_before = 1.0;
+            for (int layer_index =
+                     static_cast<int>(interpolation.layers.size()) - 1;
+                 layer_index >= 0; --layer_index) {
+                const auto atmosphere_weights =
+                    interpolation.atmosphere_for_layer(layer_index);
+                const auto source_weights =
+                    interpolation.source_for_layer(layer_index);
+                const double layer_optical_depth =
+                    optical_depth(ray, layer_index, extinction);
+                const double layer_transmission =
+                    std::exp(-layer_optical_depth);
+                const double albedo =
+                    interpolate(atmosphere_weights, ssa, wavelength);
+                const double source_fraction =
+                    -std::expm1(-layer_optical_depth);
+                const double factor =
+                    transmission_before * albedo * source_fraction;
+                for (const auto& source : source_weights) {
+                    values(offsets[row] + source.row_inner_index) +=
+                        source.weight * factor;
+                }
+                transmission_before *= layer_transmission;
+            }
+
+            if (interpolation.ground_is_hit()) {
+                for (const auto& source : interpolation.ground()) {
+                    values(offsets[row] + source.row_inner_index) +=
+                        source.weight * transmission_before;
+                }
+            }
+        }
+    }
+
+    template <int NSTOKES>
+    void RayTransportMap::assemble_jvp(
+        const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere,
+        int wavelength, Eigen::Ref<const Eigen::VectorXd> native_tangent,
+        Eigen::Ref<Eigen::VectorXd> value_tangent) const {
+        validate_wavelength(wavelength, atmosphere.num_wavel());
+        if (native_tangent.size() != atmosphere.num_deriv() ||
+            value_tangent.size() != m_sparsity.nonzeros()) {
+            throw std::invalid_argument(
+                "invalid successive-orders ray transport JVP dimensions");
+        }
+        value_tangent.setZero();
+        const auto extinction =
+            atmosphere.storage().total_extinction.col(wavelength);
+        const auto& ssa = atmosphere.storage().ssa;
+        const auto& offsets = m_sparsity.row_offsets();
+
+        for (int row = 0; row < num_rays(); ++row) {
+            const auto& interpolation = (*m_rays)[row];
+            const auto& ray = *interpolation.traced_ray;
+            double transmission_before = 1.0;
+            double cumulative_tangent = 0.0;
+            for (int layer_index =
+                     static_cast<int>(interpolation.layers.size()) - 1;
+                 layer_index >= 0; --layer_index) {
+                const auto atmosphere_weights =
+                    interpolation.atmosphere_for_layer(layer_index);
+                const auto source_weights =
+                    interpolation.source_for_layer(layer_index);
+                const double layer_optical_depth =
+                    optical_depth(ray, layer_index, extinction);
+                const double layer_tangent =
+                    optical_depth_tangent(ray, layer_index, native_tangent);
+                const double layer_transmission =
+                    std::exp(-layer_optical_depth);
+                const double albedo =
+                    interpolate(atmosphere_weights, ssa, wavelength);
+                const double albedo_tangent = interpolate_tangent(
+                    atmosphere_weights, atmosphere.ssa_deriv_start_index(),
+                    native_tangent);
+                const double source_fraction =
+                    -std::expm1(-layer_optical_depth);
+                const double factor_tangent =
+                    transmission_before *
+                    (albedo_tangent * source_fraction +
+                     albedo * layer_transmission * layer_tangent -
+                     albedo * source_fraction * cumulative_tangent);
+                for (const auto& source : source_weights) {
+                    value_tangent(offsets[row] + source.row_inner_index) +=
+                        source.weight * factor_tangent;
+                }
+                transmission_before *= layer_transmission;
+                cumulative_tangent += layer_tangent;
+            }
+
+            if (interpolation.ground_is_hit()) {
+                const double factor_tangent =
+                    -transmission_before * cumulative_tangent;
+                for (const auto& source : interpolation.ground()) {
+                    value_tangent(offsets[row] + source.row_inner_index) +=
+                        source.weight * factor_tangent;
+                }
+            }
+        }
+    }
+
+    template <int NSTOKES>
+    void RayTransportMap::accumulate_vjp(
+        const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere,
+        int wavelength, Eigen::Ref<const Eigen::VectorXd> value_gradient,
+        Eigen::Ref<Eigen::VectorXd> native_gradient,
+        RayTransportWorkspace& workspace) const {
+        validate_wavelength(wavelength, atmosphere.num_wavel());
+        if (value_gradient.size() != m_sparsity.nonzeros() ||
+            native_gradient.size() != atmosphere.num_deriv()) {
+            throw std::invalid_argument(
+                "invalid successive-orders ray transport VJP dimensions");
+        }
+        if (workspace.optical_depth.size() < m_maximum_layers) {
+            workspace.resize(m_maximum_layers);
+        }
+        const auto extinction =
+            atmosphere.storage().total_extinction.col(wavelength);
+        const auto& ssa = atmosphere.storage().ssa;
+        const auto& offsets = m_sparsity.row_offsets();
+
+        for (int row = 0; row < num_rays(); ++row) {
+            const auto& interpolation = (*m_rays)[row];
+            const auto& ray = *interpolation.traced_ray;
+            const int num_layers =
+                static_cast<int>(interpolation.layers.size());
+            double transmission_before = 1.0;
+            for (int layer_index = num_layers - 1; layer_index >= 0;
+                 --layer_index) {
+                const auto atmosphere_weights =
+                    interpolation.atmosphere_for_layer(layer_index);
+                const auto source_weights =
+                    interpolation.source_for_layer(layer_index);
+                workspace.optical_depth(layer_index) =
+                    optical_depth(ray, layer_index, extinction);
+                workspace.albedo(layer_index) =
+                    interpolate(atmosphere_weights, ssa, wavelength);
+                workspace.transmission_before(layer_index) =
+                    transmission_before;
+                const double layer_transmission =
+                    std::exp(-workspace.optical_depth(layer_index));
+                workspace.source_fraction(layer_index) =
+                    -std::expm1(-workspace.optical_depth(layer_index));
+                double factor_cotangent = 0.0;
+                for (const auto& source : source_weights) {
+                    factor_cotangent +=
+                        source.weight *
+                        value_gradient(offsets[row] + source.row_inner_index);
+                }
+                workspace.factor_cotangent(layer_index) = factor_cotangent;
+                transmission_before *= layer_transmission;
+            }
+
+            double cumulative_cotangent = 0.0;
+            if (interpolation.ground_is_hit()) {
+                double ground_cotangent = 0.0;
+                for (const auto& source : interpolation.ground()) {
+                    ground_cotangent +=
+                        source.weight *
+                        value_gradient(offsets[row] + source.row_inner_index);
+                }
+                cumulative_cotangent = -transmission_before * ground_cotangent;
+            }
+
+            // Reverse the observer-to-end source traversal. A layer optical
+            // depth affects every source closer to the observer and the
+            // terminal ground term, while its own source fraction contributes
+            // a direct derivative.
+            for (int layer_index = 0; layer_index < num_layers; ++layer_index) {
+                const auto atmosphere_weights =
+                    interpolation.atmosphere_for_layer(layer_index);
+                const double factor_cotangent =
+                    workspace.factor_cotangent(layer_index);
+                const double transmission_before =
+                    workspace.transmission_before(layer_index);
+                const double layer_transmission =
+                    std::exp(-workspace.optical_depth(layer_index));
+                const double albedo = workspace.albedo(layer_index);
+                const double source_fraction =
+                    workspace.source_fraction(layer_index);
+
+                const double optical_depth_cotangent =
+                    cumulative_cotangent + factor_cotangent *
+                                               transmission_before * albedo *
+                                               layer_transmission;
+                const auto od_weights = ray.optical_depth_weights(layer_index);
+                for (std::size_t index = 0; index < od_weights.size();
+                     ++index) {
+                    const auto [atmosphere_index, weight] = od_weights[index];
+                    native_gradient(atmosphere_index) +=
+                        weight * optical_depth_cotangent;
+                }
+
+                const double albedo_cotangent =
+                    factor_cotangent * transmission_before * source_fraction;
+                for (const auto& weight : atmosphere_weights) {
+                    native_gradient(atmosphere.ssa_deriv_start_index() +
+                                    weight.index) +=
+                        weight.weight * albedo_cotangent;
+                }
+
+                cumulative_cotangent -= factor_cotangent * transmission_before *
+                                        albedo * source_fraction;
+            }
+        }
+    }
+
+    template void RayTransportMap::assemble_values<1>(
+        const sasktran2::atmosphere::Atmosphere<1>&, int,
+        TransportOperator&) const;
+    template void RayTransportMap::assemble_values<3>(
+        const sasktran2::atmosphere::Atmosphere<3>&, int,
+        TransportOperator&) const;
+    template void RayTransportMap::assemble_jvp<1>(
+        const sasktran2::atmosphere::Atmosphere<1>&, int,
+        Eigen::Ref<const Eigen::VectorXd>, Eigen::Ref<Eigen::VectorXd>) const;
+    template void RayTransportMap::assemble_jvp<3>(
+        const sasktran2::atmosphere::Atmosphere<3>&, int,
+        Eigen::Ref<const Eigen::VectorXd>, Eigen::Ref<Eigen::VectorXd>) const;
+    template void RayTransportMap::accumulate_vjp<1>(
+        const sasktran2::atmosphere::Atmosphere<1>&, int,
+        Eigen::Ref<const Eigen::VectorXd>, Eigen::Ref<Eigen::VectorXd>,
+        RayTransportWorkspace&) const;
+    template void RayTransportMap::accumulate_vjp<3>(
+        const sasktran2::atmosphere::Atmosphere<3>&, int,
+        Eigen::Ref<const Eigen::VectorXd>, Eigen::Ref<Eigen::VectorXd>,
+        RayTransportWorkspace&) const;
+
+} // namespace sasktran2::successive_orders

--- a/cpp/lib/successive_orders/ray_transport.h
+++ b/cpp/lib/successive_orders/ray_transport.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include "interpolation.h"
+#include "transport.h"
+
+#include <sasktran2/atmosphere/atmosphere.h>
+
+#include <Eigen/Core>
+
+#include <cstddef>
+#include <vector>
+
+namespace sasktran2::successive_orders {
+
+    struct RayTransportWorkspace {
+        Eigen::VectorXd optical_depth;
+        Eigen::VectorXd albedo;
+        Eigen::VectorXd transmission_before;
+        Eigen::VectorXd source_fraction;
+        Eigen::VectorXd factor_cotangent;
+
+        void resize(int maximum_layers);
+        std::size_t storage_bytes() const;
+    };
+
+    /** Atmosphere-dependent values on fixed ray/source interpolation geometry.
+     *
+     * One scalar CSR topology is shared by all Stokes components. Values are
+     * rebuilt in place when the atmospheric state changes. Directional and
+     * reverse derivatives operate directly on extinction and single-scatter
+     * albedo native columns without materializing a derivative matrix.
+     */
+    class RayTransportMap {
+      public:
+        RayTransportMap(const std::vector<RayInterpolation>& rays,
+                        int num_source_columns,
+                        const std::vector<int>& row_offsets,
+                        const std::vector<int>& column_indices);
+
+        const TransportSparsity& sparsity() const { return m_sparsity; }
+        int num_rays() const { return m_sparsity.rows(); }
+        int maximum_layers() const { return m_maximum_layers; }
+        std::size_t storage_bytes() const;
+
+        template <int NSTOKES>
+        void assemble_values(
+            const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere,
+            int wavelength, TransportOperator& transport) const;
+
+        template <int NSTOKES>
+        void assemble_jvp(
+            const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere,
+            int wavelength, Eigen::Ref<const Eigen::VectorXd> native_tangent,
+            Eigen::Ref<Eigen::VectorXd> value_tangent) const;
+
+        template <int NSTOKES>
+        void accumulate_vjp(
+            const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere,
+            int wavelength, Eigen::Ref<const Eigen::VectorXd> value_gradient,
+            Eigen::Ref<Eigen::VectorXd> native_gradient,
+            RayTransportWorkspace& workspace) const;
+
+      private:
+        void validate_operator(const TransportOperator& transport) const;
+        void validate_wavelength(int wavelength, int num_wavelengths) const;
+
+        const std::vector<RayInterpolation>* m_rays;
+        TransportSparsity m_sparsity;
+        int m_maximum_layers = 0;
+    };
+
+    extern template void RayTransportMap::assemble_values<1>(
+        const sasktran2::atmosphere::Atmosphere<1>&, int,
+        TransportOperator&) const;
+    extern template void RayTransportMap::assemble_values<3>(
+        const sasktran2::atmosphere::Atmosphere<3>&, int,
+        TransportOperator&) const;
+    extern template void RayTransportMap::assemble_jvp<1>(
+        const sasktran2::atmosphere::Atmosphere<1>&, int,
+        Eigen::Ref<const Eigen::VectorXd>, Eigen::Ref<Eigen::VectorXd>) const;
+    extern template void RayTransportMap::assemble_jvp<3>(
+        const sasktran2::atmosphere::Atmosphere<3>&, int,
+        Eigen::Ref<const Eigen::VectorXd>, Eigen::Ref<Eigen::VectorXd>) const;
+    extern template void RayTransportMap::accumulate_vjp<1>(
+        const sasktran2::atmosphere::Atmosphere<1>&, int,
+        Eigen::Ref<const Eigen::VectorXd>, Eigen::Ref<Eigen::VectorXd>,
+        RayTransportWorkspace&) const;
+    extern template void RayTransportMap::accumulate_vjp<3>(
+        const sasktran2::atmosphere::Atmosphere<3>&, int,
+        Eigen::Ref<const Eigen::VectorXd>, Eigen::Ref<Eigen::VectorXd>,
+        RayTransportWorkspace&) const;
+
+} // namespace sasktran2::successive_orders

--- a/cpp/lib/successive_orders/scattering.cpp
+++ b/cpp/lib/successive_orders/scattering.cpp
@@ -1,0 +1,888 @@
+#include "scattering.h"
+
+#include <algorithm>
+#include <limits>
+#include <stdexcept>
+#include <utility>
+
+namespace sasktran2::successive_orders {
+    namespace {
+        using RowMajorMatrix = Eigen::Matrix<double, Eigen::Dynamic,
+                                             Eigen::Dynamic, Eigen::RowMajor>;
+
+        int checked_product(int left, int right, const char* message) {
+            const auto product = static_cast<long long>(left) * right;
+            if (left < 0 || right < 0 ||
+                product > std::numeric_limits<int>::max()) {
+                throw std::invalid_argument(message);
+            }
+            return static_cast<int>(product);
+        }
+
+        std::vector<int> make_uniform_offsets(int atmospheric_blocks,
+                                              int ground_blocks,
+                                              int atmospheric_directions,
+                                              int ground_directions,
+                                              int stokes_components) {
+            if (atmospheric_blocks < 0 || ground_blocks < 0 ||
+                atmospheric_blocks + ground_blocks < 1 ||
+                atmospheric_directions < 1 || ground_directions < 1 ||
+                stokes_components < 1) {
+                throw std::invalid_argument(
+                    "invalid successive-orders scattering block counts");
+            }
+            const int atmospheric_size = checked_product(
+                atmospheric_directions, stokes_components,
+                "successive-orders atmospheric block size overflow");
+            const int ground_size =
+                checked_product(ground_directions, stokes_components,
+                                "successive-orders ground block size overflow");
+            std::vector<int> offsets(
+                static_cast<std::size_t>(atmospheric_blocks + ground_blocks) +
+                    1,
+                0);
+            for (int block = 0; block < atmospheric_blocks; ++block) {
+                if (offsets[block] >
+                    std::numeric_limits<int>::max() - atmospheric_size) {
+                    throw std::invalid_argument(
+                        "successive-orders scattering layout overflow");
+                }
+                offsets[block + 1] = offsets[block] + atmospheric_size;
+            }
+            for (int block = atmospheric_blocks;
+                 block < atmospheric_blocks + ground_blocks; ++block) {
+                if (offsets[block] >
+                    std::numeric_limits<int>::max() - ground_size) {
+                    throw std::invalid_argument(
+                        "successive-orders scattering layout overflow");
+                }
+                offsets[block + 1] = offsets[block] + ground_size;
+            }
+            return offsets;
+        }
+
+        std::vector<int>
+        make_dense_value_offsets(const ScatteringBlockLayout& layout,
+                                 int first_block, int block_count) {
+            if (first_block < 0 || block_count < 0 ||
+                first_block + block_count > layout.blocks()) {
+                throw std::invalid_argument(
+                    "invalid successive-orders dense scattering block range");
+            }
+            std::vector<int> offsets(static_cast<std::size_t>(block_count) + 1,
+                                     0);
+            for (int local_block = 0; local_block < block_count;
+                 ++local_block) {
+                const int block = first_block + local_block;
+                const int values = checked_product(
+                    layout.input_block_size(block),
+                    layout.output_block_size(block),
+                    "successive-orders dense scattering size overflow");
+                if (offsets[local_block] >
+                    std::numeric_limits<int>::max() - values) {
+                    throw std::invalid_argument(
+                        "successive-orders dense scattering size overflow");
+                }
+                offsets[local_block + 1] = offsets[local_block] + values;
+            }
+            return offsets;
+        }
+
+        void validate_dense_tangent(const Eigen::VectorXd& values,
+                                    Eigen::Ref<const Eigen::VectorXd> tangent) {
+            if (tangent.size() != values.size()) {
+                throw std::invalid_argument(
+                    "invalid successive-orders dense scattering tangent size");
+            }
+        }
+
+        void apply_dense_blocks(const ScatteringBlockLayout& layout,
+                                int first_block,
+                                const std::vector<int>& value_offsets,
+                                const Eigen::VectorXd& values,
+                                Eigen::Ref<const Eigen::VectorXd> incoming,
+                                Eigen::Ref<Eigen::VectorXd> outgoing) {
+            const int block_count = static_cast<int>(value_offsets.size()) - 1;
+            for (int local_block = 0; local_block < block_count;
+                 ++local_block) {
+                const int block = first_block + local_block;
+                const int rows = layout.output_block_size(block);
+                const int columns = layout.input_block_size(block);
+                const Eigen::Map<const RowMajorMatrix> matrix(
+                    values.data() + value_offsets[local_block], rows, columns);
+                outgoing.segment(layout.output_offsets()[block], rows)
+                    .noalias() =
+                    matrix *
+                    incoming.segment(layout.input_offsets()[block], columns);
+            }
+        }
+
+        void
+        apply_dense_blocks_transpose(const ScatteringBlockLayout& layout,
+                                     int first_block,
+                                     const std::vector<int>& value_offsets,
+                                     const Eigen::VectorXd& values,
+                                     Eigen::Ref<const Eigen::VectorXd> outgoing,
+                                     Eigen::Ref<Eigen::VectorXd> incoming) {
+            const int block_count = static_cast<int>(value_offsets.size()) - 1;
+            for (int local_block = 0; local_block < block_count;
+                 ++local_block) {
+                const int block = first_block + local_block;
+                const int rows = layout.output_block_size(block);
+                const int columns = layout.input_block_size(block);
+                const Eigen::Map<const RowMajorMatrix> matrix(
+                    values.data() + value_offsets[local_block], rows, columns);
+                incoming.segment(layout.input_offsets()[block], columns)
+                    .noalias() =
+                    matrix.transpose() *
+                    outgoing.segment(layout.output_offsets()[block], rows);
+            }
+        }
+
+        void apply_dense_blocks_jvp(
+            const ScatteringBlockLayout& layout, int first_block,
+            const std::vector<int>& value_offsets,
+            const Eigen::VectorXd& values,
+            Eigen::Ref<const Eigen::VectorXd> value_tangent,
+            Eigen::Ref<const Eigen::VectorXd> incoming,
+            Eigen::Ref<const Eigen::VectorXd> incoming_tangent,
+            Eigen::Ref<Eigen::VectorXd> outgoing_tangent) {
+            const int block_count = static_cast<int>(value_offsets.size()) - 1;
+            for (int local_block = 0; local_block < block_count;
+                 ++local_block) {
+                const int block = first_block + local_block;
+                const int rows = layout.output_block_size(block);
+                const int columns = layout.input_block_size(block);
+                const int value_offset = value_offsets[local_block];
+                const Eigen::Map<const RowMajorMatrix> matrix(
+                    values.data() + value_offset, rows, columns);
+                const Eigen::Map<const RowMajorMatrix> matrix_tangent(
+                    value_tangent.data() + value_offset, rows, columns);
+                auto result = outgoing_tangent.segment(
+                    layout.output_offsets()[block], rows);
+                result.noalias() =
+                    matrix * incoming_tangent.segment(
+                                 layout.input_offsets()[block], columns);
+                result.noalias() +=
+                    matrix_tangent *
+                    incoming.segment(layout.input_offsets()[block], columns);
+            }
+        }
+
+        void apply_dense_blocks_vjp(
+            const ScatteringBlockLayout& layout, int first_block,
+            const std::vector<int>& value_offsets,
+            const Eigen::VectorXd& values,
+            Eigen::Ref<const Eigen::VectorXd> incoming,
+            Eigen::Ref<const Eigen::VectorXd> outgoing_cotangent,
+            Eigen::Ref<Eigen::VectorXd> incoming_cotangent,
+            Eigen::Ref<Eigen::VectorXd> value_gradient) {
+            const int block_count = static_cast<int>(value_offsets.size()) - 1;
+            for (int local_block = 0; local_block < block_count;
+                 ++local_block) {
+                const int block = first_block + local_block;
+                const int rows = layout.output_block_size(block);
+                const int columns = layout.input_block_size(block);
+                const int value_offset = value_offsets[local_block];
+                const Eigen::Map<const RowMajorMatrix> matrix(
+                    values.data() + value_offset, rows, columns);
+                const auto block_cotangent = outgoing_cotangent.segment(
+                    layout.output_offsets()[block], rows);
+                const auto block_input =
+                    incoming.segment(layout.input_offsets()[block], columns);
+                incoming_cotangent
+                    .segment(layout.input_offsets()[block], columns)
+                    .noalias() = matrix.transpose() * block_cotangent;
+                Eigen::Map<RowMajorMatrix> gradient(
+                    value_gradient.data() + value_offset, rows, columns);
+                gradient.noalias() = block_cotangent * block_input.transpose();
+            }
+        }
+
+        void pack_atmospheric_blocks(const ScatteringBlockLayout& layout,
+                                     Eigen::Ref<const Eigen::VectorXd> values,
+                                     Eigen::MatrixXd& packed) {
+            for (int point = 0; point < layout.atmospheric_blocks(); ++point) {
+                packed.row(point) = values
+                                        .segment(layout.input_offsets()[point],
+                                                 layout.input_block_size(point))
+                                        .transpose();
+            }
+        }
+
+        void
+        pack_atmospheric_output_blocks(const ScatteringBlockLayout& layout,
+                                       Eigen::Ref<const Eigen::VectorXd> values,
+                                       Eigen::MatrixXd& packed) {
+            for (int point = 0; point < layout.atmospheric_blocks(); ++point) {
+                packed.row(point) =
+                    values
+                        .segment(layout.output_offsets()[point],
+                                 layout.output_block_size(point))
+                        .transpose();
+            }
+        }
+
+        void unpack_atmospheric_blocks(const ScatteringBlockLayout& layout,
+                                       const Eigen::MatrixXd& packed,
+                                       Eigen::Ref<Eigen::VectorXd> values) {
+            for (int point = 0; point < layout.atmospheric_blocks(); ++point) {
+                values.segment(layout.output_offsets()[point],
+                               layout.output_block_size(point)) =
+                    packed.row(point).transpose();
+            }
+        }
+
+        void
+        unpack_atmospheric_input_blocks(const ScatteringBlockLayout& layout,
+                                        const Eigen::MatrixXd& packed,
+                                        Eigen::Ref<Eigen::VectorXd> values) {
+            for (int point = 0; point < layout.atmospheric_blocks(); ++point) {
+                values.segment(layout.input_offsets()[point],
+                               layout.input_block_size(point)) =
+                    packed.row(point).transpose();
+            }
+        }
+    } // namespace
+
+    ScatteringBlockLayout::ScatteringBlockLayout(
+        int atmospheric_blocks, int stokes_components,
+        std::vector<int> input_offsets, std::vector<int> output_offsets)
+        : m_atmospheric_blocks(atmospheric_blocks),
+          m_stokes_components(stokes_components),
+          m_input_offsets(std::move(input_offsets)),
+          m_output_offsets(std::move(output_offsets)) {
+        if (m_stokes_components < 1 || m_input_offsets.size() < 2 ||
+            m_input_offsets.size() != m_output_offsets.size() ||
+            m_atmospheric_blocks < 0 || m_atmospheric_blocks > blocks() ||
+            m_input_offsets.front() != 0 || m_output_offsets.front() != 0 ||
+            !std::is_sorted(m_input_offsets.begin(), m_input_offsets.end()) ||
+            !std::is_sorted(m_output_offsets.begin(), m_output_offsets.end())) {
+            throw std::invalid_argument(
+                "invalid successive-orders scattering block offsets");
+        }
+        for (int block = 0; block < blocks(); ++block) {
+            if (input_block_size(block) < 1 || output_block_size(block) < 1 ||
+                input_block_size(block) % m_stokes_components != 0 ||
+                output_block_size(block) % m_stokes_components != 0) {
+                throw std::invalid_argument(
+                    "invalid successive-orders scattering block dimensions");
+            }
+        }
+    }
+
+    ScatteringBlockLayout::ScatteringBlockLayout(
+        int atmospheric_blocks, int ground_blocks,
+        int atmospheric_input_directions, int atmospheric_output_directions,
+        int ground_input_directions, int ground_output_directions,
+        int stokes_components)
+        : ScatteringBlockLayout(
+              atmospheric_blocks, stokes_components,
+              make_uniform_offsets(atmospheric_blocks, ground_blocks,
+                                   atmospheric_input_directions,
+                                   ground_input_directions, stokes_components),
+              make_uniform_offsets(atmospheric_blocks, ground_blocks,
+                                   atmospheric_output_directions,
+                                   ground_output_directions,
+                                   stokes_components)) {}
+
+    int ScatteringBlockLayout::input_block_size(int block) const {
+        if (block < 0 || block >= blocks()) {
+            throw std::out_of_range(
+                "successive-orders scattering input block out of range");
+        }
+        return m_input_offsets[block + 1] - m_input_offsets[block];
+    }
+
+    int ScatteringBlockLayout::output_block_size(int block) const {
+        if (block < 0 || block >= blocks()) {
+            throw std::out_of_range(
+                "successive-orders scattering output block out of range");
+        }
+        return m_output_offsets[block + 1] - m_output_offsets[block];
+    }
+
+    std::size_t ScatteringBlockLayout::storage_bytes() const {
+        return (m_input_offsets.capacity() + m_output_offsets.capacity()) *
+               sizeof(int);
+    }
+
+    void ScatteringWorkspace<1>::prepare(int atmospheric_blocks,
+                                         int input_directions,
+                                         int output_directions, int modes) {
+        m_atmospheric_input.resize(atmospheric_blocks, input_directions);
+        m_atmospheric_output.resize(atmospheric_blocks, output_directions);
+        m_auxiliary_input.resize(atmospheric_blocks, input_directions);
+        m_moments.resize(atmospheric_blocks, modes);
+        m_auxiliary_moments.resize(atmospheric_blocks, modes);
+    }
+
+    std::size_t ScatteringWorkspace<1>::storage_bytes() const {
+        return static_cast<std::size_t>(
+                   m_atmospheric_input.size() + m_atmospheric_output.size() +
+                   m_auxiliary_input.size() + m_moments.size() +
+                   m_auxiliary_moments.size()) *
+               sizeof(double);
+    }
+
+    ScatteringOperator<1>::ScatteringOperator(ScatteringBlockLayout layout,
+                                              ScalarAngularBasis angular_basis)
+        : ScatteringOperator(
+              std::move(layout),
+              std::make_shared<ScalarAngularBasis>(std::move(angular_basis))) {}
+
+    ScatteringOperator<1>::ScatteringOperator(
+        ScatteringBlockLayout layout,
+        std::shared_ptr<const ScalarAngularBasis> angular_basis)
+        : m_layout(std::move(layout)), m_basis(std::move(angular_basis)),
+          m_atmospheric_coefficients(
+              m_layout.atmospheric_blocks(),
+              m_basis == nullptr ? 0 : m_basis->num_coefficients()),
+          m_ground_value_offsets(
+              make_dense_value_offsets(m_layout, m_layout.atmospheric_blocks(),
+                                       m_layout.ground_blocks())),
+          m_ground_values(m_ground_value_offsets.back()) {
+        if (m_basis == nullptr) {
+            throw std::invalid_argument(
+                "scalar successive-orders scattering requires an angular "
+                "basis");
+        }
+        if (m_layout.stokes_components() != 1) {
+            throw std::invalid_argument(
+                "scalar successive-orders scattering requires NSTOKES=1");
+        }
+        for (int block = 0; block < m_layout.atmospheric_blocks(); ++block) {
+            if (m_layout.input_block_size(block) != m_basis->input_size() ||
+                m_layout.output_block_size(block) != m_basis->output_size()) {
+                throw std::invalid_argument(
+                    "scalar successive-orders atmospheric block does not "
+                    "match its angular basis");
+            }
+        }
+        m_atmospheric_coefficients.setZero();
+        m_ground_values.setZero();
+    }
+
+    void
+    ScatteringOperator<1>::set_active_coefficients(int active_coefficients) {
+        if (active_coefficients < 1 ||
+            active_coefficients > m_basis->num_coefficients()) {
+            throw std::invalid_argument(
+                "invalid active scalar scattering coefficient count");
+        }
+        m_active_coefficients = active_coefficients;
+    }
+
+    void ScatteringOperator<1>::set_atmospheric_coefficients(
+        Eigen::Ref<const Eigen::MatrixXd> coefficients) {
+        if (coefficients.rows() != m_atmospheric_coefficients.rows() ||
+            coefficients.cols() != m_atmospheric_coefficients.cols() ||
+            !coefficients.allFinite()) {
+            throw std::invalid_argument(
+                "invalid scalar successive-orders atmospheric coefficients");
+        }
+        m_atmospheric_coefficients = coefficients;
+        int active_coefficients = 1;
+        for (int degree = coefficients.cols() - 1; degree >= 1; --degree) {
+            if (!coefficients.col(degree).isZero(0.0)) {
+                active_coefficients = degree + 1;
+                break;
+            }
+        }
+        m_active_coefficients = active_coefficients;
+    }
+
+    void ScatteringOperator<1>::set_ground_values(
+        Eigen::Ref<const Eigen::VectorXd> values) {
+        if (values.size() != m_ground_values.size() || !values.allFinite()) {
+            throw std::invalid_argument(
+                "invalid scalar successive-orders ground scattering values");
+        }
+        m_ground_values = values;
+    }
+
+    void ScatteringOperator<1>::set_ground_block(
+        int ground_block, Eigen::Ref<const Eigen::MatrixXd> values) {
+        auto target = this->ground_block(ground_block);
+        if (values.rows() != target.rows() || values.cols() != target.cols() ||
+            !values.allFinite()) {
+            throw std::invalid_argument(
+                "invalid scalar successive-orders ground scattering block");
+        }
+        target = values;
+    }
+
+    int ScatteringOperator<1>::ground_value_offset(int ground_block) const {
+        if (ground_block < 0 || ground_block >= m_layout.ground_blocks()) {
+            throw std::out_of_range(
+                "successive-orders ground scattering block out of range");
+        }
+        return m_ground_value_offsets[ground_block];
+    }
+
+    Eigen::Map<ScatteringOperator<1>::RowMajorMatrix>
+    ScatteringOperator<1>::ground_block(int ground_block) {
+        const int block = m_layout.atmospheric_blocks() + ground_block;
+        return {m_ground_values.data() + ground_value_offset(ground_block),
+                m_layout.output_block_size(block),
+                m_layout.input_block_size(block)};
+    }
+
+    Eigen::Map<const ScatteringOperator<1>::RowMajorMatrix>
+    ScatteringOperator<1>::ground_block(int ground_block) const {
+        const int block = m_layout.atmospheric_blocks() + ground_block;
+        return {m_ground_values.data() + ground_value_offset(ground_block),
+                m_layout.output_block_size(block),
+                m_layout.input_block_size(block)};
+    }
+
+    void ScatteringOperator<1>::prepare_workspace(
+        ScatteringWorkspace<1>& workspace) const {
+        workspace.prepare(m_layout.atmospheric_blocks(), m_basis->input_size(),
+                          m_basis->output_size(),
+                          m_active_coefficients * m_active_coefficients);
+    }
+
+    ScatteringWorkspace<1> ScatteringOperator<1>::make_workspace() const {
+        ScatteringWorkspace<1> workspace;
+        prepare_workspace(workspace);
+        return workspace;
+    }
+
+    ScatteringMemoryUsage ScatteringOperator<1>::memory_usage(
+        const ScatteringWorkspace<1>* workspace) const {
+        ScatteringMemoryUsage result;
+        result.layout_bytes = m_layout.storage_bytes() +
+                              m_ground_value_offsets.capacity() * sizeof(int);
+        result.angular_basis_bytes = m_basis->storage_bytes();
+        result.atmospheric_value_bytes =
+            static_cast<std::size_t>(m_atmospheric_coefficients.size()) *
+            sizeof(double);
+        result.boundary_value_bytes =
+            static_cast<std::size_t>(m_ground_values.size()) * sizeof(double);
+        result.workspace_bytes =
+            workspace == nullptr ? 0 : workspace->storage_bytes();
+        return result;
+    }
+
+    void ScatteringOperator<1>::validate_input_output(
+        Eigen::Index incoming_size, Eigen::Index outgoing_size) const {
+        if (incoming_size != input_size() || outgoing_size != output_size()) {
+            throw std::invalid_argument(
+                "invalid scalar successive-orders scattering vector sizes");
+        }
+    }
+
+    void
+    ScatteringOperator<1>::apply(Eigen::Ref<const Eigen::VectorXd> incoming,
+                                 Eigen::Ref<Eigen::VectorXd> outgoing,
+                                 ScatteringWorkspace<1>& workspace) const {
+        validate_input_output(incoming.size(), outgoing.size());
+        prepare_workspace(workspace);
+        if (m_layout.atmospheric_blocks() != 0) {
+            pack_atmospheric_blocks(m_layout, incoming,
+                                    workspace.m_atmospheric_input);
+            m_basis->apply_active(
+                workspace.m_atmospheric_input, m_atmospheric_coefficients,
+                m_active_coefficients, workspace.m_atmospheric_output,
+                workspace.m_moments);
+            unpack_atmospheric_blocks(m_layout, workspace.m_atmospheric_output,
+                                      outgoing);
+        }
+        apply_dense_blocks(m_layout, m_layout.atmospheric_blocks(),
+                           m_ground_value_offsets, m_ground_values, incoming,
+                           outgoing);
+    }
+
+    void ScatteringOperator<1>::apply_transpose(
+        Eigen::Ref<const Eigen::VectorXd> outgoing,
+        Eigen::Ref<Eigen::VectorXd> incoming,
+        ScatteringWorkspace<1>& workspace) const {
+        validate_input_output(incoming.size(), outgoing.size());
+        prepare_workspace(workspace);
+        if (m_layout.atmospheric_blocks() != 0) {
+            pack_atmospheric_output_blocks(m_layout, outgoing,
+                                           workspace.m_atmospheric_output);
+            m_basis->apply_transpose_active(
+                workspace.m_atmospheric_output, m_atmospheric_coefficients,
+                m_active_coefficients, workspace.m_atmospheric_input,
+                workspace.m_moments);
+            unpack_atmospheric_input_blocks(
+                m_layout, workspace.m_atmospheric_input, incoming);
+        }
+        apply_dense_blocks_transpose(m_layout, m_layout.atmospheric_blocks(),
+                                     m_ground_value_offsets, m_ground_values,
+                                     outgoing, incoming);
+    }
+
+    void ScatteringOperator<1>::apply_jvp(
+        Eigen::Ref<const Eigen::VectorXd> incoming,
+        Eigen::Ref<const Eigen::VectorXd> incoming_tangent,
+        Eigen::Ref<const Eigen::MatrixXd> coefficient_tangent,
+        Eigen::Ref<const Eigen::VectorXd> ground_value_tangent,
+        Eigen::Ref<Eigen::VectorXd> outgoing_tangent,
+        ScatteringWorkspace<1>& workspace) const {
+        validate_input_output(incoming.size(), outgoing_tangent.size());
+        if (incoming_tangent.size() != incoming.size() ||
+            coefficient_tangent.rows() != m_atmospheric_coefficients.rows() ||
+            coefficient_tangent.cols() != m_atmospheric_coefficients.cols()) {
+            throw std::invalid_argument(
+                "invalid scalar successive-orders scattering JVP sizes");
+        }
+        validate_dense_tangent(m_ground_values, ground_value_tangent);
+        if (coefficient_tangent.isZero(0.0) &&
+            ground_value_tangent.isZero(0.0)) {
+            apply(incoming_tangent, outgoing_tangent, workspace);
+            return;
+        }
+        prepare_workspace(workspace);
+        if (m_layout.atmospheric_blocks() != 0) {
+            pack_atmospheric_blocks(m_layout, incoming,
+                                    workspace.m_atmospheric_input);
+            pack_atmospheric_blocks(m_layout, incoming_tangent,
+                                    workspace.m_auxiliary_input);
+            int active_coefficients = m_active_coefficients;
+            for (int degree = m_basis->num_coefficients() - 1;
+                 degree >= m_active_coefficients; --degree) {
+                if (!coefficient_tangent.col(degree).isZero(0.0)) {
+                    active_coefficients = degree + 1;
+                    break;
+                }
+            }
+            m_basis->apply_jvp_active(
+                workspace.m_atmospheric_input, workspace.m_auxiliary_input,
+                m_atmospheric_coefficients, coefficient_tangent,
+                active_coefficients, workspace.m_atmospheric_output,
+                workspace.m_moments, workspace.m_auxiliary_moments);
+            unpack_atmospheric_blocks(m_layout, workspace.m_atmospheric_output,
+                                      outgoing_tangent);
+        }
+        apply_dense_blocks_jvp(m_layout, m_layout.atmospheric_blocks(),
+                               m_ground_value_offsets, m_ground_values,
+                               ground_value_tangent, incoming, incoming_tangent,
+                               outgoing_tangent);
+    }
+
+    void ScatteringOperator<1>::apply_vjp(
+        Eigen::Ref<const Eigen::VectorXd> incoming,
+        Eigen::Ref<const Eigen::VectorXd> outgoing_cotangent,
+        Eigen::Ref<Eigen::VectorXd> incoming_cotangent,
+        Eigen::Ref<Eigen::MatrixXd> coefficient_gradient,
+        Eigen::Ref<Eigen::VectorXd> ground_value_gradient,
+        ScatteringWorkspace<1>& workspace) const {
+        validate_input_output(incoming.size(), outgoing_cotangent.size());
+        if (incoming_cotangent.size() != incoming.size() ||
+            coefficient_gradient.rows() != m_atmospheric_coefficients.rows() ||
+            coefficient_gradient.cols() != m_atmospheric_coefficients.cols() ||
+            ground_value_gradient.size() != m_ground_values.size()) {
+            throw std::invalid_argument(
+                "invalid scalar successive-orders scattering VJP sizes");
+        }
+        prepare_workspace(workspace);
+        incoming_cotangent.setZero();
+        coefficient_gradient.setZero();
+        ground_value_gradient.setZero();
+        if (m_layout.atmospheric_blocks() != 0) {
+            pack_atmospheric_blocks(m_layout, incoming,
+                                    workspace.m_atmospheric_input);
+            pack_atmospheric_output_blocks(m_layout, outgoing_cotangent,
+                                           workspace.m_atmospheric_output);
+            m_basis->apply_vjp(
+                workspace.m_atmospheric_input, m_atmospheric_coefficients,
+                workspace.m_atmospheric_output, workspace.m_auxiliary_input,
+                coefficient_gradient, workspace.m_moments,
+                workspace.m_auxiliary_moments);
+            unpack_atmospheric_input_blocks(
+                m_layout, workspace.m_auxiliary_input, incoming_cotangent);
+        }
+        apply_dense_blocks_vjp(m_layout, m_layout.atmospheric_blocks(),
+                               m_ground_value_offsets, m_ground_values,
+                               incoming, outgoing_cotangent, incoming_cotangent,
+                               ground_value_gradient);
+    }
+
+    void ScatteringWorkspace<3>::prepare(int atmospheric_blocks,
+                                         int input_directions,
+                                         int output_directions) {
+        m_atmospheric_input.resize(atmospheric_blocks, 3 * input_directions);
+        m_atmospheric_output.resize(atmospheric_blocks, 3 * output_directions);
+        m_auxiliary_input.resize(atmospheric_blocks, 3 * input_directions);
+        m_auxiliary_output.resize(atmospheric_blocks, 3 * output_directions);
+    }
+
+    std::size_t ScatteringWorkspace<3>::storage_bytes() const {
+        return static_cast<std::size_t>(
+                   m_atmospheric_input.size() + m_atmospheric_output.size() +
+                   m_auxiliary_input.size() + m_auxiliary_output.size()) *
+                   sizeof(double) +
+               m_angular.storage_bytes();
+    }
+
+    ScatteringOperator<3>::ScatteringOperator(
+        ScatteringBlockLayout layout,
+        std::shared_ptr<const VectorAngularBasis> angular_basis)
+        : m_layout(std::move(layout)), m_basis(std::move(angular_basis)),
+          m_ground_value_offsets(
+              make_dense_value_offsets(m_layout, m_layout.atmospheric_blocks(),
+                                       m_layout.ground_blocks())),
+          m_atmospheric_coefficients(
+              m_layout.atmospheric_blocks(),
+              m_basis == nullptr ? 0 : 4 * m_basis->num_coefficients()),
+          m_ground_values(m_ground_value_offsets.back()) {
+        if (m_basis == nullptr) {
+            throw std::invalid_argument(
+                "vector successive-orders scattering requires an angular "
+                "basis");
+        }
+        if (m_layout.stokes_components() != 3) {
+            throw std::invalid_argument(
+                "vector successive-orders scattering requires NSTOKES=3");
+        }
+        for (int block = 0; block < m_layout.atmospheric_blocks(); ++block) {
+            if (m_layout.input_block_size(block) != m_basis->input_size() ||
+                m_layout.output_block_size(block) != m_basis->output_size()) {
+                throw std::invalid_argument(
+                    "vector successive-orders atmospheric block does not "
+                    "match its angular basis");
+            }
+        }
+        m_atmospheric_coefficients.setZero();
+        m_ground_values.setZero();
+    }
+
+    void
+    ScatteringOperator<3>::set_active_coefficients(int active_coefficients) {
+        if (active_coefficients < 1 ||
+            active_coefficients > m_basis->num_coefficients()) {
+            throw std::invalid_argument(
+                "invalid active vector scattering coefficient count");
+        }
+        m_active_coefficients = active_coefficients;
+    }
+
+    void ScatteringOperator<3>::set_atmospheric_coefficients(
+        Eigen::Ref<const Eigen::MatrixXd> coefficients) {
+        if (coefficients.rows() != m_atmospheric_coefficients.rows() ||
+            coefficients.cols() != m_atmospheric_coefficients.cols() ||
+            !coefficients.allFinite()) {
+            throw std::invalid_argument(
+                "invalid vector successive-orders atmospheric coefficients");
+        }
+        m_atmospheric_coefficients = coefficients;
+        int active_coefficients = 1;
+        for (int degree = m_basis->num_coefficients() - 1; degree >= 1;
+             --degree) {
+            if (!coefficients.middleCols(4 * degree, 4).isZero(0.0)) {
+                active_coefficients = degree + 1;
+                break;
+            }
+        }
+        m_active_coefficients = active_coefficients;
+    }
+
+    void ScatteringOperator<3>::set_ground_values(
+        Eigen::Ref<const Eigen::VectorXd> values) {
+        if (values.size() != m_ground_values.size() || !values.allFinite()) {
+            throw std::invalid_argument(
+                "invalid vector successive-orders ground values");
+        }
+        m_ground_values = values;
+    }
+
+    int ScatteringOperator<3>::ground_value_offset(int ground_block) const {
+        if (ground_block < 0 || ground_block >= m_layout.ground_blocks()) {
+            throw std::out_of_range(
+                "successive-orders ground scattering block out of range");
+        }
+        return m_ground_value_offsets[ground_block];
+    }
+
+    Eigen::Map<ScatteringOperator<3>::RowMajorMatrix>
+    ScatteringOperator<3>::ground_block(int ground_block) {
+        const int block = m_layout.atmospheric_blocks() + ground_block;
+        return {m_ground_values.data() + ground_value_offset(ground_block),
+                m_layout.output_block_size(block),
+                m_layout.input_block_size(block)};
+    }
+
+    Eigen::Map<const ScatteringOperator<3>::RowMajorMatrix>
+    ScatteringOperator<3>::ground_block(int ground_block) const {
+        const int block = m_layout.atmospheric_blocks() + ground_block;
+        return {m_ground_values.data() + ground_value_offset(ground_block),
+                m_layout.output_block_size(block),
+                m_layout.input_block_size(block)};
+    }
+
+    void ScatteringOperator<3>::set_ground_block(
+        int ground_block, Eigen::Ref<const Eigen::MatrixXd> values) {
+        auto target = this->ground_block(ground_block);
+        if (values.rows() != target.rows() || values.cols() != target.cols() ||
+            !values.allFinite()) {
+            throw std::invalid_argument(
+                "invalid vector successive-orders ground block");
+        }
+        target = values;
+    }
+
+    ScatteringMemoryUsage ScatteringOperator<3>::memory_usage(
+        const ScatteringWorkspace<3>* workspace) const {
+        ScatteringMemoryUsage result;
+        result.layout_bytes = m_layout.storage_bytes() +
+                              m_ground_value_offsets.capacity() * sizeof(int);
+        result.angular_basis_bytes = m_basis->storage_bytes();
+        result.atmospheric_value_bytes =
+            static_cast<std::size_t>(m_atmospheric_coefficients.size()) *
+            sizeof(double);
+        result.boundary_value_bytes =
+            static_cast<std::size_t>(m_ground_values.size()) * sizeof(double);
+        result.workspace_bytes =
+            workspace == nullptr ? 0 : workspace->storage_bytes();
+        return result;
+    }
+
+    void ScatteringOperator<3>::validate_input_output(
+        Eigen::Index incoming_size, Eigen::Index outgoing_size) const {
+        if (incoming_size != input_size() || outgoing_size != output_size()) {
+            throw std::invalid_argument(
+                "invalid vector successive-orders scattering vector sizes");
+        }
+    }
+
+    void ScatteringOperator<3>::prepare_workspace(
+        ScatteringWorkspace<3>& workspace) const {
+        workspace.prepare(m_layout.atmospheric_blocks(),
+                          m_basis->input_directions(),
+                          m_basis->output_directions());
+    }
+
+    ScatteringWorkspace<3> ScatteringOperator<3>::make_workspace() const {
+        ScatteringWorkspace<3> workspace;
+        prepare_workspace(workspace);
+        return workspace;
+    }
+
+    void
+    ScatteringOperator<3>::apply(Eigen::Ref<const Eigen::VectorXd> incoming,
+                                 Eigen::Ref<Eigen::VectorXd> outgoing,
+                                 ScatteringWorkspace<3>& workspace) const {
+        validate_input_output(incoming.size(), outgoing.size());
+        prepare_workspace(workspace);
+        pack_atmospheric_blocks(m_layout, incoming,
+                                workspace.m_atmospheric_input);
+        m_basis->apply_active(workspace.m_atmospheric_input,
+                              m_atmospheric_coefficients, m_active_coefficients,
+                              workspace.m_atmospheric_output,
+                              workspace.m_angular);
+        unpack_atmospheric_blocks(m_layout, workspace.m_atmospheric_output,
+                                  outgoing);
+        apply_dense_blocks(m_layout, m_layout.atmospheric_blocks(),
+                           m_ground_value_offsets, m_ground_values, incoming,
+                           outgoing);
+    }
+
+    void ScatteringOperator<3>::apply_transpose(
+        Eigen::Ref<const Eigen::VectorXd> outgoing,
+        Eigen::Ref<Eigen::VectorXd> incoming,
+        ScatteringWorkspace<3>& workspace) const {
+        validate_input_output(incoming.size(), outgoing.size());
+        prepare_workspace(workspace);
+        pack_atmospheric_output_blocks(m_layout, outgoing,
+                                       workspace.m_atmospheric_output);
+        m_basis->apply_transpose_active(
+            workspace.m_atmospheric_output, m_atmospheric_coefficients,
+            m_active_coefficients, workspace.m_atmospheric_input,
+            workspace.m_angular);
+        unpack_atmospheric_input_blocks(m_layout, workspace.m_atmospheric_input,
+                                        incoming);
+        apply_dense_blocks_transpose(m_layout, m_layout.atmospheric_blocks(),
+                                     m_ground_value_offsets, m_ground_values,
+                                     outgoing, incoming);
+    }
+
+    void ScatteringOperator<3>::apply_jvp(
+        Eigen::Ref<const Eigen::VectorXd> incoming,
+        Eigen::Ref<const Eigen::VectorXd> incoming_tangent,
+        Eigen::Ref<const Eigen::MatrixXd> coefficient_tangent,
+        Eigen::Ref<const Eigen::VectorXd> ground_value_tangent,
+        Eigen::Ref<Eigen::VectorXd> outgoing_tangent,
+        ScatteringWorkspace<3>& workspace) const {
+        validate_input_output(incoming.size(), outgoing_tangent.size());
+        if (incoming_tangent.size() != incoming.size() ||
+            coefficient_tangent.rows() != m_atmospheric_coefficients.rows() ||
+            coefficient_tangent.cols() != m_atmospheric_coefficients.cols()) {
+            throw std::invalid_argument(
+                "invalid vector successive-orders scattering JVP sizes");
+        }
+        validate_dense_tangent(m_ground_values, ground_value_tangent);
+        prepare_workspace(workspace);
+        pack_atmospheric_blocks(m_layout, incoming_tangent,
+                                workspace.m_auxiliary_input);
+        m_basis->apply_active(workspace.m_auxiliary_input,
+                              m_atmospheric_coefficients, m_active_coefficients,
+                              workspace.m_atmospheric_output,
+                              workspace.m_angular);
+        if (!coefficient_tangent.isZero(0.0)) {
+            int active_coefficients = m_active_coefficients;
+            for (int degree = m_basis->num_coefficients() - 1;
+                 degree >= m_active_coefficients; --degree) {
+                if (!coefficient_tangent.middleCols(4 * degree, 4)
+                         .isZero(0.0)) {
+                    active_coefficients = degree + 1;
+                    break;
+                }
+            }
+            pack_atmospheric_blocks(m_layout, incoming,
+                                    workspace.m_atmospheric_input);
+            m_basis->apply_active(workspace.m_atmospheric_input,
+                                  coefficient_tangent, active_coefficients,
+                                  workspace.m_auxiliary_output,
+                                  workspace.m_angular);
+            workspace.m_atmospheric_output += workspace.m_auxiliary_output;
+        }
+        unpack_atmospheric_blocks(m_layout, workspace.m_atmospheric_output,
+                                  outgoing_tangent);
+        apply_dense_blocks_jvp(m_layout, m_layout.atmospheric_blocks(),
+                               m_ground_value_offsets, m_ground_values,
+                               ground_value_tangent, incoming, incoming_tangent,
+                               outgoing_tangent);
+    }
+
+    void ScatteringOperator<3>::apply_vjp(
+        Eigen::Ref<const Eigen::VectorXd> incoming,
+        Eigen::Ref<const Eigen::VectorXd> outgoing_cotangent,
+        Eigen::Ref<Eigen::VectorXd> incoming_cotangent,
+        Eigen::Ref<Eigen::MatrixXd> coefficient_gradient,
+        Eigen::Ref<Eigen::VectorXd> ground_value_gradient,
+        ScatteringWorkspace<3>& workspace) const {
+        validate_input_output(incoming.size(), outgoing_cotangent.size());
+        if (incoming_cotangent.size() != incoming.size() ||
+            coefficient_gradient.rows() != m_atmospheric_coefficients.rows() ||
+            coefficient_gradient.cols() != m_atmospheric_coefficients.cols() ||
+            ground_value_gradient.size() != m_ground_values.size()) {
+            throw std::invalid_argument(
+                "invalid vector successive-orders scattering VJP sizes");
+        }
+        incoming_cotangent.setZero();
+        coefficient_gradient.setZero();
+        ground_value_gradient.setZero();
+        prepare_workspace(workspace);
+        pack_atmospheric_blocks(m_layout, incoming,
+                                workspace.m_atmospheric_input);
+        pack_atmospheric_output_blocks(m_layout, outgoing_cotangent,
+                                       workspace.m_atmospheric_output);
+        m_basis->apply_transpose_active(
+            workspace.m_atmospheric_output, m_atmospheric_coefficients,
+            m_active_coefficients, workspace.m_auxiliary_input,
+            workspace.m_angular);
+        unpack_atmospheric_input_blocks(m_layout, workspace.m_auxiliary_input,
+                                        incoming_cotangent);
+        m_basis->accumulate_coefficient_vjp(
+            workspace.m_atmospheric_input, workspace.m_atmospheric_output,
+            coefficient_gradient, workspace.m_angular);
+        apply_dense_blocks_vjp(m_layout, m_layout.atmospheric_blocks(),
+                               m_ground_value_offsets, m_ground_values,
+                               incoming, outgoing_cotangent, incoming_cotangent,
+                               ground_value_gradient);
+    }
+
+} // namespace sasktran2::successive_orders

--- a/cpp/lib/successive_orders/scattering.h
+++ b/cpp/lib/successive_orders/scattering.h
@@ -1,0 +1,302 @@
+#pragma once
+
+#include "angular_basis.h"
+
+#include <Eigen/Core>
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+namespace sasktran2::successive_orders {
+
+    /** Point-major block layout shared by scattering and ray transport.
+     *
+     * Each point owns a contiguous block of directions and each direction owns
+     * NSTOKES contiguous values. Atmospheric blocks precede boundary blocks.
+     * Explicit offsets allow a ground hemisphere to use fewer directions than
+     * an atmospheric sphere.
+     */
+    class ScatteringBlockLayout {
+      public:
+        ScatteringBlockLayout(int atmospheric_blocks, int stokes_components,
+                              std::vector<int> input_offsets,
+                              std::vector<int> output_offsets);
+
+        ScatteringBlockLayout(int atmospheric_blocks, int ground_blocks,
+                              int atmospheric_input_directions,
+                              int atmospheric_output_directions,
+                              int ground_input_directions,
+                              int ground_output_directions,
+                              int stokes_components);
+
+        int blocks() const {
+            return static_cast<int>(m_input_offsets.size()) - 1;
+        }
+        int atmospheric_blocks() const { return m_atmospheric_blocks; }
+        int ground_blocks() const { return blocks() - m_atmospheric_blocks; }
+        int stokes_components() const { return m_stokes_components; }
+        int input_size() const { return m_input_offsets.back(); }
+        int output_size() const { return m_output_offsets.back(); }
+
+        int input_block_size(int block) const;
+        int output_block_size(int block) const;
+        int input_directions(int block) const {
+            return input_block_size(block) / m_stokes_components;
+        }
+        int output_directions(int block) const {
+            return output_block_size(block) / m_stokes_components;
+        }
+
+        const std::vector<int>& input_offsets() const {
+            return m_input_offsets;
+        }
+        const std::vector<int>& output_offsets() const {
+            return m_output_offsets;
+        }
+        std::size_t storage_bytes() const;
+
+      private:
+        int m_atmospheric_blocks;
+        int m_stokes_components;
+        std::vector<int> m_input_offsets;
+        std::vector<int> m_output_offsets;
+    };
+
+    struct ScatteringMemoryUsage {
+        std::size_t layout_bytes = 0;
+        std::size_t angular_basis_bytes = 0;
+        std::size_t atmospheric_value_bytes = 0;
+        std::size_t boundary_value_bytes = 0;
+        std::size_t workspace_bytes = 0;
+
+        std::size_t operator_bytes() const {
+            return layout_bytes + angular_basis_bytes +
+                   atmospheric_value_bytes + boundary_value_bytes;
+        }
+        std::size_t total_bytes() const {
+            return operator_bytes() + workspace_bytes;
+        }
+    };
+
+    template <int NSTOKES> class ScatteringOperator;
+    template <int NSTOKES> class ScatteringWorkspace;
+
+    template <> class ScatteringWorkspace<1> {
+      public:
+        ScatteringWorkspace() = default;
+
+        std::size_t storage_bytes() const;
+
+      private:
+        friend class ScatteringOperator<1>;
+        void prepare(int atmospheric_blocks, int input_directions,
+                     int output_directions, int modes);
+
+        Eigen::MatrixXd m_atmospheric_input;
+        Eigen::MatrixXd m_atmospheric_output;
+        Eigen::MatrixXd m_auxiliary_input;
+        Eigen::MatrixXd m_moments;
+        Eigen::MatrixXd m_auxiliary_moments;
+    };
+
+    /** Scalar scattering with coefficient-space atmospheric blocks.
+     *
+     * The expensive angular basis is stored once. Each atmospheric point only
+     * stores its Legendre coefficients. Ground blocks remain dense because a
+     * general BRDF is not diagonal in the atmospheric angular basis.
+     */
+    template <> class ScatteringOperator<1> {
+      public:
+        using RowMajorMatrix = Eigen::Matrix<double, Eigen::Dynamic,
+                                             Eigen::Dynamic, Eigen::RowMajor>;
+
+        ScatteringOperator(ScatteringBlockLayout layout,
+                           ScalarAngularBasis angular_basis);
+        ScatteringOperator(
+            ScatteringBlockLayout layout,
+            std::shared_ptr<const ScalarAngularBasis> angular_basis);
+
+        const ScatteringBlockLayout& layout() const { return m_layout; }
+        const std::vector<int>& input_offsets() const {
+            return m_layout.input_offsets();
+        }
+        const std::vector<int>& output_offsets() const {
+            return m_layout.output_offsets();
+        }
+        int input_size() const { return m_layout.input_size(); }
+        int output_size() const { return m_layout.output_size(); }
+
+        const ScalarAngularBasis& angular_basis() const { return *m_basis; }
+        Eigen::MatrixXd& atmospheric_coefficients() {
+            // Mutable access can activate any trailing mode. Callers that know
+            // the resulting exact active count may narrow it after filling.
+            m_active_coefficients = m_basis->num_coefficients();
+            return m_atmospheric_coefficients;
+        }
+        const Eigen::MatrixXd& atmospheric_coefficients() const {
+            return m_atmospheric_coefficients;
+        }
+        Eigen::VectorXd& ground_values() { return m_ground_values; }
+        const Eigen::VectorXd& ground_values() const { return m_ground_values; }
+
+        int coefficient_value_size() const {
+            return static_cast<int>(m_atmospheric_coefficients.size());
+        }
+        int ground_value_size() const {
+            return static_cast<int>(m_ground_values.size());
+        }
+
+        void set_active_coefficients(int active_coefficients);
+        int active_coefficients() const { return m_active_coefficients; }
+
+        void set_atmospheric_coefficients(
+            Eigen::Ref<const Eigen::MatrixXd> coefficients);
+        void set_ground_values(Eigen::Ref<const Eigen::VectorXd> values);
+        void set_ground_block(int ground_block,
+                              Eigen::Ref<const Eigen::MatrixXd> values);
+
+        Eigen::Map<RowMajorMatrix> ground_block(int ground_block);
+        Eigen::Map<const RowMajorMatrix> ground_block(int ground_block) const;
+
+        ScatteringWorkspace<1> make_workspace() const;
+        ScatteringMemoryUsage
+        memory_usage(const ScatteringWorkspace<1>* workspace = nullptr) const;
+
+        void apply(Eigen::Ref<const Eigen::VectorXd> incoming,
+                   Eigen::Ref<Eigen::VectorXd> outgoing,
+                   ScatteringWorkspace<1>& workspace) const;
+        void apply_transpose(Eigen::Ref<const Eigen::VectorXd> outgoing,
+                             Eigen::Ref<Eigen::VectorXd> incoming,
+                             ScatteringWorkspace<1>& workspace) const;
+
+        void apply_jvp(Eigen::Ref<const Eigen::VectorXd> incoming,
+                       Eigen::Ref<const Eigen::VectorXd> incoming_tangent,
+                       Eigen::Ref<const Eigen::MatrixXd> coefficient_tangent,
+                       Eigen::Ref<const Eigen::VectorXd> ground_value_tangent,
+                       Eigen::Ref<Eigen::VectorXd> outgoing_tangent,
+                       ScatteringWorkspace<1>& workspace) const;
+
+        void apply_vjp(Eigen::Ref<const Eigen::VectorXd> incoming,
+                       Eigen::Ref<const Eigen::VectorXd> outgoing_cotangent,
+                       Eigen::Ref<Eigen::VectorXd> incoming_cotangent,
+                       Eigen::Ref<Eigen::MatrixXd> coefficient_gradient,
+                       Eigen::Ref<Eigen::VectorXd> ground_value_gradient,
+                       ScatteringWorkspace<1>& workspace) const;
+
+      private:
+        void prepare_workspace(ScatteringWorkspace<1>& workspace) const;
+        void validate_input_output(Eigen::Index incoming_size,
+                                   Eigen::Index outgoing_size) const;
+        int ground_value_offset(int ground_block) const;
+
+        ScatteringBlockLayout m_layout;
+        std::shared_ptr<const ScalarAngularBasis> m_basis;
+        Eigen::MatrixXd m_atmospheric_coefficients;
+        std::vector<int> m_ground_value_offsets;
+        Eigen::VectorXd m_ground_values;
+        int m_active_coefficients = 1;
+    };
+
+    template <> class ScatteringWorkspace<3> {
+      public:
+        std::size_t storage_bytes() const;
+
+      private:
+        friend class ScatteringOperator<3>;
+        void prepare(int atmospheric_blocks, int input_directions,
+                     int output_directions);
+
+        Eigen::MatrixXd m_atmospheric_input;
+        Eigen::MatrixXd m_atmospheric_output;
+        Eigen::MatrixXd m_auxiliary_input;
+        Eigen::MatrixXd m_auxiliary_output;
+        VectorAngularWorkspace m_angular;
+    };
+
+    /** Coefficient-space I/Q/U atmospheric scattering with dense boundaries. */
+    template <> class ScatteringOperator<3> {
+      public:
+        using RowMajorMatrix = Eigen::Matrix<double, Eigen::Dynamic,
+                                             Eigen::Dynamic, Eigen::RowMajor>;
+
+        ScatteringOperator(
+            ScatteringBlockLayout layout,
+            std::shared_ptr<const VectorAngularBasis> angular_basis);
+
+        const ScatteringBlockLayout& layout() const { return m_layout; }
+        const std::vector<int>& input_offsets() const {
+            return m_layout.input_offsets();
+        }
+        const std::vector<int>& output_offsets() const {
+            return m_layout.output_offsets();
+        }
+        int input_size() const { return m_layout.input_size(); }
+        int output_size() const { return m_layout.output_size(); }
+
+        Eigen::MatrixXd& atmospheric_coefficients() {
+            m_active_coefficients = m_basis->num_coefficients();
+            return m_atmospheric_coefficients;
+        }
+        const Eigen::MatrixXd& atmospheric_coefficients() const {
+            return m_atmospheric_coefficients;
+        }
+        Eigen::VectorXd& ground_values() { return m_ground_values; }
+        const Eigen::VectorXd& ground_values() const { return m_ground_values; }
+
+        int coefficient_value_size() const {
+            return static_cast<int>(m_atmospheric_coefficients.size());
+        }
+        int ground_value_size() const {
+            return static_cast<int>(m_ground_values.size());
+        }
+
+        void set_active_coefficients(int active_coefficients);
+        int active_coefficients() const { return m_active_coefficients; }
+        void set_atmospheric_coefficients(
+            Eigen::Ref<const Eigen::MatrixXd> coefficients);
+        void set_ground_values(Eigen::Ref<const Eigen::VectorXd> values);
+        void set_ground_block(int ground_block,
+                              Eigen::Ref<const Eigen::MatrixXd> values);
+
+        Eigen::Map<RowMajorMatrix> ground_block(int ground_block);
+        Eigen::Map<const RowMajorMatrix> ground_block(int ground_block) const;
+
+        ScatteringWorkspace<3> make_workspace() const;
+        ScatteringMemoryUsage
+        memory_usage(const ScatteringWorkspace<3>* workspace = nullptr) const;
+
+        void apply(Eigen::Ref<const Eigen::VectorXd> incoming,
+                   Eigen::Ref<Eigen::VectorXd> outgoing,
+                   ScatteringWorkspace<3>& workspace) const;
+        void apply_transpose(Eigen::Ref<const Eigen::VectorXd> outgoing,
+                             Eigen::Ref<Eigen::VectorXd> incoming,
+                             ScatteringWorkspace<3>& workspace) const;
+        void apply_jvp(Eigen::Ref<const Eigen::VectorXd> incoming,
+                       Eigen::Ref<const Eigen::VectorXd> incoming_tangent,
+                       Eigen::Ref<const Eigen::MatrixXd> coefficient_tangent,
+                       Eigen::Ref<const Eigen::VectorXd> ground_value_tangent,
+                       Eigen::Ref<Eigen::VectorXd> outgoing_tangent,
+                       ScatteringWorkspace<3>& workspace) const;
+        void apply_vjp(Eigen::Ref<const Eigen::VectorXd> incoming,
+                       Eigen::Ref<const Eigen::VectorXd> outgoing_cotangent,
+                       Eigen::Ref<Eigen::VectorXd> incoming_cotangent,
+                       Eigen::Ref<Eigen::MatrixXd> coefficient_gradient,
+                       Eigen::Ref<Eigen::VectorXd> ground_value_gradient,
+                       ScatteringWorkspace<3>& workspace) const;
+
+      private:
+        void validate_input_output(Eigen::Index incoming_size,
+                                   Eigen::Index outgoing_size) const;
+        void prepare_workspace(ScatteringWorkspace<3>& workspace) const;
+        int ground_value_offset(int ground_block) const;
+
+        ScatteringBlockLayout m_layout;
+        std::shared_ptr<const VectorAngularBasis> m_basis;
+        std::vector<int> m_ground_value_offsets;
+        Eigen::MatrixXd m_atmospheric_coefficients;
+        Eigen::VectorXd m_ground_values;
+        int m_active_coefficients = 1;
+    };
+
+} // namespace sasktran2::successive_orders

--- a/cpp/lib/successive_orders/scattering_assembler.cpp
+++ b/cpp/lib/successive_orders/scattering_assembler.cpp
@@ -1,0 +1,911 @@
+#include "scattering_assembler.h"
+
+#include <sasktran2/math/scattering.h>
+#include <sasktran2/math/wigner.h>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+#include <utility>
+
+namespace sasktran2::successive_orders {
+    namespace {
+        ScatteringBlockLayout make_layout(const SourceGeometry1D& geometry) {
+            if (geometry.num_interior_points() < 1 ||
+                geometry.num_points() < 1 ||
+                geometry.incoming_point_offsets().size() !=
+                    static_cast<std::size_t>(geometry.num_points()) + 1 ||
+                geometry.outgoing_point_offsets().size() !=
+                    static_cast<std::size_t>(geometry.num_points()) + 1) {
+                throw std::invalid_argument(
+                    "successive-orders scattering assembly requires "
+                    "initialized source geometry");
+            }
+            return {geometry.num_interior_points(), 1,
+                    geometry.incoming_point_offsets(),
+                    geometry.outgoing_point_offsets()};
+        }
+
+        std::shared_ptr<const ScalarAngularBasis>
+        make_basis(const SourceGeometry1D& geometry, int num_coefficients) {
+            if (num_coefficients < 1 || geometry.num_interior_points() < 1) {
+                throw std::invalid_argument(
+                    "invalid scalar successive-orders coefficient count");
+            }
+            const auto& point = geometry.source_point(0);
+            return std::make_shared<const ScalarAngularBasis>(
+                point.incoming_sphere(), point.outgoing_sphere(),
+                num_coefficients);
+        }
+
+        int checked_dense_size(int rows, int columns) {
+            const auto size = static_cast<long long>(rows) * columns;
+            if (rows < 0 || columns < 0 ||
+                size > std::numeric_limits<int>::max()) {
+                throw std::length_error(
+                    "successive-orders ground scattering size exceeds the "
+                    "supported range");
+            }
+            return static_cast<int>(size);
+        }
+
+        Eigen::Vector3d
+        deterministic_horizontal(const Eigen::Vector3d& normal) {
+            const Eigen::Vector3d reference = std::abs(normal.z()) < 0.9
+                                                  ? Eigen::Vector3d::UnitZ()
+                                                  : Eigen::Vector3d::UnitX();
+            return (reference - reference.dot(normal) * normal).normalized();
+        }
+
+        Eigen::Vector3d
+        horizontal_direction(const Eigen::Vector3d& direction,
+                             const Eigen::Vector3d& normal,
+                             const Eigen::Vector3d& vertical_fallback) {
+            const Eigen::Vector3d projection =
+                direction - direction.dot(normal) * normal;
+            const double norm = projection.norm();
+            if (!std::isfinite(norm) ||
+                norm <= 64.0 * std::numeric_limits<double>::epsilon()) {
+                // Azimuth is physically undefined for a vertical direction,
+                // but an anisotropic BRDF still requires a finite convention.
+                return vertical_fallback;
+            }
+            return projection / norm;
+        }
+
+        double relative_azimuth(const Eigen::Vector3d& horizontal_in,
+                                const Eigen::Vector3d& horizontal_out) {
+            const double cosine =
+                std::clamp(horizontal_in.dot(horizontal_out), -1.0, 1.0);
+            // Preserve the legacy HR relative-azimuth convention.
+            return EIGEN_PI - std::acos(cosine);
+        }
+
+        std::vector<int> stokes_offsets(const std::vector<int>& offsets,
+                                        int stokes_components) {
+            std::vector<int> result(offsets.size());
+            for (std::size_t index = 0; index < offsets.size(); ++index) {
+                if (offsets[index] < 0 ||
+                    offsets[index] >
+                        std::numeric_limits<int>::max() / stokes_components) {
+                    throw std::length_error(
+                        "successive-orders Stokes layout exceeds the "
+                        "supported range");
+                }
+                result[index] = offsets[index] * stokes_components;
+            }
+            return result;
+        }
+
+        ScatteringBlockLayout
+        make_vector_layout(const SourceGeometry1D& geometry) {
+            // Reuse the scalar validation before applying the Stokes stride.
+            static_cast<void>(make_layout(geometry));
+            return {geometry.num_interior_points(), 3,
+                    stokes_offsets(geometry.incoming_point_offsets(), 3),
+                    stokes_offsets(geometry.outgoing_point_offsets(), 3)};
+        }
+
+        std::vector<int> make_dense_offsets(const ScatteringBlockLayout& layout,
+                                            int first_block, int block_count) {
+            std::vector<int> offsets(static_cast<std::size_t>(block_count) + 1,
+                                     0);
+            for (int local_block = 0; local_block < block_count;
+                 ++local_block) {
+                const int block = first_block + local_block;
+                const int block_size =
+                    checked_dense_size(layout.output_block_size(block),
+                                       layout.input_block_size(block));
+                if (offsets[local_block] >
+                    std::numeric_limits<int>::max() - block_size) {
+                    throw std::length_error(
+                        "successive-orders dense scattering storage exceeds "
+                        "the supported range");
+                }
+                offsets[local_block + 1] = offsets[local_block] + block_size;
+            }
+            return offsets;
+        }
+
+        template <typename Storage>
+        double delta_m_coefficient_scale(const Storage& storage, int location,
+                                         int wavelength) {
+            if (storage.applied_f_order <= 0) {
+                return 0.0;
+            }
+            const double f = storage.f(location, wavelength);
+            return f / (1.0 - f);
+        }
+
+        template <typename Storage>
+        double delta_m_derivative_scale(const Storage& storage, int location,
+                                        int wavelength, int group) {
+            if (storage.applied_f_order <= 0) {
+                return 0.0;
+            }
+            const double f = storage.f(location, wavelength);
+            return storage.d_f(location, wavelength, group) /
+                   ((1.0 - f) * (1.0 - f));
+        }
+
+        bool delta_m_corrects_vector_component(int coefficient) {
+            // The forward delta peak contributes to the three generalized
+            // spherical-function "a" coefficients, but not to b1.
+            return coefficient % 4 != 3;
+        }
+    } // namespace
+
+    ScalarScatteringAssembler::ScalarScatteringAssembler(
+        const SourceGeometry1D& geometry, int num_coefficients)
+        : m_geometry(&geometry), m_layout(make_layout(geometry)),
+          m_angular_basis(make_basis(geometry, num_coefficients)) {
+        for (int point_index = 0; point_index < geometry.num_interior_points();
+             ++point_index) {
+            const auto& point = geometry.source_point(point_index);
+            if (point.num_incoming() != m_angular_basis->input_size() ||
+                point.num_outgoing() != m_angular_basis->output_size()) {
+                throw std::invalid_argument(
+                    "scalar successive-orders atmospheric angular grids "
+                    "must share one basis");
+            }
+        }
+
+        m_ground_value_offsets.assign(
+            static_cast<std::size_t>(geometry.num_ground_points()) + 1, 0);
+        m_ground_geometry.resize(geometry.num_ground_points());
+        for (int ground_index = 0; ground_index < geometry.num_ground_points();
+             ++ground_index) {
+            const int point_index =
+                geometry.num_interior_points() + ground_index;
+            const auto& point = geometry.source_point(point_index);
+            const int rows = point.num_outgoing();
+            const int columns = point.num_incoming();
+            const int block_size = checked_dense_size(rows, columns);
+            if (m_ground_value_offsets[ground_index] >
+                std::numeric_limits<int>::max() - block_size) {
+                throw std::length_error(
+                    "successive-orders ground scattering storage exceeds "
+                    "the supported range");
+            }
+            m_ground_value_offsets[ground_index + 1] =
+                m_ground_value_offsets[ground_index] + block_size;
+
+            auto& angular = m_ground_geometry[ground_index];
+            angular.mu_in.resize(columns);
+            angular.weighted_mu_in.resize(columns);
+            angular.mu_out.resize(rows);
+            angular.phi_difference.resize(rows, columns);
+            const Eigen::Vector3d normal =
+                point.location().position.normalized();
+            const Eigen::Vector3d vertical_fallback =
+                deterministic_horizontal(normal);
+            std::vector<Eigen::Vector3d> horizontal_in(columns);
+            std::vector<Eigen::Vector3d> horizontal_out(rows);
+            for (int input = 0; input < columns; ++input) {
+                const Eigen::Vector3d direction =
+                    point.incoming_sphere().get_quad_position(input);
+                angular.mu_in(input) =
+                    point.location().cos_zenith_angle(direction);
+                angular.weighted_mu_in(input) =
+                    4.0 * EIGEN_PI * angular.mu_in(input) *
+                    point.incoming_sphere().quadrature_weight(input);
+                horizontal_in[input] =
+                    horizontal_direction(direction, normal, vertical_fallback);
+            }
+            for (int output = 0; output < rows; ++output) {
+                const Eigen::Vector3d direction =
+                    point.outgoing_sphere().get_quad_position(output);
+                angular.mu_out(output) =
+                    point.location().cos_zenith_angle(direction);
+                horizontal_out[output] =
+                    horizontal_direction(direction, normal, vertical_fallback);
+            }
+            for (int output = 0; output < rows; ++output) {
+                for (int input = 0; input < columns; ++input) {
+                    angular.phi_difference(output, input) = relative_azimuth(
+                        horizontal_in[input], horizontal_out[output]);
+                }
+            }
+        }
+    }
+
+    ScatteringOperator<1> ScalarScatteringAssembler::create_operator() const {
+        return {m_layout, m_angular_basis};
+    }
+
+    void ScalarScatteringAssembler::validate_atmosphere(
+        const sasktran2::atmosphere::Atmosphere<1>& atmosphere,
+        int wavelength) const {
+        const auto& storage = atmosphere.storage();
+        if (wavelength < 0 || wavelength >= atmosphere.num_wavel() ||
+            m_angular_basis->num_coefficients() >
+                storage.max_stored_legendre() ||
+            atmosphere.surface().brdf_args().cols() != atmosphere.num_wavel()) {
+            throw std::invalid_argument(
+                "atmosphere does not match scalar successive-orders "
+                "scattering assembly");
+        }
+        for (const auto& point : m_geometry->source_points()) {
+            for (const auto& weight : point.atmosphere_weights()) {
+                if (weight.index < 0 ||
+                    weight.index >= storage.total_extinction.rows()) {
+                    throw std::invalid_argument(
+                        "successive-orders source interpolation exceeds the "
+                        "atmosphere grid");
+                }
+            }
+        }
+    }
+
+    void ScalarScatteringAssembler::validate_operator(
+        const ScatteringOperator<1>& scattering) const {
+        if (scattering.input_offsets() != m_layout.input_offsets() ||
+            scattering.output_offsets() != m_layout.output_offsets() ||
+            scattering.layout().atmospheric_blocks() !=
+                m_layout.atmospheric_blocks() ||
+            scattering.atmospheric_coefficients().rows() !=
+                m_geometry->num_interior_points() ||
+            scattering.atmospheric_coefficients().cols() !=
+                m_angular_basis->num_coefficients() ||
+            scattering.ground_value_size() != ground_value_size()) {
+            throw std::invalid_argument(
+                "scattering operator does not match its successive-orders "
+                "assembler");
+        }
+    }
+
+    void ScalarScatteringAssembler::validate_native_product(
+        const sasktran2::atmosphere::Atmosphere<1>& atmosphere,
+        Eigen::Index native_size) const {
+        if (native_size != atmosphere.num_deriv()) {
+            throw std::invalid_argument(
+                "invalid native tangent or gradient size for scalar "
+                "successive-orders scattering");
+        }
+        const auto& storage = atmosphere.storage();
+        if (atmosphere.num_scattering_deriv_groups() !=
+                storage.d_leg_coeff.dimension(3) ||
+            (atmosphere.num_scattering_deriv_groups() != 0 &&
+             (storage.d_leg_coeff.dimension(0) <
+                  m_angular_basis->num_coefficients() ||
+              storage.d_leg_coeff.dimension(1) !=
+                  storage.total_extinction.rows() ||
+              storage.d_leg_coeff.dimension(2) != atmosphere.num_wavel()))) {
+            throw std::invalid_argument(
+                "invalid native Legendre derivative storage for scalar "
+                "successive-orders scattering");
+        }
+    }
+
+    void ScalarScatteringAssembler::assemble_ground(
+        const sasktran2::atmosphere::Atmosphere<1>& atmosphere, int wavelength,
+        Eigen::VectorXd& values) const {
+        values.resize(ground_value_size());
+        for (int ground_index = 0;
+             ground_index < m_geometry->num_ground_points(); ++ground_index) {
+            const auto& angular = m_ground_geometry[ground_index];
+            const int rows = static_cast<int>(angular.mu_out.size());
+            const int columns = static_cast<int>(angular.mu_in.size());
+            const int offset = m_ground_value_offsets[ground_index];
+            for (int output = 0; output < rows; ++output) {
+                for (int input = 0; input < columns; ++input) {
+                    const auto brdf = atmosphere.surface().brdf(
+                        wavelength, angular.mu_in(input),
+                        angular.mu_out(output),
+                        angular.phi_difference(output, input));
+                    values(offset + output * columns + input) =
+                        angular.weighted_mu_in(input) * brdf(0, 0);
+                }
+            }
+        }
+    }
+
+    void ScalarScatteringAssembler::assemble_values(
+        const sasktran2::atmosphere::Atmosphere<1>& atmosphere, int wavelength,
+        ScatteringOperator<1>& scattering) const {
+        validate_atmosphere(atmosphere, wavelength);
+        validate_operator(scattering);
+        auto& coefficients = scattering.atmospheric_coefficients();
+        coefficients.setZero();
+        const auto& storage = atmosphere.storage();
+        for (int point_index = 0;
+             point_index < m_geometry->num_interior_points(); ++point_index) {
+            for (const auto& weight :
+                 m_geometry->source_point(point_index).atmosphere_weights()) {
+                const double delta_m_scale = delta_m_coefficient_scale(
+                    storage, weight.index, wavelength);
+                for (int degree = 0;
+                     degree < m_angular_basis->num_coefficients(); ++degree) {
+                    const double coefficient =
+                        storage.leg_coeff(degree, weight.index, wavelength) -
+                        (2.0 * degree + 1.0) * delta_m_scale;
+                    coefficients(point_index, degree) +=
+                        weight.weight * coefficient;
+                }
+            }
+        }
+        int active_coefficients = 1;
+        for (int degree = coefficients.cols() - 1; degree >= 1; --degree) {
+            if (!coefficients.col(degree).isZero(0.0)) {
+                active_coefficients = degree + 1;
+                break;
+            }
+        }
+        scattering.set_active_coefficients(active_coefficients);
+        assemble_ground(atmosphere, wavelength, scattering.ground_values());
+    }
+
+    void ScalarScatteringAssembler::assemble_jvp(
+        const sasktran2::atmosphere::Atmosphere<1>& atmosphere, int wavelength,
+        Eigen::Ref<const Eigen::VectorXd> native_tangent,
+        Eigen::MatrixXd& atmospheric_coefficient_tangent,
+        Eigen::VectorXd& ground_value_tangent) const {
+        validate_atmosphere(atmosphere, wavelength);
+        validate_native_product(atmosphere, native_tangent.size());
+        atmospheric_coefficient_tangent.setZero(
+            m_geometry->num_interior_points(),
+            m_angular_basis->num_coefficients());
+        ground_value_tangent.setZero(ground_value_size());
+        if (atmosphere.num_deriv() == 0) {
+            return;
+        }
+
+        const auto& storage = atmosphere.storage();
+        const int locations = storage.total_extinction.rows();
+        for (int point_index = 0;
+             point_index < m_geometry->num_interior_points(); ++point_index) {
+            for (const auto& weight :
+                 m_geometry->source_point(point_index).atmosphere_weights()) {
+                for (int group = 0;
+                     group < atmosphere.num_scattering_deriv_groups();
+                     ++group) {
+                    const double direction =
+                        native_tangent(atmosphere.scat_deriv_start_index() +
+                                       group * locations + weight.index);
+                    if (direction == 0.0) {
+                        continue;
+                    }
+                    const double delta_m_scale = delta_m_derivative_scale(
+                        storage, weight.index, wavelength, group);
+                    for (int degree = 0;
+                         degree < m_angular_basis->num_coefficients();
+                         ++degree) {
+                        const double coefficient_tangent =
+                            storage.d_leg_coeff(degree, weight.index,
+                                                wavelength, group) -
+                            (2.0 * degree + 1.0) * delta_m_scale;
+                        atmospheric_coefficient_tangent(point_index, degree) +=
+                            weight.weight * direction * coefficient_tangent;
+                    }
+                }
+            }
+        }
+
+        for (int ground_index = 0;
+             ground_index < m_geometry->num_ground_points(); ++ground_index) {
+            const auto& angular = m_ground_geometry[ground_index];
+            const int rows = static_cast<int>(angular.mu_out.size());
+            const int columns = static_cast<int>(angular.mu_in.size());
+            const int offset = m_ground_value_offsets[ground_index];
+            for (int derivative = 0;
+                 derivative < atmosphere.surface().num_deriv(); ++derivative) {
+                const double direction = native_tangent(
+                    atmosphere.surface_deriv_start_index() + derivative);
+                if (direction == 0.0) {
+                    continue;
+                }
+                for (int output = 0; output < rows; ++output) {
+                    for (int input = 0; input < columns; ++input) {
+                        const auto derivative_brdf =
+                            atmosphere.surface().d_brdf(
+                                wavelength, angular.mu_in(input),
+                                angular.mu_out(output),
+                                angular.phi_difference(output, input),
+                                derivative);
+                        ground_value_tangent(offset + output * columns +
+                                             input) +=
+                            direction * angular.weighted_mu_in(input) *
+                            derivative_brdf(0, 0);
+                    }
+                }
+            }
+        }
+    }
+
+    void ScalarScatteringAssembler::accumulate_vjp(
+        const sasktran2::atmosphere::Atmosphere<1>& atmosphere, int wavelength,
+        Eigen::Ref<const Eigen::MatrixXd> atmospheric_coefficient_gradient,
+        Eigen::Ref<const Eigen::VectorXd> ground_value_gradient,
+        Eigen::Ref<Eigen::VectorXd> native_gradient) const {
+        validate_atmosphere(atmosphere, wavelength);
+        validate_native_product(atmosphere, native_gradient.size());
+        if (atmospheric_coefficient_gradient.rows() !=
+                m_geometry->num_interior_points() ||
+            atmospheric_coefficient_gradient.cols() !=
+                m_angular_basis->num_coefficients() ||
+            ground_value_gradient.size() != ground_value_size()) {
+            throw std::invalid_argument(
+                "invalid scattering cotangent dimensions for native VJP");
+        }
+        if (atmosphere.num_deriv() == 0) {
+            return;
+        }
+
+        const auto& storage = atmosphere.storage();
+        const int locations = storage.total_extinction.rows();
+            for (int point_index = 0;
+                 point_index < m_geometry->num_interior_points();
+                 ++point_index) {
+                for (const auto& weight : m_geometry->source_point(point_index)
+                                              .atmosphere_weights()) {
+                    for (int group = 0;
+                         group < atmosphere.num_scattering_deriv_groups();
+                         ++group) {
+                        double value = 0.0;
+                        const double delta_m_scale = delta_m_derivative_scale(
+                            storage, weight.index, wavelength, group);
+                        for (int degree = 0;
+                             degree < m_angular_basis->num_coefficients();
+                             ++degree) {
+                            const double coefficient_derivative =
+                                storage.d_leg_coeff(degree, weight.index,
+                                                    wavelength, group) -
+                                (2.0 * degree + 1.0) * delta_m_scale;
+                            value += atmospheric_coefficient_gradient(
+                                         point_index, degree) *
+                                     weight.weight * coefficient_derivative;
+                        }
+                        native_gradient(atmosphere.scat_deriv_start_index() +
+                                        group * locations + weight.index) +=
+                            value;
+                    }
+                }
+            }
+        for (int ground_index = 0;
+             ground_index < m_geometry->num_ground_points();
+             ++ground_index) {
+            const auto& angular = m_ground_geometry[ground_index];
+            const int rows = static_cast<int>(angular.mu_out.size());
+            const int columns = static_cast<int>(angular.mu_in.size());
+            const int offset = m_ground_value_offsets[ground_index];
+            for (int derivative = 0;
+                 derivative < atmosphere.surface().num_deriv(); ++derivative) {
+                double value = 0.0;
+                for (int output = 0; output < rows; ++output) {
+                    for (int input = 0; input < columns; ++input) {
+                        const auto derivative_brdf =
+                            atmosphere.surface().d_brdf(
+                                wavelength, angular.mu_in(input),
+                                angular.mu_out(output),
+                                angular.phi_difference(output, input),
+                                derivative);
+                        value += ground_value_gradient(
+                                     offset + output * columns + input) *
+                                 angular.weighted_mu_in(input) *
+                                 derivative_brdf(0, 0);
+                    }
+                }
+                native_gradient(atmosphere.surface_deriv_start_index() +
+                                derivative) += value;
+            }
+        }
+    }
+
+    std::size_t ScalarScatteringAssembler::storage_bytes() const {
+        std::size_t result =
+            m_layout.storage_bytes() + m_angular_basis->storage_bytes() +
+            m_ground_value_offsets.capacity() * sizeof(int) +
+            m_ground_geometry.capacity() * sizeof(GroundAngularGeometry);
+        for (const auto& geometry : m_ground_geometry) {
+            result += geometry.storage_bytes();
+        }
+        return result;
+    }
+
+    VectorScatteringAssembler::VectorScatteringAssembler(
+        const SourceGeometry1D& geometry, int num_coefficients)
+        : m_geometry(&geometry), m_layout(make_vector_layout(geometry)),
+          m_ground_value_offsets(
+              make_dense_offsets(m_layout, geometry.num_interior_points(),
+                                 geometry.num_ground_points())) {
+        if (num_coefficients < 1) {
+            throw std::invalid_argument(
+                "invalid vector successive-orders coefficient count");
+        }
+
+        const auto& atmospheric_point = geometry.source_point(0);
+        m_angular_basis = std::make_shared<const VectorAngularBasis>(
+            atmospheric_point.incoming_sphere(),
+            atmospheric_point.outgoing_sphere(), num_coefficients);
+
+        for (int point_index = 0; point_index < geometry.num_interior_points();
+             ++point_index) {
+            const auto& point = geometry.source_point(point_index);
+            if (point.num_incoming() != m_angular_basis->input_directions() ||
+                point.num_outgoing() != m_angular_basis->output_directions()) {
+                throw std::invalid_argument(
+                    "vector successive-orders atmospheric angular grids "
+                    "must share one basis");
+            }
+        }
+
+        m_ground_geometry.resize(geometry.num_ground_points());
+        for (int ground_index = 0; ground_index < geometry.num_ground_points();
+             ++ground_index) {
+            const int point_index =
+                geometry.num_interior_points() + ground_index;
+            const auto& point = geometry.source_point(point_index);
+            const int rows = point.num_outgoing();
+            const int columns = point.num_incoming();
+            auto& ground = m_ground_geometry[ground_index];
+            ground.mu_in.resize(columns);
+            ground.weighted_mu_in.resize(columns);
+            ground.mu_out.resize(rows);
+            ground.phi_difference.resize(rows, columns);
+            const Eigen::Vector3d normal =
+                point.location().position.normalized();
+            const Eigen::Vector3d vertical_fallback =
+                deterministic_horizontal(normal);
+            std::vector<Eigen::Vector3d> horizontal_in(columns);
+            std::vector<Eigen::Vector3d> horizontal_out(rows);
+            for (int input = 0; input < columns; ++input) {
+                const Eigen::Vector3d direction =
+                    point.incoming_sphere().get_quad_position(input);
+                ground.mu_in(input) =
+                    point.location().cos_zenith_angle(direction);
+                ground.weighted_mu_in(input) =
+                    4.0 * EIGEN_PI * ground.mu_in(input) *
+                    point.incoming_sphere().quadrature_weight(input);
+                horizontal_in[input] =
+                    horizontal_direction(direction, normal, vertical_fallback);
+            }
+            for (int output = 0; output < rows; ++output) {
+                const Eigen::Vector3d direction =
+                    point.outgoing_sphere().get_quad_position(output);
+                ground.mu_out(output) =
+                    point.location().cos_zenith_angle(direction);
+                horizontal_out[output] =
+                    horizontal_direction(direction, normal, vertical_fallback);
+            }
+            for (int output = 0; output < rows; ++output) {
+                for (int input = 0; input < columns; ++input) {
+                    ground.phi_difference(output, input) = relative_azimuth(
+                        horizontal_in[input], horizontal_out[output]);
+                }
+            }
+        }
+    }
+
+    ScatteringOperator<3> VectorScatteringAssembler::create_operator() const {
+        return ScatteringOperator<3>(m_layout, m_angular_basis);
+    }
+
+    void VectorScatteringAssembler::validate_atmosphere(
+        const sasktran2::atmosphere::Atmosphere<3>& atmosphere,
+        int wavelength) const {
+        const auto& storage = atmosphere.storage();
+        if (wavelength < 0 || wavelength >= atmosphere.num_wavel() ||
+            num_coefficients() > storage.max_stored_legendre() ||
+            atmosphere.surface().brdf_args().cols() != atmosphere.num_wavel()) {
+            throw std::invalid_argument(
+                "atmosphere does not match vector successive-orders "
+                "scattering assembly");
+        }
+        for (const auto& point : m_geometry->source_points()) {
+            for (const auto& weight : point.atmosphere_weights()) {
+                if (weight.index < 0 ||
+                    weight.index >= storage.total_extinction.rows()) {
+                    throw std::invalid_argument(
+                        "successive-orders source interpolation exceeds the "
+                        "atmosphere grid");
+                }
+            }
+        }
+    }
+
+    void VectorScatteringAssembler::validate_operator(
+        const ScatteringOperator<3>& scattering) const {
+        if (scattering.input_offsets() != m_layout.input_offsets() ||
+            scattering.output_offsets() != m_layout.output_offsets() ||
+            scattering.layout().atmospheric_blocks() !=
+                m_layout.atmospheric_blocks() ||
+            scattering.coefficient_value_size() != coefficient_value_size() ||
+            scattering.ground_value_size() != ground_value_size()) {
+            throw std::invalid_argument(
+                "scattering operator does not match its vector "
+                "successive-orders assembler");
+        }
+    }
+
+    void VectorScatteringAssembler::validate_native_product(
+        const sasktran2::atmosphere::Atmosphere<3>& atmosphere,
+        Eigen::Index native_size) const {
+        if (native_size != atmosphere.num_deriv()) {
+            throw std::invalid_argument(
+                "invalid native tangent or gradient size for vector "
+                "successive-orders scattering");
+        }
+        const auto& storage = atmosphere.storage();
+        if (atmosphere.num_scattering_deriv_groups() !=
+                storage.d_leg_coeff.dimension(3) ||
+            (atmosphere.num_scattering_deriv_groups() != 0 &&
+             (storage.d_leg_coeff.dimension(0) < 4 * num_coefficients() ||
+              storage.d_leg_coeff.dimension(1) !=
+                  storage.total_extinction.rows() ||
+              storage.d_leg_coeff.dimension(2) != atmosphere.num_wavel()))) {
+            throw std::invalid_argument(
+                "invalid native Greek-coefficient derivative storage for "
+                "vector successive-orders scattering");
+        }
+    }
+
+    void VectorScatteringAssembler::assemble_ground(
+        const sasktran2::atmosphere::Atmosphere<3>& atmosphere, int wavelength,
+        Eigen::VectorXd& values) const {
+        values.setZero(ground_value_size());
+        for (int ground_index = 0;
+             ground_index < m_geometry->num_ground_points(); ++ground_index) {
+            const auto& angular = m_ground_geometry[ground_index];
+            const int rows = static_cast<int>(angular.mu_out.size());
+            const int columns = static_cast<int>(angular.mu_in.size());
+            Eigen::Map<RowMajorMatrix> block(
+                values.data() + m_ground_value_offsets[ground_index], 3 * rows,
+                3 * columns);
+            for (int output = 0; output < rows; ++output) {
+                for (int input = 0; input < columns; ++input) {
+                    const auto brdf = atmosphere.surface().brdf(
+                        wavelength, angular.mu_in(input),
+                        angular.mu_out(output),
+                        angular.phi_difference(output, input));
+                    // Match the legacy HR ground convention: the BRDF only
+                    // contributes to I <- I for vector radiance.
+                    block(3 * output, 3 * input) =
+                        angular.weighted_mu_in(input) * brdf(0, 0);
+                }
+            }
+        }
+    }
+
+    void VectorScatteringAssembler::assemble_values(
+        const sasktran2::atmosphere::Atmosphere<3>& atmosphere, int wavelength,
+        ScatteringOperator<3>& scattering) const {
+        validate_atmosphere(atmosphere, wavelength);
+        validate_operator(scattering);
+        auto& coefficients = scattering.atmospheric_coefficients();
+        coefficients.setZero();
+        const auto& storage = atmosphere.storage();
+        for (int point_index = 0;
+             point_index < m_geometry->num_interior_points(); ++point_index) {
+            for (const auto& weight :
+                 m_geometry->source_point(point_index).atmosphere_weights()) {
+                const double delta_m_scale = delta_m_coefficient_scale(
+                    storage, weight.index, wavelength);
+                for (int coefficient = 0; coefficient < coefficients.cols();
+                     ++coefficient) {
+                    const int degree = coefficient / 4;
+                    const double delta_m_correction =
+                        delta_m_corrects_vector_component(coefficient)
+                            ? (2.0 * degree + 1.0) * delta_m_scale
+                            : 0.0;
+                    coefficients(point_index, coefficient) +=
+                        weight.weight *
+                        (storage.leg_coeff(coefficient, weight.index,
+                                           wavelength) -
+                         delta_m_correction);
+                }
+            }
+        }
+        int active_coefficients = 1;
+        for (int degree = num_coefficients() - 1; degree >= 1; --degree) {
+            if (!coefficients.middleCols(4 * degree, 4).isZero(0.0)) {
+                active_coefficients = degree + 1;
+                break;
+            }
+        }
+        scattering.set_active_coefficients(active_coefficients);
+        assemble_ground(atmosphere, wavelength, scattering.ground_values());
+    }
+
+    void VectorScatteringAssembler::assemble_jvp(
+        const sasktran2::atmosphere::Atmosphere<3>& atmosphere, int wavelength,
+        Eigen::Ref<const Eigen::VectorXd> native_tangent,
+        Eigen::MatrixXd& atmospheric_coefficient_tangent,
+        Eigen::VectorXd& ground_value_tangent) const {
+        validate_atmosphere(atmosphere, wavelength);
+        validate_native_product(atmosphere, native_tangent.size());
+        atmospheric_coefficient_tangent.setZero(
+            m_geometry->num_interior_points(), 4 * num_coefficients());
+        ground_value_tangent.setZero(ground_value_size());
+        if (atmosphere.num_deriv() == 0) {
+            return;
+        }
+
+        const auto& storage = atmosphere.storage();
+        const int locations = storage.total_extinction.rows();
+        for (int point_index = 0;
+             point_index < m_geometry->num_interior_points(); ++point_index) {
+            for (const auto& weight :
+                 m_geometry->source_point(point_index).atmosphere_weights()) {
+                for (int group = 0;
+                     group < atmosphere.num_scattering_deriv_groups();
+                     ++group) {
+                    const double direction =
+                        native_tangent(atmosphere.scat_deriv_start_index() +
+                                       group * locations + weight.index);
+                    if (direction == 0.0) {
+                        continue;
+                    }
+                    const double delta_m_scale = delta_m_derivative_scale(
+                        storage, weight.index, wavelength, group);
+                    for (int coefficient = 0;
+                         coefficient < atmospheric_coefficient_tangent.cols();
+                         ++coefficient) {
+                        const int degree = coefficient / 4;
+                        const double delta_m_correction =
+                            delta_m_corrects_vector_component(coefficient)
+                                ? (2.0 * degree + 1.0) * delta_m_scale
+                                : 0.0;
+                        atmospheric_coefficient_tangent(point_index,
+                                                        coefficient) +=
+                            weight.weight * direction *
+                            (storage.d_leg_coeff(coefficient, weight.index,
+                                                 wavelength, group) -
+                             delta_m_correction);
+                    }
+                }
+            }
+        }
+
+        for (int ground_index = 0;
+             ground_index < m_geometry->num_ground_points(); ++ground_index) {
+            const auto& angular = m_ground_geometry[ground_index];
+            const int rows = static_cast<int>(angular.mu_out.size());
+            const int columns = static_cast<int>(angular.mu_in.size());
+            Eigen::Map<RowMajorMatrix> block(
+                ground_value_tangent.data() +
+                    m_ground_value_offsets[ground_index],
+                3 * rows, 3 * columns);
+            for (int derivative = 0;
+                 derivative < atmosphere.surface().num_deriv(); ++derivative) {
+                const double direction = native_tangent(
+                    atmosphere.surface_deriv_start_index() + derivative);
+                if (direction == 0.0) {
+                    continue;
+                }
+                for (int output = 0; output < rows; ++output) {
+                    for (int input = 0; input < columns; ++input) {
+                        const auto derivative_brdf =
+                            atmosphere.surface().d_brdf(
+                                wavelength, angular.mu_in(input),
+                                angular.mu_out(output),
+                                angular.phi_difference(output, input),
+                                derivative);
+                        block(3 * output, 3 * input) +=
+                            direction * angular.weighted_mu_in(input) *
+                            derivative_brdf(0, 0);
+                    }
+                }
+            }
+        }
+    }
+
+    void VectorScatteringAssembler::accumulate_vjp(
+        const sasktran2::atmosphere::Atmosphere<3>& atmosphere, int wavelength,
+        Eigen::Ref<const Eigen::MatrixXd> atmospheric_coefficient_gradient,
+        Eigen::Ref<const Eigen::VectorXd> ground_value_gradient,
+        Eigen::Ref<Eigen::VectorXd> native_gradient) const {
+        validate_atmosphere(atmosphere, wavelength);
+        validate_native_product(atmosphere, native_gradient.size());
+        if (atmospheric_coefficient_gradient.rows() !=
+                m_geometry->num_interior_points() ||
+            atmospheric_coefficient_gradient.cols() != 4 * num_coefficients() ||
+            ground_value_gradient.size() != ground_value_size()) {
+            throw std::invalid_argument(
+                "invalid vector scattering cotangent dimensions for native "
+                "VJP");
+        }
+        if (atmosphere.num_deriv() == 0) {
+            return;
+        }
+
+        const auto& storage = atmosphere.storage();
+        const int locations = storage.total_extinction.rows();
+            for (int point_index = 0;
+                 point_index < m_geometry->num_interior_points();
+                 ++point_index) {
+                for (const auto& weight : m_geometry->source_point(point_index)
+                                              .atmosphere_weights()) {
+                    for (int group = 0;
+                         group < atmosphere.num_scattering_deriv_groups();
+                         ++group) {
+                        double value = 0.0;
+                        const double delta_m_scale = delta_m_derivative_scale(
+                            storage, weight.index, wavelength, group);
+                        for (int coefficient = 0;
+                             coefficient <
+                             atmospheric_coefficient_gradient.cols();
+                             ++coefficient) {
+                            const int degree = coefficient / 4;
+                            const double delta_m_correction =
+                                delta_m_corrects_vector_component(coefficient)
+                                    ? (2.0 * degree + 1.0) * delta_m_scale
+                                    : 0.0;
+                            value +=
+                                atmospheric_coefficient_gradient(point_index,
+                                                                 coefficient) *
+                                weight.weight *
+                                (storage.d_leg_coeff(coefficient, weight.index,
+                                                     wavelength, group) -
+                                 delta_m_correction);
+                        }
+                        native_gradient(atmosphere.scat_deriv_start_index() +
+                                        group * locations + weight.index) +=
+                            value;
+                    }
+                }
+            }
+        for (int ground_index = 0;
+             ground_index < m_geometry->num_ground_points();
+             ++ground_index) {
+            const auto& angular = m_ground_geometry[ground_index];
+            const int rows = static_cast<int>(angular.mu_out.size());
+            const int columns = static_cast<int>(angular.mu_in.size());
+            Eigen::Map<const RowMajorMatrix> block_gradient(
+                ground_value_gradient.data() +
+                    m_ground_value_offsets[ground_index],
+                3 * rows, 3 * columns);
+            for (int derivative = 0;
+                 derivative < atmosphere.surface().num_deriv(); ++derivative) {
+                double value = 0.0;
+                for (int output = 0; output < rows; ++output) {
+                    for (int input = 0; input < columns; ++input) {
+                        const auto derivative_brdf =
+                            atmosphere.surface().d_brdf(
+                                wavelength, angular.mu_in(input),
+                                angular.mu_out(output),
+                                angular.phi_difference(output, input),
+                                derivative);
+                        value += block_gradient(3 * output, 3 * input) *
+                                 angular.weighted_mu_in(input) *
+                                 derivative_brdf(0, 0);
+                    }
+                }
+                native_gradient(atmosphere.surface_deriv_start_index() +
+                                derivative) += value;
+            }
+        }
+    }
+
+    std::size_t VectorScatteringAssembler::storage_bytes() const {
+        std::size_t result =
+            m_layout.storage_bytes() + m_angular_basis->storage_bytes() +
+            m_ground_value_offsets.capacity() * sizeof(int) +
+            m_ground_geometry.capacity() * sizeof(GroundAngularGeometry);
+        for (const auto& geometry : m_ground_geometry) {
+            result += geometry.storage_bytes();
+        }
+        return result;
+    }
+
+} // namespace sasktran2::successive_orders

--- a/cpp/lib/successive_orders/scattering_assembler.cpp
+++ b/cpp/lib/successive_orders/scattering_assembler.cpp
@@ -454,37 +454,34 @@ namespace sasktran2::successive_orders {
 
         const auto& storage = atmosphere.storage();
         const int locations = storage.total_extinction.rows();
-            for (int point_index = 0;
-                 point_index < m_geometry->num_interior_points();
-                 ++point_index) {
-                for (const auto& weight : m_geometry->source_point(point_index)
-                                              .atmosphere_weights()) {
-                    for (int group = 0;
-                         group < atmosphere.num_scattering_deriv_groups();
-                         ++group) {
-                        double value = 0.0;
-                        const double delta_m_scale = delta_m_derivative_scale(
-                            storage, weight.index, wavelength, group);
-                        for (int degree = 0;
-                             degree < m_angular_basis->num_coefficients();
-                             ++degree) {
-                            const double coefficient_derivative =
-                                storage.d_leg_coeff(degree, weight.index,
-                                                    wavelength, group) -
-                                (2.0 * degree + 1.0) * delta_m_scale;
-                            value += atmospheric_coefficient_gradient(
-                                         point_index, degree) *
-                                     weight.weight * coefficient_derivative;
-                        }
-                        native_gradient(atmosphere.scat_deriv_start_index() +
-                                        group * locations + weight.index) +=
-                            value;
+        for (int point_index = 0;
+             point_index < m_geometry->num_interior_points(); ++point_index) {
+            for (const auto& weight :
+                 m_geometry->source_point(point_index).atmosphere_weights()) {
+                for (int group = 0;
+                     group < atmosphere.num_scattering_deriv_groups();
+                     ++group) {
+                    double value = 0.0;
+                    const double delta_m_scale = delta_m_derivative_scale(
+                        storage, weight.index, wavelength, group);
+                    for (int degree = 0;
+                         degree < m_angular_basis->num_coefficients();
+                         ++degree) {
+                        const double coefficient_derivative =
+                            storage.d_leg_coeff(degree, weight.index,
+                                                wavelength, group) -
+                            (2.0 * degree + 1.0) * delta_m_scale;
+                        value += atmospheric_coefficient_gradient(point_index,
+                                                                  degree) *
+                                 weight.weight * coefficient_derivative;
                     }
+                    native_gradient(atmosphere.scat_deriv_start_index() +
+                                    group * locations + weight.index) += value;
                 }
             }
+        }
         for (int ground_index = 0;
-             ground_index < m_geometry->num_ground_points();
-             ++ground_index) {
+             ground_index < m_geometry->num_ground_points(); ++ground_index) {
             const auto& angular = m_ground_geometry[ground_index];
             const int rows = static_cast<int>(angular.mu_out.size());
             const int columns = static_cast<int>(angular.mu_in.size());
@@ -831,43 +828,38 @@ namespace sasktran2::successive_orders {
 
         const auto& storage = atmosphere.storage();
         const int locations = storage.total_extinction.rows();
-            for (int point_index = 0;
-                 point_index < m_geometry->num_interior_points();
-                 ++point_index) {
-                for (const auto& weight : m_geometry->source_point(point_index)
-                                              .atmosphere_weights()) {
-                    for (int group = 0;
-                         group < atmosphere.num_scattering_deriv_groups();
-                         ++group) {
-                        double value = 0.0;
-                        const double delta_m_scale = delta_m_derivative_scale(
-                            storage, weight.index, wavelength, group);
-                        for (int coefficient = 0;
-                             coefficient <
-                             atmospheric_coefficient_gradient.cols();
-                             ++coefficient) {
-                            const int degree = coefficient / 4;
-                            const double delta_m_correction =
-                                delta_m_corrects_vector_component(coefficient)
-                                    ? (2.0 * degree + 1.0) * delta_m_scale
-                                    : 0.0;
-                            value +=
-                                atmospheric_coefficient_gradient(point_index,
-                                                                 coefficient) *
-                                weight.weight *
-                                (storage.d_leg_coeff(coefficient, weight.index,
-                                                     wavelength, group) -
-                                 delta_m_correction);
-                        }
-                        native_gradient(atmosphere.scat_deriv_start_index() +
-                                        group * locations + weight.index) +=
-                            value;
+        for (int point_index = 0;
+             point_index < m_geometry->num_interior_points(); ++point_index) {
+            for (const auto& weight :
+                 m_geometry->source_point(point_index).atmosphere_weights()) {
+                for (int group = 0;
+                     group < atmosphere.num_scattering_deriv_groups();
+                     ++group) {
+                    double value = 0.0;
+                    const double delta_m_scale = delta_m_derivative_scale(
+                        storage, weight.index, wavelength, group);
+                    for (int coefficient = 0;
+                         coefficient < atmospheric_coefficient_gradient.cols();
+                         ++coefficient) {
+                        const int degree = coefficient / 4;
+                        const double delta_m_correction =
+                            delta_m_corrects_vector_component(coefficient)
+                                ? (2.0 * degree + 1.0) * delta_m_scale
+                                : 0.0;
+                        value += atmospheric_coefficient_gradient(point_index,
+                                                                  coefficient) *
+                                 weight.weight *
+                                 (storage.d_leg_coeff(coefficient, weight.index,
+                                                      wavelength, group) -
+                                  delta_m_correction);
                     }
+                    native_gradient(atmosphere.scat_deriv_start_index() +
+                                    group * locations + weight.index) += value;
                 }
             }
+        }
         for (int ground_index = 0;
-             ground_index < m_geometry->num_ground_points();
-             ++ground_index) {
+             ground_index < m_geometry->num_ground_points(); ++ground_index) {
             const auto& angular = m_ground_geometry[ground_index];
             const int rows = static_cast<int>(angular.mu_out.size());
             const int columns = static_cast<int>(angular.mu_in.size());

--- a/cpp/lib/successive_orders/scattering_assembler.h
+++ b/cpp/lib/successive_orders/scattering_assembler.h
@@ -1,0 +1,169 @@
+#pragma once
+
+#include "geometry.h"
+#include "scattering.h"
+
+#include <sasktran2/atmosphere/atmosphere.h>
+
+#include <Eigen/Core>
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+namespace sasktran2::successive_orders {
+
+    /** Geometry-only assembly of the scalar point scattering operator.
+     *
+     * Atmospheric points retain Legendre coefficients rather than dense
+     * angular matrices. Ground BRDF geometry is precomputed once, while BRDF
+     * values remain wavelength and atmosphere dependent. Native derivative
+     * products use Atmosphere's standard scattering-group and surface slots.
+     */
+    class ScalarScatteringAssembler {
+      public:
+        ScalarScatteringAssembler(const SourceGeometry1D& geometry,
+                                  int num_coefficients);
+
+        const ScatteringBlockLayout& layout() const { return m_layout; }
+        int num_coefficients() const {
+            return m_angular_basis->num_coefficients();
+        }
+        int ground_value_size() const { return m_ground_value_offsets.back(); }
+
+        ScatteringOperator<1> create_operator() const;
+
+        void
+        assemble_values(const sasktran2::atmosphere::Atmosphere<1>& atmosphere,
+                        int wavelength,
+                        ScatteringOperator<1>& scattering) const;
+
+        /** Maps a native atmospheric tangent into scattering parameters. */
+        void
+        assemble_jvp(const sasktran2::atmosphere::Atmosphere<1>& atmosphere,
+                     int wavelength,
+                     Eigen::Ref<const Eigen::VectorXd> native_tangent,
+                     Eigen::MatrixXd& atmospheric_coefficient_tangent,
+                     Eigen::VectorXd& ground_value_tangent) const;
+
+        /** Accumulates scattering-parameter cotangents into native slots. */
+        void accumulate_vjp(
+            const sasktran2::atmosphere::Atmosphere<1>& atmosphere,
+            int wavelength,
+            Eigen::Ref<const Eigen::MatrixXd> atmospheric_coefficient_gradient,
+            Eigen::Ref<const Eigen::VectorXd> ground_value_gradient,
+            Eigen::Ref<Eigen::VectorXd> native_gradient) const;
+
+        std::size_t storage_bytes() const;
+
+      private:
+        struct GroundAngularGeometry {
+            Eigen::VectorXd mu_in;
+            Eigen::VectorXd weighted_mu_in;
+            Eigen::VectorXd mu_out;
+            Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic,
+                          Eigen::RowMajor>
+                phi_difference;
+
+            std::size_t storage_bytes() const {
+                return static_cast<std::size_t>(
+                           mu_in.size() + weighted_mu_in.size() +
+                           mu_out.size() + phi_difference.size()) *
+                       sizeof(double);
+            }
+        };
+
+        void validate_atmosphere(
+            const sasktran2::atmosphere::Atmosphere<1>& atmosphere,
+            int wavelength) const;
+        void validate_operator(const ScatteringOperator<1>& scattering) const;
+        void validate_native_product(
+            const sasktran2::atmosphere::Atmosphere<1>& atmosphere,
+            Eigen::Index native_size) const;
+        void
+        assemble_ground(const sasktran2::atmosphere::Atmosphere<1>& atmosphere,
+                        int wavelength, Eigen::VectorXd& values) const;
+
+        const SourceGeometry1D* m_geometry;
+        ScatteringBlockLayout m_layout;
+        std::shared_ptr<const ScalarAngularBasis> m_angular_basis;
+        std::vector<int> m_ground_value_offsets;
+        std::vector<GroundAngularGeometry> m_ground_geometry;
+    };
+
+    /** Geometry-only assembly of coefficient-space I/Q/U scattering. */
+    class VectorScatteringAssembler {
+      public:
+        VectorScatteringAssembler(const SourceGeometry1D& geometry,
+                                  int num_coefficients);
+
+        const ScatteringBlockLayout& layout() const { return m_layout; }
+        int num_coefficients() const {
+            return m_angular_basis->num_coefficients();
+        }
+        int coefficient_value_size() const {
+            return m_layout.atmospheric_blocks() * 4 * num_coefficients();
+        }
+        int ground_value_size() const { return m_ground_value_offsets.back(); }
+
+        ScatteringOperator<3> create_operator() const;
+
+        void
+        assemble_values(const sasktran2::atmosphere::Atmosphere<3>& atmosphere,
+                        int wavelength,
+                        ScatteringOperator<3>& scattering) const;
+
+        /** Maps a native atmospheric tangent into dense scattering values. */
+        void
+        assemble_jvp(const sasktran2::atmosphere::Atmosphere<3>& atmosphere,
+                     int wavelength,
+                     Eigen::Ref<const Eigen::VectorXd> native_tangent,
+                     Eigen::MatrixXd& atmospheric_coefficient_tangent,
+                     Eigen::VectorXd& ground_value_tangent) const;
+
+        /** Accumulates dense scattering cotangents into native slots. */
+        void accumulate_vjp(
+            const sasktran2::atmosphere::Atmosphere<3>& atmosphere,
+            int wavelength,
+            Eigen::Ref<const Eigen::MatrixXd> atmospheric_coefficient_gradient,
+            Eigen::Ref<const Eigen::VectorXd> ground_value_gradient,
+            Eigen::Ref<Eigen::VectorXd> native_gradient) const;
+
+        std::size_t storage_bytes() const;
+
+      private:
+        using RowMajorMatrix = ScatteringOperator<3>::RowMajorMatrix;
+
+        struct GroundAngularGeometry {
+            Eigen::VectorXd mu_in;
+            Eigen::VectorXd weighted_mu_in;
+            Eigen::VectorXd mu_out;
+            RowMajorMatrix phi_difference;
+
+            std::size_t storage_bytes() const {
+                return static_cast<std::size_t>(
+                           mu_in.size() + weighted_mu_in.size() +
+                           mu_out.size() + phi_difference.size()) *
+                       sizeof(double);
+            }
+        };
+
+        void validate_atmosphere(
+            const sasktran2::atmosphere::Atmosphere<3>& atmosphere,
+            int wavelength) const;
+        void validate_operator(const ScatteringOperator<3>& scattering) const;
+        void validate_native_product(
+            const sasktran2::atmosphere::Atmosphere<3>& atmosphere,
+            Eigen::Index native_size) const;
+        void
+        assemble_ground(const sasktran2::atmosphere::Atmosphere<3>& atmosphere,
+                        int wavelength, Eigen::VectorXd& values) const;
+
+        const SourceGeometry1D* m_geometry;
+        ScatteringBlockLayout m_layout;
+        std::shared_ptr<const VectorAngularBasis> m_angular_basis;
+        std::vector<int> m_ground_value_offsets;
+        std::vector<GroundAngularGeometry> m_ground_geometry;
+    };
+
+} // namespace sasktran2::successive_orders

--- a/cpp/lib/successive_orders/source.cpp
+++ b/cpp/lib/successive_orders/source.cpp
@@ -472,8 +472,7 @@ namespace sasktran2::successive_orders {
             auto gradient = native_gradient.col(0);
             warn_if_implicit_derivative_is_unchecked(m_solver_settings,
                                                      block.start, "VJP");
-            reverse(block.start, threadidx, work, work.los_cotangent,
-                    gradient);
+            reverse(block.start, threadidx, work, work.los_cotangent, gradient);
         }
 
         void start_of_ray_source(
@@ -718,8 +717,7 @@ namespace sasktran2::successive_orders {
                     native_gradient, work.transport_vjp_workspace);
             }
             Adapter::accumulate_vjp(*m_scattering_assembler, *m_atmosphere,
-                                    wavelength, work.gradient,
-                                    native_gradient);
+                                    wavelength, work.gradient, native_gradient);
             if (m_first_order.uses_compact_scalar_kernel()) {
                 if (work.transport_state_projected) {
                     m_first_order.accumulate_vjp_with_projected_transport(
@@ -732,9 +730,9 @@ namespace sasktran2::successive_orders {
                         work.gradient.forcing, native_gradient);
                 }
             } else {
-                m_first_order.accumulate_vjp(
-                    wavelength, threadidx, work.gradient.forcing,
-                    native_gradient);
+                m_first_order.accumulate_vjp(wavelength, threadidx,
+                                             work.gradient.forcing,
+                                             native_gradient);
             }
         }
 
@@ -893,8 +891,7 @@ namespace sasktran2::successive_orders {
     template class SuccessiveOrdersSource<3>;
 
     template <int NSTOKES>
-    std::unique_ptr<SourceTermInterface<NSTOKES>>
-    make_successive_orders_source(
+    std::unique_ptr<SourceTermInterface<NSTOKES>> make_successive_orders_source(
         const sasktran2::raytracing::RayTracerBase& raytracer,
         const sasktran2::Geometry1D& geometry) {
         return std::make_unique<SuccessiveOrdersSource<NSTOKES>>(raytracer,

--- a/cpp/lib/successive_orders/source.cpp
+++ b/cpp/lib/successive_orders/source.cpp
@@ -1,0 +1,913 @@
+#include "factory.h"
+
+#include "first_order.h"
+#include "fixed_point.h"
+#include "geometry.h"
+#include "problem.h"
+#include "ray_transport.h"
+#include "scattering_assembler.h"
+
+#include <sasktran2/geometry.h>
+
+#include <spdlog/spdlog.h>
+
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace sasktran2::successive_orders {
+    /** Private concrete source. Engine code interacts with it only through the
+     * SourceTermInterface returned by make_successive_orders_source(). */
+    template <int NSTOKES>
+    class SuccessiveOrdersSource final : public SourceTermInterface<NSTOKES> {
+      public:
+        SuccessiveOrdersSource(
+            const sasktran2::raytracing::RayTracerBase& raytracer,
+            const sasktran2::Geometry1D& geometry);
+        ~SuccessiveOrdersSource() override;
+
+        SuccessiveOrdersSource(const SuccessiveOrdersSource&) = delete;
+        SuccessiveOrdersSource&
+        operator=(const SuccessiveOrdersSource&) = delete;
+
+        void initialize_config(const sasktran2::Config& config) override;
+        void initialize_geometry(
+            const sasktran2::viewinggeometry::InternalViewingGeometry&
+                internal_viewing) override;
+        void initialize_atmosphere(
+            const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere)
+            override;
+
+        void calculate(const sasktran2::WavelengthBlock<>& block,
+                       int threadidx) override;
+        void calculate_jvp(
+            const sasktran2::WavelengthBlock<>& block, int threadidx,
+            Eigen::Ref<const Eigen::VectorXd> native_tangent) override;
+        void calculate_vjp(const sasktran2::WavelengthBlock<>& block,
+                           int threadidx) override;
+        void finalize_vjp(
+            const sasktran2::WavelengthBlock<>& block, int threadidx,
+            Eigen::Ref<Eigen::MatrixXd> native_gradient) const override;
+
+        int maximum_wavelength_block_size() const override { return 1; }
+        bool requires_integration() const override { return false; }
+        bool has_interior_source() const override { return false; }
+        bool supports_linearization(
+            sasktran2::LinearizationMode mode) const override;
+        bool supports_geometry_dimension(int dimension) const override {
+            return dimension == 1;
+        }
+        bool supports_sparse_derivative_tracking() const override {
+            return true;
+        }
+
+        void integrated_source(
+            const sasktran2::WavelengthBlock<>&, int, int, int, int,
+            const sasktran2::raytracing::TracedLayer&,
+            const sasktran2::raytracing::GridWeightStencilView&,
+            const sasktran2::raytracing::GridWeightStencilView&,
+            const sasktran2::WavelengthBlockODView&,
+            sasktran2::WavelengthBlockDual<NSTOKES>&,
+            typename SourceTermInterface<NSTOKES>::IntegrationDirection)
+            const override {}
+
+        void end_of_ray_source(
+            const sasktran2::WavelengthBlock<>&, int, int, int,
+            sasktran2::WavelengthBlockDual<NSTOKES>&) const override {}
+        void start_of_ray_source(
+            const sasktran2::WavelengthBlock<>& block, int losidx,
+            int wavel_threadidx, int threadidx,
+            sasktran2::WavelengthBlockDual<NSTOKES>& source) const override;
+
+        void
+        end_of_ray_source_jvp(int, int, int, int,
+                              Eigen::Ref<const Eigen::VectorXd>,
+                              sasktran2::RadianceJVP<NSTOKES>&) const override {
+        }
+        void start_of_ray_source_jvp(
+            int wavelength, int losidx, int wavel_threadidx, int threadidx,
+            Eigen::Ref<const Eigen::VectorXd> native_tangent,
+            sasktran2::RadianceJVP<NSTOKES>& source) const override;
+
+        void end_of_ray_source_vjp(int, int, int, int,
+                                   const Eigen::Vector<double, NSTOKES>&,
+                                   Eigen::Vector<double, NSTOKES>&,
+                                   Eigen::Ref<Eigen::VectorXd>) const override {
+        }
+        void start_of_ray_source_vjp(
+            int wavelength, int losidx, int wavel_threadidx, int threadidx,
+            const Eigen::Vector<double, NSTOKES>& value_before,
+            Eigen::Vector<double, NSTOKES>& cotangent,
+            Eigen::Ref<Eigen::VectorXd> native_gradient) const override;
+
+      private:
+        class Impl;
+        std::unique_ptr<Impl> m_impl;
+    };
+
+    namespace {
+        void warn_if_not_converged(const FixedPointDiagnostics& diagnostics,
+                                   const FixedPointSettings& settings,
+                                   int wavelength, const char* calculation) {
+            if (settings.convergence_enabled() && !diagnostics.converged()) {
+                spdlog::warn(
+                    "C++ successive-orders {} did not converge at wavelength "
+                    "index {} after {} iterations (residual {}, threshold "
+                    "{}). Returning the current result; its accuracy may be "
+                    "reduced.",
+                    calculation, wavelength, diagnostics.iterations,
+                    diagnostics.residual_norm,
+                    diagnostics.convergence_threshold);
+            }
+        }
+
+        void warn_if_implicit_derivative_is_unchecked(
+            const FixedPointSettings& settings, int wavelength,
+            const char* calculation) {
+            if (!settings.convergence_enabled()) {
+                spdlog::warn(
+                    "C++ successive-orders {} was requested at wavelength "
+                    "index {} with convergence tolerances disabled. The "
+                    "implicit derivative assumes a converged fixed point and "
+                    "may differ from the derivative of the configured "
+                    "fixed-count primal iteration.",
+                    calculation, wavelength);
+            }
+        }
+
+        void validate_single_wavelength_block(
+            const sasktran2::WavelengthBlock<>& block) {
+            if (block.count != 1) {
+                throw std::invalid_argument(
+                    "The C++ successive-orders source currently processes "
+                    "one wavelength per block");
+            }
+        }
+    } // namespace
+
+    template <int NSTOKES> struct ScatteringAssemblerAdapter;
+
+    template <> struct ScatteringAssemblerAdapter<1> {
+        using Assembler = ScalarScatteringAssembler;
+
+        static void
+        assemble_jvp(const Assembler& assembler,
+                     const sasktran2::atmosphere::Atmosphere<1>& atmosphere,
+                     int wavelength,
+                     Eigen::Ref<const Eigen::VectorXd> native_tangent,
+                     ProblemParameterData<1>& tangent) {
+            assembler.assemble_jvp(atmosphere, wavelength, native_tangent,
+                                   tangent.atmospheric_coefficients,
+                                   tangent.ground_values);
+        }
+
+        static void
+        accumulate_vjp(const Assembler& assembler,
+                       const sasktran2::atmosphere::Atmosphere<1>& atmosphere,
+                       int wavelength, const ProblemParameterData<1>& gradient,
+                       Eigen::Ref<Eigen::VectorXd> native_gradient) {
+            assembler.accumulate_vjp(atmosphere, wavelength,
+                                     gradient.atmospheric_coefficients,
+                                     gradient.ground_values, native_gradient);
+        }
+    };
+
+    template <> struct ScatteringAssemblerAdapter<3> {
+        using Assembler = VectorScatteringAssembler;
+
+        static void
+        assemble_jvp(const Assembler& assembler,
+                     const sasktran2::atmosphere::Atmosphere<3>& atmosphere,
+                     int wavelength,
+                     Eigen::Ref<const Eigen::VectorXd> native_tangent,
+                     ProblemParameterData<3>& tangent) {
+            assembler.assemble_jvp(atmosphere, wavelength, native_tangent,
+                                   tangent.atmospheric_coefficients,
+                                   tangent.ground_values);
+        }
+
+        static void
+        accumulate_vjp(const Assembler& assembler,
+                       const sasktran2::atmosphere::Atmosphere<3>& atmosphere,
+                       int wavelength, const ProblemParameterData<3>& gradient,
+                       Eigen::Ref<Eigen::VectorXd> native_gradient) {
+            assembler.accumulate_vjp(atmosphere, wavelength,
+                                     gradient.atmospheric_coefficients,
+                                     gradient.ground_values, native_gradient);
+        }
+    };
+
+    /** Shared scalar/vector driver.  Only scattering-parameter assembly differs
+     * between the scalar and polarized coefficient-space operators; transport,
+     * fixed-point solves, and native products use identical state and thread
+     * ownership. */
+    template <int NSTOKES> class SuccessiveOrdersImplementation {
+      private:
+        using Adapter = ScatteringAssemblerAdapter<NSTOKES>;
+        using Assembler = typename Adapter::Assembler;
+        using Atmosphere = sasktran2::atmosphere::Atmosphere<NSTOKES>;
+
+        struct WavelengthState {
+            WavelengthState(const RayTransportMap& transport_map,
+                            const RayTransportMap& los_map,
+                            const Assembler& assembler)
+                : transport(transport_map.sparsity()),
+                  los_transport(los_map.sparsity()),
+                  scattering(assembler.create_operator()),
+                  problem(transport, scattering) {
+                workspace.resize(transport, scattering);
+                forcing.resize(scattering.input_size());
+                state.resize(scattering.output_size());
+                state_tangent.resize(scattering.output_size());
+                direct_transport_tangent.resize(scattering.input_size());
+                const int los_size = los_transport.sparsity().rows() * NSTOKES;
+                los_value.resize(los_size);
+                los_tangent.resize(los_size);
+                los_cotangent.resize(los_size);
+                state_cotangent.resize(scattering.output_size());
+                los_value_gradient.resize(los_transport.values().size());
+                los_transport_tangent.resize(los_transport.values().size());
+            }
+
+            TransportOperator transport;
+            TransportOperator los_transport;
+            ScatteringOperator<NSTOKES> scattering;
+            Problem<NSTOKES> problem;
+            ProblemWorkspace<NSTOKES> workspace;
+            ProblemParameterData<NSTOKES> tangent;
+            ProblemParameterData<NSTOKES> gradient;
+            RayTransportWorkspace transport_vjp_workspace;
+            RayTransportWorkspace los_vjp_workspace;
+            Eigen::VectorXd forcing;
+            Eigen::VectorXd state;
+            Eigen::VectorXd state_tangent;
+            Eigen::VectorXd layer_state_projection;
+            Eigen::VectorXd ground_state_projection;
+            Eigen::VectorXd direct_transport_tangent;
+            Eigen::VectorXd los_value;
+            Eigen::VectorXd los_tangent;
+            Eigen::VectorXd los_cotangent;
+            Eigen::VectorXd state_cotangent;
+            Eigen::VectorXd los_value_gradient;
+            Eigen::VectorXd los_transport_tangent;
+            Eigen::VectorXd adjoint;
+            Eigen::MatrixXd jacobian;
+            int active_wavelength = -1;
+            int state_wavelength = -1;
+            bool transport_state_projected = false;
+        };
+
+      public:
+        SuccessiveOrdersImplementation(
+            const sasktran2::raytracing::RayTracerBase& raytracer,
+            const sasktran2::Geometry1D& geometry)
+            : m_source_geometry(raytracer, geometry),
+              m_first_order(geometry, raytracer) {}
+
+        void initialize_config(const sasktran2::Config& config) {
+            invalidate_geometry();
+            m_config = &config;
+            m_geometry_settings.num_incoming = config.num_hr_incoming();
+            m_geometry_settings.num_outgoing = config.num_hr_outgoing();
+            m_geometry_settings.num_sza = config.num_do_sza();
+            m_geometry_settings.num_threads = config.num_threads();
+            m_geometry_settings.include_refraction =
+                config.multiple_scatter_refraction();
+            m_geometry_settings.altitude_grid_m =
+                config.successive_orders_altitude_grid_m();
+
+            m_solver_settings.maximum_iterations =
+                config.num_hr_spherical_iterations();
+            m_solver_settings.relative_tolerance =
+                config.successive_orders_relative_tolerance();
+            m_solver_settings.absolute_tolerance =
+                config.successive_orders_absolute_tolerance();
+            m_solver_settings.anderson_depth =
+                config.successive_orders_anderson_depth();
+            m_solver_settings.damping = config.successive_orders_damping();
+            m_solver_settings.validate();
+            m_geometry_settings.validate();
+            m_first_order.initialize_config(config);
+        }
+
+        void initialize_geometry(
+            const sasktran2::viewinggeometry::InternalViewingGeometry&
+                internal_viewing) {
+            if (m_config == nullptr) {
+                throw std::logic_error(
+                    "C++ successive-orders config must be initialized before "
+                    "geometry");
+            }
+            invalidate_geometry();
+            m_source_geometry.initialize(internal_viewing, m_geometry_settings);
+            m_transport_map = std::make_unique<RayTransportMap>(
+                m_source_geometry.incoming_interpolation(),
+                m_source_geometry.total_num_outgoing(),
+                m_source_geometry.transport_row_offsets(),
+                m_source_geometry.transport_column_indices());
+            m_los_map = std::make_unique<RayTransportMap>(
+                m_source_geometry.los_interpolation(),
+                m_source_geometry.total_num_outgoing(),
+                m_source_geometry.los_transport_row_offsets(),
+                m_source_geometry.los_transport_column_indices());
+            m_scattering_assembler = std::make_unique<Assembler>(
+                m_source_geometry, m_config->num_do_streams());
+
+            create_wavelength_states(m_config->num_wavelength_threads());
+
+            const int output_size = m_los_map->num_rays() * NSTOKES;
+            m_thread_los_cotangent.resize(m_config->num_threads());
+            for (auto& cotangent : m_thread_los_cotangent) {
+                cotangent.setZero(output_size);
+            }
+            m_first_order.initialize_geometry(m_source_geometry);
+            m_geometry_initialized = true;
+        }
+
+        void initialize_atmosphere(const Atmosphere& atmosphere) {
+            if (!m_geometry_initialized) {
+                throw std::logic_error(
+                    "C++ successive-orders geometry must be initialized "
+                    "before the atmosphere");
+            }
+            // Preserve directly-mutable C++ Atmosphere behavior at revision
+            // zero. Python constituent builds and explicitly tracked native
+            // storage opt into cache reuse by calling mark_changed().
+            if (atmosphere.revision() != 0 && m_atmosphere == &atmosphere &&
+                m_has_atmosphere_revision &&
+                m_atmosphere_instance_id == atmosphere.instance_id() &&
+                m_atmosphere_revision == atmosphere.revision()) {
+                return;
+            }
+            m_atmosphere = nullptr;
+            // Scalar workspaces are compact enough to retain one complete
+            // state per wavelength. Vector workspaces stay thread-local, but
+            // their converged solution is cached separately below so native
+            // products do not have to repeat the primal solve.
+            if constexpr (NSTOKES == 1) {
+                if (static_cast<int>(m_wavelength_state.size()) !=
+                    atmosphere.num_wavel()) {
+                    create_wavelength_states(atmosphere.num_wavel());
+                }
+            } else {
+                if (static_cast<int>(m_vector_state_cache.size()) !=
+                    atmosphere.num_wavel()) {
+                    m_vector_state_cache.clear();
+                    m_vector_state_cache.resize(atmosphere.num_wavel());
+                }
+            }
+            for (auto& state : m_wavelength_state) {
+                state->active_wavelength = -1;
+            }
+            m_first_order.initialize_atmosphere(atmosphere);
+            m_atmosphere = &atmosphere;
+            m_atmosphere_instance_id = atmosphere.instance_id();
+            m_atmosphere_revision = atmosphere.revision();
+            m_has_atmosphere_revision = true;
+        }
+
+        void calculate(const sasktran2::WavelengthBlock<>& block,
+                       int threadidx) {
+            validate_single_wavelength_block(block);
+            auto& work = prepare_primal(block.start, threadidx);
+            if (m_atmosphere->num_deriv() > 0) {
+                warn_if_implicit_derivative_is_unchecked(
+                    m_solver_settings, block.start, "full Jacobian");
+                calculate_jacobian(block.start, threadidx, work);
+            }
+        }
+
+        void calculate_jvp(const sasktran2::WavelengthBlock<>& block,
+                           int threadidx,
+                           Eigen::Ref<const Eigen::VectorXd> native_tangent) {
+            validate_single_wavelength_block(block);
+            validate_calculation(block.start, threadidx);
+            if (native_tangent.size() != m_atmosphere->num_deriv()) {
+                throw std::invalid_argument(
+                    "Invalid C++ successive-orders native tangent size");
+            }
+            auto& work = wavelength_state(block.start, threadidx);
+            const bool compact_scalar =
+                m_first_order.uses_compact_scalar_kernel();
+            work.tangent.resize(work.transport, work.scattering,
+                                !compact_scalar);
+            work.tangent.set_zero();
+            prepare_primal(block.start, threadidx);
+            if (native_tangent.isZero(0.0)) {
+                work.state_tangent.setZero();
+                work.los_tangent.setZero();
+            } else {
+                warn_if_implicit_derivative_is_unchecked(m_solver_settings,
+                                                         block.start, "JVP");
+                if (compact_scalar) {
+                    if (!work.transport_state_projected) {
+                        m_first_order.project_transport_state(
+                            work.state, work.layer_state_projection,
+                            work.ground_state_projection);
+                        work.transport_state_projected = true;
+                    }
+                    m_first_order.calculate_jvp_with_transport(
+                        block.start, threadidx, native_tangent,
+                        work.layer_state_projection,
+                        work.ground_state_projection,
+                        work.direct_transport_tangent, work.forcing,
+                        work.tangent.forcing);
+                } else {
+                    m_first_order.calculate_jvp(block.start, threadidx,
+                                                native_tangent, work.forcing,
+                                                work.tangent.forcing);
+                }
+                if (!compact_scalar) {
+                    m_transport_map->assemble_jvp(
+                        *m_atmosphere, block.start, native_tangent,
+                        work.tangent.transport_values);
+                }
+                Adapter::assemble_jvp(*m_scattering_assembler, *m_atmosphere,
+                                      block.start, native_tangent,
+                                      work.tangent);
+                const auto jvp_diagnostics = work.problem.solve_jvp(
+                    work.forcing, work.state, work.tangent, work.state_tangent,
+                    m_solver_settings, work.workspace,
+                    compact_scalar ? &work.direct_transport_tangent : nullptr);
+                warn_if_not_converged(jvp_diagnostics, m_solver_settings,
+                                      block.start, "JVP solve");
+                m_los_map->assemble_jvp(*m_atmosphere, block.start,
+                                        native_tangent,
+                                        work.los_transport_tangent);
+                work.los_transport.template apply_jvp_stokes<NSTOKES>(
+                    work.state, work.state_tangent, work.los_transport_tangent,
+                    work.los_tangent);
+            }
+            work.jacobian.resize(0, 0);
+            work.active_wavelength = block.start;
+        }
+
+        void calculate_vjp(const sasktran2::WavelengthBlock<>& block,
+                           int threadidx) {
+            validate_single_wavelength_block(block);
+            prepare_primal(block.start, threadidx);
+            reset_vjp_cotangents(threadidx);
+        }
+
+        void finalize_vjp(const sasktran2::WavelengthBlock<>& block,
+                          int threadidx,
+                          Eigen::Ref<Eigen::MatrixXd> native_gradient) {
+            validate_single_wavelength_block(block);
+            validate_active(block.start, threadidx);
+            if (native_gradient.rows() != m_atmosphere->num_deriv() ||
+                native_gradient.cols() != 1) {
+                throw std::invalid_argument(
+                    "Invalid C++ successive-orders native VJP storage");
+            }
+            auto& work = wavelength_state(block.start, threadidx);
+            work.los_cotangent.setZero();
+            const auto [first_thread, last_thread] =
+                source_thread_range(threadidx);
+            for (int thread = first_thread; thread < last_thread; ++thread) {
+                work.los_cotangent += m_thread_los_cotangent[thread];
+            }
+            auto gradient = native_gradient.col(0);
+            warn_if_implicit_derivative_is_unchecked(m_solver_settings,
+                                                     block.start, "VJP");
+            reverse(block.start, threadidx, work, work.los_cotangent,
+                    gradient);
+        }
+
+        void start_of_ray_source(
+            const sasktran2::WavelengthBlock<>& block, int losidx,
+            int wavel_threadidx,
+            sasktran2::WavelengthBlockDual<NSTOKES>& source) const {
+            validate_single_wavelength_block(block);
+            validate_active(block.start, wavel_threadidx);
+            validate_los(losidx);
+            const auto& work = wavelength_state(block.start, wavel_threadidx);
+            const int output_offset = losidx * NSTOKES;
+            source.value.col(0) +=
+                work.los_value.template segment<NSTOKES>(output_offset);
+            if (work.jacobian.rows() != 0) {
+                if (source.derivative_size() != work.jacobian.cols()) {
+                    throw std::invalid_argument(
+                        "C++ successive-orders Jacobian storage mismatch");
+                }
+                for (int derivative = 0; derivative < source.derivative_size();
+                     ++derivative) {
+                    source.derivative(derivative, 1).col(0) +=
+                        work.jacobian.col(derivative)
+                            .template segment<NSTOKES>(output_offset);
+                }
+            }
+        }
+
+        void
+        start_of_ray_source_jvp(int wavelength, int losidx, int wavel_threadidx,
+                                sasktran2::RadianceJVP<NSTOKES>& source) const {
+            validate_active(wavelength, wavel_threadidx);
+            validate_los(losidx);
+            const auto& work = wavelength_state(wavelength, wavel_threadidx);
+            const int output_offset = losidx * NSTOKES;
+            source.value +=
+                work.los_value.template segment<NSTOKES>(output_offset);
+            source.jvp +=
+                work.los_tangent.template segment<NSTOKES>(output_offset);
+        }
+
+        void start_of_ray_source_vjp(
+            int wavelength, int losidx, int wavel_threadidx, int threadidx,
+            Eigen::Vector<double, NSTOKES>& cotangent) const {
+            validate_active(wavelength, wavel_threadidx);
+            validate_los(losidx);
+            if (threadidx < 0 ||
+                threadidx >= static_cast<int>(m_thread_los_cotangent.size())) {
+                throw std::out_of_range(
+                    "C++ successive-orders VJP thread is out of range");
+            }
+            m_thread_los_cotangent[threadidx].template segment<NSTOKES>(
+                losidx * NSTOKES) += cotangent;
+        }
+
+        bool supports_linearization(sasktran2::LinearizationMode) const {
+            return true;
+        }
+
+      private:
+        void create_wavelength_states(int count) {
+            if (count < 1 || m_transport_map == nullptr ||
+                m_los_map == nullptr || m_scattering_assembler == nullptr) {
+                throw std::logic_error(
+                    "Cannot allocate C++ successive-orders wavelength state");
+            }
+            m_wavelength_state.clear();
+            m_vector_state_cache.clear();
+            m_wavelength_state.reserve(count);
+            for (int index = 0; index < count; ++index) {
+                m_wavelength_state.emplace_back(
+                    std::make_unique<WavelengthState>(
+                        *m_transport_map, *m_los_map, *m_scattering_assembler));
+            }
+        }
+
+        int wavelength_state_index(int wavelength, int threadidx) const {
+            if constexpr (NSTOKES == 1) {
+                return wavelength;
+            } else {
+                return threadidx;
+            }
+        }
+
+        WavelengthState& wavelength_state(int wavelength, int threadidx) {
+            const int index = wavelength_state_index(wavelength, threadidx);
+            if (index < 0 ||
+                index >= static_cast<int>(m_wavelength_state.size())) {
+                throw std::logic_error(
+                    "C++ successive-orders wavelength cache is invalid");
+            }
+            return *m_wavelength_state[index];
+        }
+
+        const WavelengthState& wavelength_state(int wavelength,
+                                                int threadidx) const {
+            const int index = wavelength_state_index(wavelength, threadidx);
+            if (index < 0 ||
+                index >= static_cast<int>(m_wavelength_state.size())) {
+                throw std::logic_error(
+                    "C++ successive-orders wavelength cache is invalid");
+            }
+            return *m_wavelength_state[index];
+        }
+
+        void invalidate_geometry() {
+            m_geometry_initialized = false;
+            m_atmosphere = nullptr;
+            m_has_atmosphere_revision = false;
+            m_wavelength_state.clear();
+            m_thread_los_cotangent.clear();
+            m_scattering_assembler.reset();
+            m_los_map.reset();
+            m_transport_map.reset();
+        }
+
+        std::pair<int, int> source_thread_range(int wavelength_thread) const {
+            const int first_thread = wavelength_thread;
+            const int last_thread =
+                first_thread + m_config->num_source_threads();
+            if (first_thread < 0 ||
+                last_thread > static_cast<int>(m_thread_los_cotangent.size())) {
+                throw std::logic_error(
+                    "C++ successive-orders thread layout is invalid");
+            }
+            return {first_thread, last_thread};
+        }
+
+        void validate_calculation(int wavelength, int threadidx) const {
+            if (m_atmosphere == nullptr || threadidx < 0 ||
+                threadidx >= m_config->num_wavelength_threads() ||
+                wavelength < 0 || wavelength >= m_atmosphere->num_wavel()) {
+                throw std::invalid_argument(
+                    "Invalid C++ successive-orders calculation");
+            }
+        }
+
+        void validate_active(int wavelength, int threadidx) const {
+            validate_calculation(wavelength, threadidx);
+            if (wavelength_state(wavelength, threadidx).active_wavelength !=
+                wavelength) {
+                throw std::logic_error(
+                    "C++ successive-orders wavelength state is not active");
+            }
+        }
+
+        void validate_los(int losidx) const {
+            if (losidx < 0 || losidx >= m_los_map->num_rays()) {
+                throw std::out_of_range(
+                    "C++ successive-orders LOS index is out of range");
+            }
+        }
+
+        void assemble_values(int wavelength, WavelengthState& work) {
+            if (!m_first_order.uses_compact_scalar_kernel()) {
+                m_transport_map->assemble_values(*m_atmosphere, wavelength,
+                                                 work.transport);
+            }
+            m_los_map->assemble_values(*m_atmosphere, wavelength,
+                                       work.los_transport);
+            m_scattering_assembler->assemble_values(*m_atmosphere, wavelength,
+                                                    work.scattering);
+        }
+
+        WavelengthState& prepare_primal(int wavelength, int threadidx) {
+            validate_calculation(wavelength, threadidx);
+            auto& work = wavelength_state(wavelength, threadidx);
+            if (work.active_wavelength == wavelength) {
+                return work;
+            }
+            work.active_wavelength = -1;
+            work.transport_state_projected = false;
+            assemble_values(wavelength, work);
+            if (m_first_order.uses_compact_scalar_kernel()) {
+                m_first_order.calculate_with_transport(
+                    wavelength, threadidx, work.transport, work.forcing);
+            } else {
+                m_first_order.calculate(wavelength, threadidx, work.forcing);
+            }
+            // Retrieval loops usually perturb the atmosphere only slightly,
+            // so a previous converged state is a useful initial guess. Fixed
+            // iteration mode must instead start from zero: otherwise its
+            // result would depend on earlier engine calculations. Preserve
+            // the historical zero-state semantics when no iterations are
+            // requested as well.
+            if constexpr (NSTOKES == 1) {
+                if (work.state_wavelength != wavelength ||
+                    m_solver_settings.maximum_iterations == 0 ||
+                    !m_solver_settings.convergence_enabled()) {
+                    work.state.setZero();
+                }
+            } else {
+                const auto& cached_state = m_vector_state_cache[wavelength];
+                if (m_solver_settings.maximum_iterations > 0 &&
+                    m_solver_settings.convergence_enabled() &&
+                    cached_state.size() == work.problem.state_size()) {
+                    work.state = cached_state;
+                } else {
+                    work.state.setZero();
+                }
+            }
+            const auto diagnostics = work.problem.solve(
+                work.forcing, work.state, m_solver_settings, work.workspace);
+            if constexpr (NSTOKES == 3) {
+                if (m_solver_settings.maximum_iterations > 0 &&
+                    m_solver_settings.convergence_enabled()) {
+                    m_vector_state_cache[wavelength] = work.state;
+                }
+            }
+            work.state_wavelength =
+                m_solver_settings.maximum_iterations == 0 ? -1 : wavelength;
+            warn_if_not_converged(diagnostics, m_solver_settings, wavelength,
+                                  "primal solve");
+            work.los_transport.template apply_stokes<NSTOKES>(work.state,
+                                                              work.los_value);
+            work.los_tangent.setZero();
+            work.jacobian.resize(0, 0);
+            work.active_wavelength = wavelength;
+            return work;
+        }
+
+        void reverse(int wavelength, int threadidx, WavelengthState& work,
+                     Eigen::Ref<const Eigen::VectorXd> los_cotangent,
+                     Eigen::Ref<Eigen::VectorXd> native_gradient,
+                     bool emit_convergence_warning = true) {
+            work.los_transport.template apply_vjp_stokes<NSTOKES>(
+                work.state, los_cotangent, work.state_cotangent,
+                work.los_value_gradient);
+            m_los_map->accumulate_vjp(*m_atmosphere, wavelength,
+                                      work.los_value_gradient, native_gradient,
+                                      work.los_vjp_workspace);
+            const auto diagnostics = work.problem.solve_vjp(
+                work.forcing, work.state, work.state_cotangent, work.gradient,
+                m_solver_settings, work.workspace, work.adjoint,
+                !m_first_order.uses_compact_scalar_kernel());
+            if (emit_convergence_warning) {
+                warn_if_not_converged(diagnostics, m_solver_settings,
+                                      wavelength, "VJP solve");
+            }
+            if (!m_first_order.uses_compact_scalar_kernel()) {
+                m_transport_map->accumulate_vjp(
+                    *m_atmosphere, wavelength, work.gradient.transport_values,
+                    native_gradient, work.transport_vjp_workspace);
+            }
+            Adapter::accumulate_vjp(*m_scattering_assembler, *m_atmosphere,
+                                    wavelength, work.gradient,
+                                    native_gradient);
+            if (m_first_order.uses_compact_scalar_kernel()) {
+                if (work.transport_state_projected) {
+                    m_first_order.accumulate_vjp_with_projected_transport(
+                        wavelength, threadidx, work.layer_state_projection,
+                        work.ground_state_projection, work.gradient.forcing,
+                        native_gradient);
+                } else {
+                    m_first_order.accumulate_vjp_with_transport(
+                        wavelength, threadidx, work.state,
+                        work.gradient.forcing, native_gradient);
+                }
+            } else {
+                m_first_order.accumulate_vjp(
+                    wavelength, threadidx, work.gradient.forcing,
+                    native_gradient);
+            }
+        }
+
+        void calculate_jacobian(int wavelength, int threadidx,
+                                WavelengthState& work) {
+            const int outputs = m_los_map->num_rays() * NSTOKES;
+            const int derivatives = m_atmosphere->num_deriv();
+            work.jacobian.resize(outputs, derivatives);
+            work.los_cotangent.setZero();
+            Eigen::VectorXd native_gradient(derivatives);
+            if (m_first_order.uses_compact_scalar_kernel() &&
+                !work.transport_state_projected) {
+                m_first_order.project_transport_state(
+                    work.state, work.layer_state_projection,
+                    work.ground_state_projection);
+                work.transport_state_projected = true;
+            }
+            for (int output = 0; output < outputs; ++output) {
+                work.los_cotangent(output) = 1.0;
+                native_gradient.setZero();
+                reverse(wavelength, threadidx, work, work.los_cotangent,
+                        native_gradient, output == 0);
+                work.jacobian.row(output) = native_gradient.transpose();
+                work.los_cotangent(output) = 0.0;
+            }
+        }
+
+        void reset_vjp_cotangents(int wavelength_thread) {
+            const auto [first_thread, last_thread] =
+                source_thread_range(wavelength_thread);
+            for (int thread = first_thread; thread < last_thread; ++thread) {
+                m_thread_los_cotangent[thread].setZero();
+            }
+        }
+
+        const sasktran2::Config* m_config = nullptr;
+        const Atmosphere* m_atmosphere = nullptr;
+        std::uint64_t m_atmosphere_instance_id = 0;
+        std::uint64_t m_atmosphere_revision = 0;
+        bool m_has_atmosphere_revision = false;
+        SourceGeometrySettings m_geometry_settings;
+        FixedPointSettings m_solver_settings;
+        SourceGeometry1D m_source_geometry;
+        FirstOrderProvider<NSTOKES> m_first_order;
+        std::unique_ptr<RayTransportMap> m_transport_map;
+        std::unique_ptr<RayTransportMap> m_los_map;
+        std::unique_ptr<Assembler> m_scattering_assembler;
+        std::vector<std::unique_ptr<WavelengthState>> m_wavelength_state;
+        std::vector<Eigen::VectorXd> m_vector_state_cache;
+        mutable std::vector<Eigen::VectorXd> m_thread_los_cotangent;
+        bool m_geometry_initialized = false;
+    };
+
+    template <>
+    class SuccessiveOrdersSource<1>::Impl
+        : public SuccessiveOrdersImplementation<1> {
+      public:
+        using SuccessiveOrdersImplementation<1>::SuccessiveOrdersImplementation;
+    };
+
+    template <>
+    class SuccessiveOrdersSource<3>::Impl
+        : public SuccessiveOrdersImplementation<3> {
+      public:
+        using SuccessiveOrdersImplementation<3>::SuccessiveOrdersImplementation;
+    };
+
+    template <int NSTOKES>
+    SuccessiveOrdersSource<NSTOKES>::SuccessiveOrdersSource(
+        const sasktran2::raytracing::RayTracerBase& raytracer,
+        const sasktran2::Geometry1D& geometry)
+        : m_impl(std::make_unique<Impl>(raytracer, geometry)) {}
+
+    template <int NSTOKES>
+    SuccessiveOrdersSource<NSTOKES>::~SuccessiveOrdersSource() = default;
+
+    template <int NSTOKES>
+    void SuccessiveOrdersSource<NSTOKES>::initialize_config(
+        const sasktran2::Config& config) {
+        m_impl->initialize_config(config);
+    }
+
+    template <int NSTOKES>
+    void SuccessiveOrdersSource<NSTOKES>::initialize_geometry(
+        const sasktran2::viewinggeometry::InternalViewingGeometry&
+            internal_viewing) {
+        m_impl->initialize_geometry(internal_viewing);
+    }
+
+    template <int NSTOKES>
+    void SuccessiveOrdersSource<NSTOKES>::initialize_atmosphere(
+        const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere) {
+        m_impl->initialize_atmosphere(atmosphere);
+    }
+
+    template <int NSTOKES>
+    void SuccessiveOrdersSource<NSTOKES>::calculate(
+        const sasktran2::WavelengthBlock<>& block, int threadidx) {
+        m_impl->calculate(block, threadidx);
+    }
+
+    template <int NSTOKES>
+    void SuccessiveOrdersSource<NSTOKES>::calculate_jvp(
+        const sasktran2::WavelengthBlock<>& block, int threadidx,
+        Eigen::Ref<const Eigen::VectorXd> native_tangent) {
+        m_impl->calculate_jvp(block, threadidx, native_tangent);
+    }
+
+    template <int NSTOKES>
+    void SuccessiveOrdersSource<NSTOKES>::calculate_vjp(
+        const sasktran2::WavelengthBlock<>& block, int threadidx) {
+        m_impl->calculate_vjp(block, threadidx);
+    }
+
+    template <int NSTOKES>
+    void SuccessiveOrdersSource<NSTOKES>::finalize_vjp(
+        const sasktran2::WavelengthBlock<>& block, int threadidx,
+        Eigen::Ref<Eigen::MatrixXd> native_gradient) const {
+        m_impl->finalize_vjp(block, threadidx, native_gradient);
+    }
+
+    template <int NSTOKES>
+    bool SuccessiveOrdersSource<NSTOKES>::supports_linearization(
+        sasktran2::LinearizationMode mode) const {
+        return m_impl->supports_linearization(mode);
+    }
+
+    template <int NSTOKES>
+    void SuccessiveOrdersSource<NSTOKES>::start_of_ray_source(
+        const sasktran2::WavelengthBlock<>& block, int losidx,
+        int wavel_threadidx, int,
+        sasktran2::WavelengthBlockDual<NSTOKES>& source) const {
+        m_impl->start_of_ray_source(block, losidx, wavel_threadidx, source);
+    }
+
+    template <int NSTOKES>
+    void SuccessiveOrdersSource<NSTOKES>::start_of_ray_source_jvp(
+        int wavelength, int losidx, int wavel_threadidx, int,
+        Eigen::Ref<const Eigen::VectorXd>,
+        sasktran2::RadianceJVP<NSTOKES>& source) const {
+        m_impl->start_of_ray_source_jvp(wavelength, losidx, wavel_threadidx,
+                                        source);
+    }
+
+    template <int NSTOKES>
+    void SuccessiveOrdersSource<NSTOKES>::start_of_ray_source_vjp(
+        int wavelength, int losidx, int wavel_threadidx, int threadidx,
+        const Eigen::Vector<double, NSTOKES>&,
+        Eigen::Vector<double, NSTOKES>& cotangent,
+        Eigen::Ref<Eigen::VectorXd>) const {
+        m_impl->start_of_ray_source_vjp(wavelength, losidx, wavel_threadidx,
+                                        threadidx, cotangent);
+    }
+
+    template class SuccessiveOrdersSource<1>;
+    template class SuccessiveOrdersSource<3>;
+
+    template <int NSTOKES>
+    std::unique_ptr<SourceTermInterface<NSTOKES>>
+    make_successive_orders_source(
+        const sasktran2::raytracing::RayTracerBase& raytracer,
+        const sasktran2::Geometry1D& geometry) {
+        return std::make_unique<SuccessiveOrdersSource<NSTOKES>>(raytracer,
+                                                                 geometry);
+    }
+
+    template std::unique_ptr<SourceTermInterface<1>>
+    make_successive_orders_source<1>(
+        const sasktran2::raytracing::RayTracerBase&,
+        const sasktran2::Geometry1D&);
+    template std::unique_ptr<SourceTermInterface<3>>
+    make_successive_orders_source<3>(
+        const sasktran2::raytracing::RayTracerBase&,
+        const sasktran2::Geometry1D&);
+
+} // namespace sasktran2::successive_orders

--- a/cpp/lib/successive_orders/transport.h
+++ b/cpp/lib/successive_orders/transport.h
@@ -1,0 +1,385 @@
+#pragma once
+
+#include <Eigen/Core>
+
+#include <algorithm>
+#include <cstddef>
+#include <stdexcept>
+#include <vector>
+
+namespace sasktran2::successive_orders {
+
+    /** Fixed CSR topology for ray transport.
+     *
+     * Geometry construction owns the topology; only the values are rebuilt
+     * for a changing atmosphere. Rows are incoming angular radiances and
+     * columns are outgoing source samples.
+     */
+    class TransportSparsity {
+      public:
+        TransportSparsity() = default;
+        TransportSparsity(int columns, std::vector<int> row_offsets,
+                          std::vector<int> column_indices)
+            : m_columns(columns), m_row_offsets(std::move(row_offsets)),
+              m_column_indices(std::move(column_indices)) {
+            validate();
+        }
+
+        int rows() const {
+            return m_row_offsets.empty()
+                       ? 0
+                       : static_cast<int>(m_row_offsets.size()) - 1;
+        }
+        int columns() const { return m_columns; }
+        int nonzeros() const {
+            return static_cast<int>(m_column_indices.size());
+        }
+        const std::vector<int>& row_offsets() const { return m_row_offsets; }
+        const std::vector<int>& column_indices() const {
+            return m_column_indices;
+        }
+        std::size_t storage_bytes() const {
+            return m_row_offsets.capacity() * sizeof(int) +
+                   m_column_indices.capacity() * sizeof(int);
+        }
+
+      private:
+        void validate() const {
+            if (m_columns < 0 || m_row_offsets.empty() ||
+                m_row_offsets.front() != 0 ||
+                m_row_offsets.back() !=
+                    static_cast<int>(m_column_indices.size()) ||
+                !std::is_sorted(m_row_offsets.begin(), m_row_offsets.end())) {
+                throw std::invalid_argument(
+                    "invalid successive-orders transport CSR offsets");
+            }
+            for (int row = 0; row < rows(); ++row) {
+                const auto begin =
+                    m_column_indices.begin() + m_row_offsets[row];
+                const auto end =
+                    m_column_indices.begin() + m_row_offsets[row + 1];
+                if (!std::is_sorted(begin, end) ||
+                    std::adjacent_find(begin, end) != end ||
+                    std::any_of(begin, end, [&](int column) {
+                        return column < 0 || column >= m_columns;
+                    })) {
+                    throw std::invalid_argument(
+                        "invalid successive-orders transport CSR columns");
+                }
+            }
+        }
+
+        int m_columns = 0;
+        std::vector<int> m_row_offsets{0};
+        std::vector<int> m_column_indices;
+    };
+
+    class TransportOperator {
+      public:
+        explicit TransportOperator(const TransportSparsity& sparsity)
+            : m_sparsity(&sparsity),
+              m_values(Eigen::VectorXd::Zero(sparsity.nonzeros())) {}
+
+        const TransportSparsity& sparsity() const { return *m_sparsity; }
+        Eigen::VectorXd& values() { return m_values; }
+        const Eigen::VectorXd& values() const { return m_values; }
+
+        std::size_t storage_bytes() const {
+            return static_cast<std::size_t>(m_values.size()) * sizeof(double);
+        }
+
+        void apply(Eigen::Ref<const Eigen::VectorXd> state,
+                   Eigen::Ref<Eigen::VectorXd> incoming) const {
+            validate_vectors(state, incoming);
+            const auto& offsets = m_sparsity->row_offsets();
+            const auto& columns = m_sparsity->column_indices();
+            for (int row = 0; row < m_sparsity->rows(); ++row) {
+                double value = 0.0;
+                for (int index = offsets[row]; index < offsets[row + 1];
+                     ++index) {
+                    value += m_values(index) * state(columns[index]);
+                }
+                incoming(row) = value;
+            }
+        }
+
+        /** Applies one geometry operator to interleaved Stokes channels
+         * without duplicating CSR values or column indices. */
+        template <int NSTOKES>
+        void apply_stokes(Eigen::Ref<const Eigen::VectorXd> state,
+                          Eigen::Ref<Eigen::VectorXd> incoming) const {
+            if constexpr (NSTOKES == 1) {
+                apply(state, incoming);
+                return;
+            }
+            validate_stokes_vectors<NSTOKES>(state, incoming);
+            incoming.setZero();
+            const auto& offsets = m_sparsity->row_offsets();
+            const auto& columns = m_sparsity->column_indices();
+            for (int row = 0; row < m_sparsity->rows(); ++row) {
+                for (int index = offsets[row]; index < offsets[row + 1];
+                     ++index) {
+                    const int column = columns[index];
+                    for (int stokes = 0; stokes < NSTOKES; ++stokes) {
+                        incoming(row * NSTOKES + stokes) +=
+                            m_values(index) * state(column * NSTOKES + stokes);
+                    }
+                }
+            }
+        }
+
+        void apply_affine(Eigen::Ref<const Eigen::VectorXd> state,
+                          Eigen::Ref<const Eigen::VectorXd> forcing,
+                          Eigen::Ref<Eigen::VectorXd> incoming) const {
+            if (forcing.size() != m_sparsity->rows()) {
+                throw std::invalid_argument(
+                    "invalid successive-orders transport forcing size");
+            }
+            apply(state, incoming);
+            incoming += forcing;
+        }
+
+        void apply_transpose(Eigen::Ref<const Eigen::VectorXd> incoming,
+                             Eigen::Ref<Eigen::VectorXd> state) const {
+            if (incoming.size() != m_sparsity->rows() ||
+                state.size() != m_sparsity->columns()) {
+                throw std::invalid_argument(
+                    "invalid successive-orders transpose transport sizes");
+            }
+            state.setZero();
+            const auto& offsets = m_sparsity->row_offsets();
+            const auto& columns = m_sparsity->column_indices();
+            for (int row = 0; row < m_sparsity->rows(); ++row) {
+                const double row_value = incoming(row);
+                for (int index = offsets[row]; index < offsets[row + 1];
+                     ++index) {
+                    state(columns[index]) += m_values(index) * row_value;
+                }
+            }
+        }
+
+        template <int NSTOKES>
+        void apply_transpose_stokes(Eigen::Ref<const Eigen::VectorXd> incoming,
+                                    Eigen::Ref<Eigen::VectorXd> state) const {
+            if constexpr (NSTOKES == 1) {
+                apply_transpose(incoming, state);
+                return;
+            }
+            validate_stokes_vectors<NSTOKES>(state, incoming);
+            state.setZero();
+            const auto& offsets = m_sparsity->row_offsets();
+            const auto& columns = m_sparsity->column_indices();
+            for (int row = 0; row < m_sparsity->rows(); ++row) {
+                for (int index = offsets[row]; index < offsets[row + 1];
+                     ++index) {
+                    const int column = columns[index];
+                    for (int stokes = 0; stokes < NSTOKES; ++stokes) {
+                        state(column * NSTOKES + stokes) +=
+                            m_values(index) * incoming(row * NSTOKES + stokes);
+                    }
+                }
+            }
+        }
+
+        void apply_jvp(Eigen::Ref<const Eigen::VectorXd> state,
+                       Eigen::Ref<const Eigen::VectorXd> state_tangent,
+                       Eigen::Ref<const Eigen::VectorXd> value_tangent,
+                       Eigen::Ref<Eigen::VectorXd> incoming_tangent) const {
+            if (state_tangent.size() != state.size() ||
+                value_tangent.size() != m_values.size()) {
+                throw std::invalid_argument(
+                    "invalid successive-orders transport JVP sizes");
+            }
+            validate_vectors(state, incoming_tangent);
+            const auto& offsets = m_sparsity->row_offsets();
+            const auto& columns = m_sparsity->column_indices();
+            for (int row = 0; row < m_sparsity->rows(); ++row) {
+                double value = 0.0;
+                for (int index = offsets[row]; index < offsets[row + 1];
+                     ++index) {
+                    const int column = columns[index];
+                    value += m_values(index) * state_tangent(column) +
+                             value_tangent(index) * state(column);
+                }
+                incoming_tangent(row) = value;
+            }
+        }
+
+        /** Applies only the direct value derivative, dT * state. */
+        void
+        apply_value_jvp(Eigen::Ref<const Eigen::VectorXd> state,
+                        Eigen::Ref<const Eigen::VectorXd> value_tangent,
+                        Eigen::Ref<Eigen::VectorXd> incoming_tangent) const {
+            if (value_tangent.size() != m_values.size()) {
+                throw std::invalid_argument(
+                    "invalid successive-orders transport value JVP size");
+            }
+            validate_vectors(state, incoming_tangent);
+            const auto& offsets = m_sparsity->row_offsets();
+            const auto& columns = m_sparsity->column_indices();
+            for (int row = 0; row < m_sparsity->rows(); ++row) {
+                double value = 0.0;
+                for (int index = offsets[row]; index < offsets[row + 1];
+                     ++index) {
+                    value += value_tangent(index) * state(columns[index]);
+                }
+                incoming_tangent(row) = value;
+            }
+        }
+
+        template <int NSTOKES>
+        void apply_value_jvp_stokes(
+            Eigen::Ref<const Eigen::VectorXd> state,
+            Eigen::Ref<const Eigen::VectorXd> value_tangent,
+            Eigen::Ref<Eigen::VectorXd> incoming_tangent) const {
+            if constexpr (NSTOKES == 1) {
+                apply_value_jvp(state, value_tangent, incoming_tangent);
+                return;
+            }
+            validate_stokes_vectors<NSTOKES>(state, incoming_tangent);
+            if (value_tangent.size() != m_values.size()) {
+                throw std::invalid_argument(
+                    "invalid successive-orders Stokes transport value JVP "
+                    "size");
+            }
+            incoming_tangent.setZero();
+            const auto& offsets = m_sparsity->row_offsets();
+            const auto& columns = m_sparsity->column_indices();
+            for (int row = 0; row < m_sparsity->rows(); ++row) {
+                for (int index = offsets[row]; index < offsets[row + 1];
+                     ++index) {
+                    const int column = columns[index];
+                    for (int stokes = 0; stokes < NSTOKES; ++stokes) {
+                        incoming_tangent(row * NSTOKES + stokes) +=
+                            value_tangent(index) *
+                            state(column * NSTOKES + stokes);
+                    }
+                }
+            }
+        }
+
+        template <int NSTOKES>
+        void
+        apply_jvp_stokes(Eigen::Ref<const Eigen::VectorXd> state,
+                         Eigen::Ref<const Eigen::VectorXd> state_tangent,
+                         Eigen::Ref<const Eigen::VectorXd> value_tangent,
+                         Eigen::Ref<Eigen::VectorXd> incoming_tangent) const {
+            if constexpr (NSTOKES == 1) {
+                apply_jvp(state, state_tangent, value_tangent,
+                          incoming_tangent);
+                return;
+            }
+            validate_stokes_vectors<NSTOKES>(state, incoming_tangent);
+            if (state_tangent.size() != state.size() ||
+                value_tangent.size() != m_values.size()) {
+                throw std::invalid_argument(
+                    "invalid successive-orders Stokes transport JVP sizes");
+            }
+            incoming_tangent.setZero();
+            const auto& offsets = m_sparsity->row_offsets();
+            const auto& columns = m_sparsity->column_indices();
+            for (int row = 0; row < m_sparsity->rows(); ++row) {
+                for (int index = offsets[row]; index < offsets[row + 1];
+                     ++index) {
+                    const int column = columns[index];
+                    for (int stokes = 0; stokes < NSTOKES; ++stokes) {
+                        incoming_tangent(row * NSTOKES + stokes) +=
+                            m_values(index) *
+                                state_tangent(column * NSTOKES + stokes) +
+                            value_tangent(index) *
+                                state(column * NSTOKES + stokes);
+                    }
+                }
+            }
+        }
+
+        void apply_vjp(Eigen::Ref<const Eigen::VectorXd> state,
+                       Eigen::Ref<const Eigen::VectorXd> incoming_cotangent,
+                       Eigen::Ref<Eigen::VectorXd> state_cotangent,
+                       Eigen::Ref<Eigen::VectorXd> value_gradient) const {
+            if (state.size() != m_sparsity->columns() ||
+                incoming_cotangent.size() != m_sparsity->rows() ||
+                state_cotangent.size() != m_sparsity->columns() ||
+                value_gradient.size() != m_values.size()) {
+                throw std::invalid_argument(
+                    "invalid successive-orders transport VJP sizes");
+            }
+            state_cotangent.setZero();
+            value_gradient.setZero();
+            const auto& offsets = m_sparsity->row_offsets();
+            const auto& columns = m_sparsity->column_indices();
+            for (int row = 0; row < m_sparsity->rows(); ++row) {
+                const double row_cotangent = incoming_cotangent(row);
+                for (int index = offsets[row]; index < offsets[row + 1];
+                     ++index) {
+                    const int column = columns[index];
+                    state_cotangent(column) += m_values(index) * row_cotangent;
+                    value_gradient(index) = state(column) * row_cotangent;
+                }
+            }
+        }
+
+        template <int NSTOKES>
+        void
+        apply_vjp_stokes(Eigen::Ref<const Eigen::VectorXd> state,
+                         Eigen::Ref<const Eigen::VectorXd> incoming_cotangent,
+                         Eigen::Ref<Eigen::VectorXd> state_cotangent,
+                         Eigen::Ref<Eigen::VectorXd> value_gradient) const {
+            if constexpr (NSTOKES == 1) {
+                apply_vjp(state, incoming_cotangent, state_cotangent,
+                          value_gradient);
+                return;
+            }
+            validate_stokes_vectors<NSTOKES>(state, incoming_cotangent);
+            if (state_cotangent.size() != state.size() ||
+                value_gradient.size() != m_values.size()) {
+                throw std::invalid_argument(
+                    "invalid successive-orders Stokes transport VJP sizes");
+            }
+            state_cotangent.setZero();
+            value_gradient.setZero();
+            const auto& offsets = m_sparsity->row_offsets();
+            const auto& columns = m_sparsity->column_indices();
+            for (int row = 0; row < m_sparsity->rows(); ++row) {
+                for (int index = offsets[row]; index < offsets[row + 1];
+                     ++index) {
+                    const int column = columns[index];
+                    for (int stokes = 0; stokes < NSTOKES; ++stokes) {
+                        const double cotangent =
+                            incoming_cotangent(row * NSTOKES + stokes);
+                        state_cotangent(column * NSTOKES + stokes) +=
+                            m_values(index) * cotangent;
+                        value_gradient(index) +=
+                            state(column * NSTOKES + stokes) * cotangent;
+                    }
+                }
+            }
+        }
+
+      private:
+        void validate_vectors(Eigen::Ref<const Eigen::VectorXd> state,
+                              Eigen::Ref<Eigen::VectorXd> incoming) const {
+            if (state.size() != m_sparsity->columns() ||
+                incoming.size() != m_sparsity->rows()) {
+                throw std::invalid_argument(
+                    "invalid successive-orders transport vector sizes");
+            }
+        }
+
+        template <int NSTOKES>
+        void validate_stokes_vectors(
+            Eigen::Ref<const Eigen::VectorXd> state,
+            Eigen::Ref<const Eigen::VectorXd> incoming) const {
+            static_assert(NSTOKES > 0);
+            if (state.size() != m_sparsity->columns() * NSTOKES ||
+                incoming.size() != m_sparsity->rows() * NSTOKES) {
+                throw std::invalid_argument(
+                    "invalid successive-orders Stokes transport vector sizes");
+            }
+        }
+
+        const TransportSparsity* m_sparsity;
+        Eigen::VectorXd m_values;
+    };
+
+} // namespace sasktran2::successive_orders

--- a/cpp/lib/tests/CMakeLists.txt
+++ b/cpp/lib/tests/CMakeLists.txt
@@ -21,6 +21,15 @@ add_executable(
   engine/wf/test_wf_singlescatter_scalar.cpp
   engine/wf/test_wf_vector.cpp
   engine/hr/test_hr_basic.cpp
+  successive_orders/test_angular_basis.cpp
+  successive_orders/test_fixed_point.cpp
+  successive_orders/test_geometry.cpp
+  successive_orders/test_problem.cpp
+  successive_orders/test_ray_transport.cpp
+  successive_orders/test_scattering.cpp
+  successive_orders/test_scattering_assembler.cpp
+  successive_orders/test_source.cpp
+  successive_orders/test_transport.cpp
   sktran_disco/test_util.cpp
   sktran_disco/test_band_factorization.cpp
   sktran_disco/tests_lowlevel.cpp

--- a/cpp/lib/tests/engine/benchmark/bench_hr.cpp
+++ b/cpp/lib/tests/engine/benchmark/bench_hr.cpp
@@ -87,7 +87,7 @@ TEST_CASE("HR_bench Vector", "[sasktran2][engine]") {
     sasktran2::Config config;
 
     config.set_multiple_scatter_source(
-        sasktran2::Config::MultipleScatterSource::hr);
+        sasktran2::Config::MultipleScatterSource::successive_orders_legacy);
     // config.set_initialize_hr_with_do(true);
     config.set_num_hr_spherical_iterations(50);
     config.set_wf_enabled(false);

--- a/cpp/lib/tests/engine/hr/test_hr_basic.cpp
+++ b/cpp/lib/tests/engine/hr/test_hr_basic.cpp
@@ -87,7 +87,7 @@ TEST_CASE("Basic Calculation HR", "[sasktran2][engine][hr]") {
     // Construct the config
     sasktran2::Config config;
     config.set_multiple_scatter_source(
-        sasktran2::Config::MultipleScatterSource::hr);
+        sasktran2::Config::MultipleScatterSource::successive_orders_legacy);
     // config.set_num_do_streams(16);
 
     config.set_num_threads(1);

--- a/cpp/lib/tests/sktran_disco/test_band_factorization.cpp
+++ b/cpp/lib/tests/sktran_disco/test_band_factorization.cpp
@@ -264,7 +264,7 @@ TEST_CASE("Runtime band factorization tuner covers every DISCO source path",
     SECTION("HR initialized with discrete ordinates is tuned") {
         sasktran2::Config config;
         config.set_num_do_streams(8);
-        config.set_multiple_scatter_source(Source::hr);
+        config.set_multiple_scatter_source(Source::successive_orders_legacy);
         config.set_initialize_hr_with_do(true);
 
         Tuner::resolve(config, 20);
@@ -276,7 +276,7 @@ TEST_CASE("Runtime band factorization tuner covers every DISCO source path",
     SECTION("HR without discrete-ordinates initialization is not tuned") {
         sasktran2::Config config;
         config.set_num_do_streams(8);
-        config.set_multiple_scatter_source(Source::hr);
+        config.set_multiple_scatter_source(Source::successive_orders_legacy);
         config.set_initialize_hr_with_do(false);
 
         Tuner::resolve(config, 20);

--- a/cpp/lib/tests/successive_orders/test_angular_basis.cpp
+++ b/cpp/lib/tests/successive_orders/test_angular_basis.cpp
@@ -1,0 +1,107 @@
+#include "../../successive_orders/angular_basis.h"
+
+#include <sasktran2/math/unitsphere.h>
+#include <sasktran2/math/wigner.h>
+#include <sasktran2/test_helper.h>
+
+#include <algorithm>
+#include <cmath>
+
+TEST_CASE("Scalar successive-orders coefficient scattering matches Legendre "
+          "matrix",
+          "[successive_orders][scattering]") {
+    constexpr int num_coefficients = 6;
+    sasktran2::math::LebedevSphere incoming_sphere(14);
+    sasktran2::math::LebedevSphere outgoing_sphere(26);
+    sasktran2::successive_orders::ScalarAngularBasis basis(
+        incoming_sphere, outgoing_sphere, num_coefficients);
+
+    constexpr int num_blocks = 3;
+    Eigen::MatrixXd incoming(num_blocks, incoming_sphere.num_points());
+    Eigen::MatrixXd coefficients(num_blocks, num_coefficients);
+    for (int point = 0; point < num_blocks; ++point) {
+        for (int direction = 0; direction < incoming.cols(); ++direction) {
+            incoming(point, direction) = 0.2 + 0.01 * direction + 0.03 * point;
+        }
+        for (int degree = 0; degree < num_coefficients; ++degree) {
+            coefficients(point, degree) =
+                std::exp(-0.35 * degree) * (1.0 + 0.05 * point);
+        }
+    }
+
+    Eigen::MatrixXd actual(num_blocks, outgoing_sphere.num_points());
+    Eigen::MatrixXd moments;
+    basis.apply(incoming, coefficients, actual, moments);
+
+    Eigen::MatrixXd expected =
+        Eigen::MatrixXd::Zero(actual.rows(), actual.cols());
+    sasktran2::math::WignerDCalculator legendre(0, 0);
+    for (int point = 0; point < num_blocks; ++point) {
+        for (int outgoing = 0; outgoing < outgoing_sphere.num_points();
+             ++outgoing) {
+            for (int incoming_index = 0;
+                 incoming_index < incoming_sphere.num_points();
+                 ++incoming_index) {
+                const double cosine = std::clamp(
+                    incoming_sphere.get_quad_position(incoming_index)
+                        .dot(outgoing_sphere.get_quad_position(outgoing)),
+                    -1.0, 1.0);
+                double phase = 0.0;
+                for (int degree = 0; degree < num_coefficients; ++degree) {
+                    phase += coefficients(point, degree) *
+                             legendre.d(std::acos(cosine), degree);
+                }
+                expected(point, outgoing) +=
+                    incoming_sphere.quadrature_weight(incoming_index) * phase *
+                    incoming(point, incoming_index);
+            }
+        }
+    }
+
+    INFO("maximum absolute error = "
+         << (actual - expected).cwiseAbs().maxCoeff());
+    REQUIRE(actual.isApprox(expected, 2.0e-12));
+}
+
+TEST_CASE("Scalar successive-orders scattering JVP and VJP are adjoint",
+          "[successive_orders][scattering]") {
+    constexpr int num_coefficients = 5;
+    sasktran2::math::LebedevSphere incoming_sphere(14);
+    sasktran2::math::LebedevSphere outgoing_sphere(26);
+    sasktran2::successive_orders::ScalarAngularBasis basis(
+        incoming_sphere, outgoing_sphere, num_coefficients);
+
+    constexpr int num_blocks = 4;
+    Eigen::MatrixXd incoming =
+        Eigen::MatrixXd::Random(num_blocks, incoming_sphere.num_points());
+    Eigen::MatrixXd incoming_tangent =
+        Eigen::MatrixXd::Random(num_blocks, incoming_sphere.num_points());
+    Eigen::MatrixXd coefficients =
+        Eigen::MatrixXd::Random(num_blocks, num_coefficients);
+    Eigen::MatrixXd coefficient_tangent =
+        Eigen::MatrixXd::Random(num_blocks, num_coefficients);
+    Eigen::MatrixXd output_tangent(num_blocks, outgoing_sphere.num_points());
+    Eigen::MatrixXd moments;
+    Eigen::MatrixXd tangent_moments;
+    basis.apply_jvp(incoming, incoming_tangent, coefficients,
+                    coefficient_tangent, output_tangent, moments,
+                    tangent_moments);
+
+    Eigen::MatrixXd output_cotangent =
+        Eigen::MatrixXd::Random(num_blocks, outgoing_sphere.num_points());
+    Eigen::MatrixXd incoming_cotangent(num_blocks,
+                                       incoming_sphere.num_points());
+    Eigen::MatrixXd coefficient_gradient(num_blocks, num_coefficients);
+    Eigen::MatrixXd analyzed;
+    Eigen::MatrixXd moment_cotangent;
+    basis.apply_vjp(incoming, coefficients, output_cotangent,
+                    incoming_cotangent, coefficient_gradient, analyzed,
+                    moment_cotangent);
+
+    const double forward =
+        (output_tangent.array() * output_cotangent.array()).sum();
+    const double reverse =
+        (incoming_tangent.array() * incoming_cotangent.array()).sum() +
+        (coefficient_tangent.array() * coefficient_gradient.array()).sum();
+    REQUIRE(forward == Catch::Approx(reverse).epsilon(2.0e-12));
+}

--- a/cpp/lib/tests/successive_orders/test_fixed_point.cpp
+++ b/cpp/lib/tests/successive_orders/test_fixed_point.cpp
@@ -1,0 +1,132 @@
+#include "../../successive_orders/fixed_point.h"
+
+#include <sasktran2/test_helper.h>
+
+#include <Eigen/LU>
+
+namespace {
+    sasktran2::successive_orders::FixedPointSettings test_settings() {
+        sasktran2::successive_orders::FixedPointSettings settings;
+        settings.maximum_iterations = 100;
+        settings.relative_tolerance = 1.0e-12;
+        settings.absolute_tolerance = 1.0e-14;
+        return settings;
+    }
+} // namespace
+
+TEST_CASE("Successive-orders fixed point converges to affine solution",
+          "[successive_orders][solver]") {
+    Eigen::Matrix2d transport;
+    transport << 0.7, 0.05, 0.1, 0.4;
+    const Eigen::Vector2d forcing(1.0, 0.25);
+    const Eigen::Vector2d expected =
+        (Eigen::Matrix2d::Identity() - transport).inverse() * forcing;
+
+    Eigen::VectorXd state = Eigen::Vector2d::Zero();
+    sasktran2::successive_orders::FixedPointWorkspace workspace;
+    const auto diagnostics =
+        sasktran2::successive_orders::FixedPointSolver::solve(
+            state,
+            [&](const Eigen::VectorXd& input, Eigen::VectorXd& output) {
+                output.noalias() = forcing + transport * input;
+            },
+            test_settings(), workspace);
+
+    REQUIRE(diagnostics.converged());
+    REQUIRE(state.isApprox(expected, 1.0e-10));
+}
+
+TEST_CASE("Successive-orders Anderson history is reusable",
+          "[successive_orders][solver]") {
+    sasktran2::successive_orders::FixedPointWorkspace workspace;
+    auto settings = test_settings();
+    settings.anderson_depth = 3;
+
+    for (double contraction : {0.85, 0.65}) {
+        Eigen::VectorXd state = Eigen::VectorXd::Zero(8);
+        Eigen::VectorXd forcing = Eigen::VectorXd::LinSpaced(8, 0.1, 0.8);
+        const auto diagnostics =
+            sasktran2::successive_orders::FixedPointSolver::solve(
+                state,
+                [&](const Eigen::VectorXd& input, Eigen::VectorXd& output) {
+                    output = forcing + contraction * input;
+                },
+                settings, workspace);
+        REQUIRE(diagnostics.converged());
+        REQUIRE(state.isApprox(forcing / (1.0 - contraction), 1.0e-9));
+    }
+}
+
+TEST_CASE("Successive-orders zero tolerances preserve fixed iteration mode",
+          "[successive_orders][solver]") {
+    auto settings = test_settings();
+    settings.maximum_iterations = 4;
+    settings.relative_tolerance = 0.0;
+    settings.absolute_tolerance = 0.0;
+    settings.anderson_depth = 0;
+
+    Eigen::VectorXd state = Eigen::VectorXd::Zero(1);
+    sasktran2::successive_orders::FixedPointWorkspace workspace;
+    const auto diagnostics =
+        sasktran2::successive_orders::FixedPointSolver::solve(
+            state,
+            [](const Eigen::VectorXd& input, Eigen::VectorXd& output) {
+                output(0) = 1.0 + 0.5 * input(0);
+            },
+            settings, workspace);
+
+    REQUIRE_FALSE(diagnostics.converged());
+    REQUIRE(diagnostics.iterations == 4);
+    REQUIRE(state(0) == Catch::Approx(1.875));
+}
+
+TEST_CASE("Successive-orders damped Anderson uses undamped state history",
+          "[successive_orders][solver]") {
+    auto settings = test_settings();
+    settings.maximum_iterations = 2;
+    settings.relative_tolerance = 0.0;
+    settings.absolute_tolerance = 0.0;
+    settings.damping = 0.5;
+    settings.anderson_depth = 1;
+
+    Eigen::VectorXd state = Eigen::VectorXd::Zero(1);
+    sasktran2::successive_orders::FixedPointWorkspace workspace;
+    const auto diagnostics =
+        sasktran2::successive_orders::FixedPointSolver::solve(
+            state,
+            [](const Eigen::VectorXd& input, Eigen::VectorXd& output) {
+                output(0) = 1.0 + 0.5 * input(0);
+            },
+            settings, workspace);
+
+    // x_1 = 0.5, delta_x = 0.5, delta_f = -0.25, and gamma = -3.
+    // Type-II damping gives
+    // x_2 = x_1 + beta*f_1 - gamma*(delta_x + beta*delta_f) = 2.
+    // Scaling delta_x by beta as well would instead give 1.25.
+    REQUIRE_FALSE(diagnostics.converged());
+    REQUIRE(diagnostics.iterations == 2);
+    REQUIRE(state(0) == Catch::Approx(2.0).margin(1.0e-12));
+}
+
+TEST_CASE("Successive-orders implicit transpose uses the same solver",
+          "[successive_orders][solver][vjp]") {
+    Eigen::Matrix3d transport;
+    transport << 0.35, 0.04, 0.01, 0.12, 0.45, 0.02, 0.03, 0.08, 0.25;
+    const Eigen::Vector3d forcing(0.2, 0.5, -0.1);
+    const Eigen::Vector3d expected =
+        (Eigen::Matrix3d::Identity() - transport.transpose()).inverse() *
+        forcing;
+
+    Eigen::VectorXd adjoint = Eigen::Vector3d::Zero();
+    sasktran2::successive_orders::FixedPointWorkspace workspace;
+    const auto diagnostics =
+        sasktran2::successive_orders::FixedPointSolver::solve(
+            adjoint,
+            [&](const Eigen::VectorXd& input, Eigen::VectorXd& output) {
+                output.noalias() = forcing + transport.transpose() * input;
+            },
+            test_settings(), workspace);
+
+    REQUIRE(diagnostics.converged());
+    REQUIRE(adjoint.isApprox(expected, 1.0e-10));
+}

--- a/cpp/lib/tests/successive_orders/test_geometry.cpp
+++ b/cpp/lib/tests/successive_orders/test_geometry.cpp
@@ -1,0 +1,382 @@
+#include "../../successive_orders/geometry.h"
+
+#include <sasktran2/test_helper.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+
+namespace {
+    Eigen::VectorXd altitude_grid() {
+        return (Eigen::Vector3d() << 0.0, 1000.0, 3000.0).finished();
+    }
+
+    sasktran2::viewinggeometry::InternalViewingGeometry
+    make_los_geometry(const sasktran2::Geometry1D& geometry,
+                      const sasktran2::raytracing::RayTracerBase& raytracer) {
+        sasktran2::viewinggeometry::InternalViewingGeometry result;
+        result.traced_rays.resize(1);
+        sasktran2::viewinggeometry::ViewingRay ray;
+        ray.observer.position = geometry.coordinates().reference_point(4000.0);
+        ray.look_away = -ray.observer.position.normalized();
+        raytracer.trace_ray(ray, result.traced_rays.front());
+        return result;
+    }
+
+    class ThrowingRayTracer final
+        : public sasktran2::raytracing::RayTracerBase {
+      public:
+        void trace_ray(const sasktran2::viewinggeometry::ViewingRay&,
+                       sasktran2::raytracing::TracedRay&, bool) const override {
+            throw std::runtime_error("deliberate incoming ray-tracing failure");
+        }
+    };
+
+    sasktran2::viewinggeometry::InternalViewingGeometry
+    make_exact_direction_los(const sasktran2::Geometry1D& geometry) {
+        const std::array<Eigen::Vector3d, 4> directions{
+            Eigen::Vector3d::UnitZ(), -Eigen::Vector3d::UnitZ(),
+            Eigen::Vector3d::UnitX(), Eigen::Vector3d::UnitY()};
+        const Eigen::Vector3d location =
+            geometry.coordinates().reference_point(500.0);
+
+        sasktran2::viewinggeometry::InternalViewingGeometry result;
+        result.traced_rays.resize(directions.size());
+        for (std::size_t ray_index = 0; ray_index < directions.size();
+             ++ray_index) {
+            auto& ray = result.traced_rays[ray_index];
+            ray.observer_and_look.observer.position = location;
+            ray.observer_and_look.look_away = directions[ray_index];
+            ray.layers.resize(1);
+            auto& layer = ray.layers.front();
+            layer.entrance.position = location;
+            layer.exit.position = location;
+            layer.average_look_away = directions[ray_index];
+            layer.cos_sza_entrance = 1.0;
+            layer.cos_sza_exit = 1.0;
+        }
+        return result;
+    }
+
+    template <typename Weights> void require_sorted(const Weights& weights) {
+        REQUIRE(std::is_sorted(weights.begin(), weights.end(),
+                               [](const auto& left, const auto& right) {
+                                   return left.index < right.index;
+                               }));
+    }
+
+    void require_compiled_topology(
+        const std::vector<sasktran2::successive_orders::RayInterpolation>& rays,
+        const std::vector<int>& row_offsets,
+        const std::vector<int>& column_indices, int num_source_columns) {
+        REQUIRE(row_offsets.size() == rays.size() + 1);
+        REQUIRE(row_offsets.front() == 0);
+        REQUIRE(row_offsets.back() == static_cast<int>(column_indices.size()));
+        for (std::size_t row = 0; row < rays.size(); ++row) {
+            const auto& ray = rays[row];
+            REQUIRE(ray.traced_ray != nullptr);
+            REQUIRE(ray.layers.size() == ray.traced_ray->layers.size());
+            REQUIRE(ray.transport_value_offset ==
+                    static_cast<std::size_t>(row_offsets[row]));
+            REQUIRE(ray.transport_row_nnz ==
+                    static_cast<std::uint32_t>(row_offsets[row + 1] -
+                                               row_offsets[row]));
+            const auto begin = column_indices.begin() + row_offsets[row];
+            const auto end = column_indices.begin() + row_offsets[row + 1];
+            REQUIRE(std::is_sorted(begin, end));
+            REQUIRE(std::adjacent_find(begin, end) == end);
+            for (std::size_t layer = 0; layer < ray.layers.size(); ++layer) {
+                require_sorted(ray.atmosphere_for_layer(layer));
+                const auto source = ray.source_for_layer(layer);
+                for (const auto& weight : source) {
+                    REQUIRE(weight.source_index >= 0);
+                    REQUIRE(weight.source_index < num_source_columns);
+                    REQUIRE(row_offsets[row] + weight.row_inner_index <
+                            row_offsets[row + 1]);
+                    REQUIRE(column_indices[row_offsets[row] +
+                                           weight.row_inner_index] ==
+                            weight.source_index);
+                }
+            }
+            for (const auto& weight : ray.ground()) {
+                REQUIRE(weight.source_index >= 0);
+                REQUIRE(weight.source_index < num_source_columns);
+                REQUIRE(
+                    column_indices[row_offsets[row] + weight.row_inner_index] ==
+                    weight.source_index);
+            }
+        }
+    }
+
+    void require_los_direction(
+        const sasktran2::successive_orders::SourceGeometry1D& geometry,
+        std::size_t ray_index, const Eigen::Vector3d& expected_direction) {
+        const auto weights =
+            geometry.los_interpolation()[ray_index].source_for_layer(0);
+        REQUIRE(!weights.empty());
+
+        double weight_sum = 0.0;
+        for (const auto& weight : weights) {
+            REQUIRE(std::isfinite(weight.weight));
+            weight_sum += weight.weight;
+
+            const sasktran2::successive_orders::SourcePoint* owner = nullptr;
+            for (const auto& point : geometry.source_points()) {
+                if (weight.source_index >= point.outgoing_offset() &&
+                    weight.source_index <
+                        point.outgoing_offset() + point.num_outgoing()) {
+                    owner = &point;
+                    break;
+                }
+            }
+            REQUIRE(owner != nullptr);
+            const int local_direction =
+                weight.source_index - owner->outgoing_offset();
+            const Eigen::Vector3d compiled_direction =
+                owner->outgoing_sphere().get_quad_position(local_direction);
+            REQUIRE(compiled_direction.dot(expected_direction) ==
+                    Catch::Approx(1.0).margin(1.0e-12));
+        }
+        REQUIRE(weight_sum == Catch::Approx(1.0).margin(1.0e-12));
+    }
+} // namespace
+
+TEST_CASE("Successive-orders 1D geometry compiles midpoint source and LOS "
+          "topology",
+          "[successive_orders][geometry]") {
+    sasktran2::Geometry1D geometry(0.4, 0.0, 6372000.0, altitude_grid(),
+                                   sasktran2::grids::interpolation::linear,
+                                   sasktran2::geometrytype::spherical);
+    sasktran2::raytracing::SphericalShellRayTracer raytracer(geometry);
+    const auto los = make_los_geometry(geometry, raytracer);
+
+    sasktran2::successive_orders::SourceGeometrySettings settings;
+    settings.num_incoming = 6;
+    settings.num_outgoing = 14;
+    settings.num_threads = 1;
+    sasktran2::successive_orders::SourceGeometry1D source_geometry(raytracer,
+                                                                   geometry);
+    source_geometry.initialize(los, settings);
+
+    REQUIRE(source_geometry.source_altitudes_m() ==
+            std::vector<double>{500.0, 2000.0});
+    REQUIRE(source_geometry.num_interior_points() == 2);
+    REQUIRE(source_geometry.num_ground_points() == 1);
+    REQUIRE(source_geometry.num_points() == 3);
+    REQUIRE(source_geometry.incoming_point_offsets().size() == 4);
+    REQUIRE(source_geometry.outgoing_point_offsets().size() == 4);
+    REQUIRE(source_geometry.incoming_rays().size() ==
+            static_cast<std::size_t>(source_geometry.total_num_incoming()));
+    for (std::size_t ray = 0; ray < source_geometry.incoming_rays().size();
+         ++ray) {
+        REQUIRE(source_geometry.incoming_interpolation()[ray].traced_ray ==
+                &source_geometry.incoming_rays()[ray]);
+    }
+    for (const auto& point : source_geometry.source_points()) {
+        require_sorted(point.atmosphere_weights());
+    }
+
+    require_compiled_topology(source_geometry.incoming_interpolation(),
+                              source_geometry.transport_row_offsets(),
+                              source_geometry.transport_column_indices(),
+                              source_geometry.total_num_outgoing());
+    require_compiled_topology(source_geometry.los_interpolation(),
+                              source_geometry.los_transport_row_offsets(),
+                              source_geometry.los_transport_column_indices(),
+                              source_geometry.total_num_outgoing());
+}
+
+TEST_CASE("Successive-orders default source grid preserves nonuniform midpoint "
+          "interpolation",
+          "[successive_orders][geometry]") {
+    Eigen::VectorXd altitudes(4);
+    altitudes << 0.0, 1000.0, 3000.0, 6000.0;
+    sasktran2::Geometry1D geometry(0.4, 0.0, 6372000.0, std::move(altitudes),
+                                   sasktran2::grids::interpolation::linear,
+                                   sasktran2::geometrytype::planeparallel);
+    sasktran2::raytracing::PlaneParallelRayTracer raytracer(geometry);
+
+    sasktran2::viewinggeometry::InternalViewingGeometry los;
+    los.traced_rays.resize(1);
+    auto& ray = los.traced_rays.front();
+    const Eigen::Vector3d location =
+        geometry.coordinates().reference_point(3000.0);
+    const Eigen::Vector3d direction = location.normalized();
+    ray.observer_and_look.observer.position = location;
+    ray.observer_and_look.look_away = direction;
+    ray.layers.resize(1);
+    ray.layers.front().entrance.position = location;
+    ray.layers.front().exit.position = location;
+    ray.layers.front().average_look_away = direction;
+    ray.layers.front().cos_sza_entrance = 0.4;
+    ray.layers.front().cos_sza_exit = 0.4;
+
+    sasktran2::successive_orders::SourceGeometrySettings settings;
+    settings.num_incoming = 6;
+    settings.num_outgoing = 6;
+    sasktran2::successive_orders::SourceGeometry1D source_geometry(raytracer,
+                                                                   geometry);
+    source_geometry.initialize(los, settings);
+
+    REQUIRE(source_geometry.source_altitudes_m() ==
+            std::vector<double>{500.0, 2000.0, 4500.0});
+    std::vector<double> location_weights(3, 0.0);
+    for (const auto& weight :
+         source_geometry.los_interpolation().front().source_for_layer(0)) {
+        int owner = -1;
+        for (int point_index = 0;
+             point_index < source_geometry.num_interior_points();
+             ++point_index) {
+            const auto& point = source_geometry.source_point(point_index);
+            if (weight.source_index >= point.outgoing_offset() &&
+                weight.source_index <
+                    point.outgoing_offset() + point.num_outgoing()) {
+                owner = point_index;
+                break;
+            }
+        }
+        REQUIRE(owner >= 0);
+        location_weights[owner] += weight.weight;
+    }
+
+    REQUIRE(location_weights[0] == Catch::Approx(0.0).margin(1.0e-14));
+    REQUIRE(location_weights[1] == Catch::Approx(0.6).margin(1.0e-13));
+    REQUIRE(location_weights[2] == Catch::Approx(0.4).margin(1.0e-13));
+}
+
+TEST_CASE("Successive-orders 1D geometry accepts a valid explicit altitude "
+          "grid and rejects invalid grids",
+          "[successive_orders][geometry]") {
+    sasktran2::Geometry1D geometry(0.4, 0.0, 6372000.0, altitude_grid(),
+                                   sasktran2::grids::interpolation::linear,
+                                   sasktran2::geometrytype::spherical);
+    sasktran2::raytracing::SphericalShellRayTracer raytracer(geometry);
+    const auto los = make_los_geometry(geometry, raytracer);
+
+    sasktran2::successive_orders::SourceGeometrySettings settings;
+    settings.num_incoming = 6;
+    settings.num_outgoing = 6;
+    settings.altitude_grid_m = {250.0, 2750.0};
+    sasktran2::successive_orders::SourceGeometry1D valid(raytracer, geometry);
+    valid.initialize(los, settings);
+    REQUIRE(valid.source_altitudes_m() == settings.altitude_grid_m);
+
+    settings.altitude_grid_m = {500.0, 400.0};
+    sasktran2::successive_orders::SourceGeometry1D unordered(raytracer,
+                                                             geometry);
+    REQUIRE_THROWS_AS(unordered.initialize(los, settings),
+                      std::invalid_argument);
+
+    settings.altitude_grid_m = {-1.0, 500.0};
+    sasktran2::successive_orders::SourceGeometry1D outside(raytracer, geometry);
+    REQUIRE_THROWS_AS(outside.initialize(los, settings), std::invalid_argument);
+
+    const std::string boundary_error =
+        "Successive-orders source altitudes must lie strictly inside the "
+        "atmosphere altitude range";
+    settings.altitude_grid_m = {0.0, 500.0};
+    sasktran2::successive_orders::SourceGeometry1D lower_boundary(raytracer,
+                                                                  geometry);
+    REQUIRE_THROWS_WITH(lower_boundary.initialize(los, settings),
+                        boundary_error);
+
+    settings.altitude_grid_m = {500.0, 3000.0};
+    sasktran2::successive_orders::SourceGeometry1D upper_boundary(raytracer,
+                                                                  geometry);
+    REQUIRE_THROWS_WITH(upper_boundary.initialize(los, settings),
+                        boundary_error);
+}
+
+TEST_CASE("Successive-orders pseudospherical geometry avoids duplicate SZA "
+          "source columns",
+          "[successive_orders][geometry]") {
+    sasktran2::Geometry1D geometry(0.4, 0.0, 6372000.0, altitude_grid(),
+                                   sasktran2::grids::interpolation::linear,
+                                   sasktran2::geometrytype::pseudospherical);
+    sasktran2::raytracing::PlaneParallelRayTracer raytracer(geometry);
+    auto los = make_los_geometry(geometry, raytracer);
+    // Even if externally supplied ray metadata spans an SZA range, a
+    // pseudospherical Geometry1D source has only one physical column.
+    los.traced_rays.front().layers.front().cos_sza_entrance = 0.2;
+    los.traced_rays.front().layers.front().cos_sza_exit = 0.6;
+
+    sasktran2::successive_orders::SourceGeometrySettings settings;
+    settings.num_incoming = 6;
+    settings.num_outgoing = 6;
+    settings.num_sza = 4;
+    sasktran2::successive_orders::SourceGeometry1D source_geometry(raytracer,
+                                                                   geometry);
+    source_geometry.initialize(los, settings);
+
+    REQUIRE(source_geometry.source_cos_sza() == std::vector<double>{0.4});
+    REQUIRE(source_geometry.num_interior_points() == 2);
+    REQUIRE(source_geometry.num_ground_points() == 1);
+}
+
+TEST_CASE("Successive-orders geometry propagates incoming ray-tracing errors "
+          "outside the parallel region",
+          "[successive_orders][geometry]") {
+    sasktran2::Geometry1D geometry(0.4, 0.0, 6372000.0, altitude_grid(),
+                                   sasktran2::grids::interpolation::linear,
+                                   sasktran2::geometrytype::spherical);
+    sasktran2::raytracing::SphericalShellRayTracer valid_raytracer(geometry);
+    const auto los = make_los_geometry(geometry, valid_raytracer);
+    const ThrowingRayTracer throwing_raytracer;
+
+    sasktran2::successive_orders::SourceGeometrySettings settings;
+    settings.num_incoming = 6;
+    settings.num_outgoing = 6;
+    settings.num_threads = 2;
+    sasktran2::successive_orders::SourceGeometry1D source_geometry(
+        throwing_raytracer, geometry);
+
+    REQUIRE_THROWS_WITH(source_geometry.initialize(los, settings),
+                        "deliberate incoming ray-tracing failure");
+}
+
+TEST_CASE("Successive-orders geometry propagates LOS interpolation errors "
+          "outside the parallel region",
+          "[successive_orders][geometry]") {
+    sasktran2::Geometry1D geometry(0.4, 0.0, 6372000.0, altitude_grid(),
+                                   sasktran2::grids::interpolation::linear,
+                                   sasktran2::geometrytype::spherical);
+    sasktran2::raytracing::SphericalShellRayTracer raytracer(geometry);
+    auto los = make_los_geometry(geometry, raytracer);
+    los.traced_rays.front().layers.front().entrance.position.x() =
+        std::numeric_limits<double>::quiet_NaN();
+
+    sasktran2::successive_orders::SourceGeometrySettings settings;
+    settings.num_incoming = 6;
+    settings.num_outgoing = 6;
+    settings.num_threads = 2;
+    sasktran2::successive_orders::SourceGeometry1D source_geometry(raytracer,
+                                                                   geometry);
+
+    REQUIRE_THROWS_WITH(source_geometry.initialize(los, settings),
+                        "Invalid input. Check log for more information");
+}
+
+TEST_CASE("Successive-orders spherical interpolation preserves exact axial "
+          "directions",
+          "[successive_orders][geometry]") {
+    sasktran2::Geometry1D geometry(1.0, 0.0, 6372000.0, altitude_grid(),
+                                   sasktran2::grids::interpolation::linear,
+                                   sasktran2::geometrytype::spherical);
+    sasktran2::raytracing::SphericalShellRayTracer raytracer(geometry);
+    const auto los = make_exact_direction_los(geometry);
+
+    sasktran2::successive_orders::SourceGeometrySettings settings;
+    settings.num_incoming = 6;
+    settings.num_outgoing = 6;
+    settings.num_threads = 2;
+    sasktran2::successive_orders::SourceGeometry1D source_geometry(raytracer,
+                                                                   geometry);
+    source_geometry.initialize(los, settings);
+
+    require_los_direction(source_geometry, 0, Eigen::Vector3d::UnitZ());
+    require_los_direction(source_geometry, 1, -Eigen::Vector3d::UnitZ());
+    require_los_direction(source_geometry, 2, Eigen::Vector3d::UnitX());
+    require_los_direction(source_geometry, 3, Eigen::Vector3d::UnitY());
+}

--- a/cpp/lib/tests/successive_orders/test_problem.cpp
+++ b/cpp/lib/tests/successive_orders/test_problem.cpp
@@ -1,0 +1,282 @@
+#include "../../successive_orders/problem.h"
+
+#include <sasktran2/math/unitsphere.h>
+#include <sasktran2/test_helper.h>
+
+#include <Eigen/LU>
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace {
+    using namespace sasktran2::successive_orders;
+
+    TransportSparsity dense_sparsity(int size) {
+        std::vector<int> row_offsets(static_cast<std::size_t>(size) + 1);
+        std::vector<int> column_indices;
+        column_indices.reserve(static_cast<std::size_t>(size) * size);
+        for (int row = 0; row < size; ++row) {
+            row_offsets[row] = static_cast<int>(column_indices.size());
+            for (int column = 0; column < size; ++column) {
+                column_indices.push_back(column);
+            }
+        }
+        row_offsets[size] = static_cast<int>(column_indices.size());
+        return {size, std::move(row_offsets), std::move(column_indices)};
+    }
+
+    ScalarAngularBasis scalar_basis() {
+        sasktran2::math::LebedevSphere incoming(6);
+        sasktran2::math::LebedevSphere outgoing(6);
+        return {incoming, outgoing, 3};
+    }
+
+    FixedPointSettings tight_settings() {
+        FixedPointSettings settings;
+        settings.maximum_iterations = 150;
+        settings.relative_tolerance = 1.0e-13;
+        settings.absolute_tolerance = 1.0e-14;
+        settings.anderson_depth = 3;
+        return settings;
+    }
+
+    template <int NSTOKES>
+    Eigen::MatrixXd build_linear_matrix(const Problem<NSTOKES>& problem,
+                                        ProblemWorkspace<NSTOKES>& workspace) {
+        Eigen::MatrixXd result(problem.state_size(), problem.state_size());
+        Eigen::VectorXd input = Eigen::VectorXd::Zero(problem.state_size());
+        Eigen::VectorXd output(problem.state_size());
+        for (int column = 0; column < problem.state_size(); ++column) {
+            input(column) = 1.0;
+            problem.apply_linear(input, output, workspace);
+            result.col(column) = output;
+            input(column) = 0.0;
+        }
+        return result;
+    }
+
+    struct ScalarProblemFixture {
+        ScalarProblemFixture()
+            : sparsity(dense_sparsity(8)), transport(sparsity),
+              scattering(ScatteringBlockLayout(1, 1, 6, 6, 2, 2, 1),
+                         scalar_basis()),
+              problem(transport, scattering),
+              forcing(Eigen::VectorXd::LinSpaced(8, 0.04, 0.11)) {
+            for (int row = 0; row < 8; ++row) {
+                for (int column = 0; column < 8; ++column) {
+                    transport.values()(row * 8 + column) =
+                        0.002 * (1 + (row + 2 * column) % 5);
+                }
+            }
+            scattering.atmospheric_coefficients() << 0.22, 0.035, -0.012;
+            Eigen::Matrix2d ground;
+            ground << 0.12, 0.025, -0.015, 0.09;
+            scattering.set_ground_block(0, ground);
+            workspace.resize(transport, scattering);
+        }
+
+        ProblemParameterData<1> tangent() const {
+            ProblemParameterData<1> result;
+            result.resize(transport, scattering);
+            result.forcing = Eigen::VectorXd::LinSpaced(8, -0.025, 0.018);
+            for (int index = 0; index < result.transport_values.size();
+                 ++index) {
+                result.transport_values(index) = 0.0007 * ((index % 7) - 3);
+            }
+            result.atmospheric_coefficients << 0.018, -0.011, 0.006;
+            result.ground_values << 0.012, -0.008, 0.004, 0.009;
+            return result;
+        }
+
+        TransportSparsity sparsity;
+        TransportOperator transport;
+        ScatteringOperator<1> scattering;
+        Problem<1> problem;
+        ProblemWorkspace<1> workspace;
+        Eigen::VectorXd forcing;
+    };
+
+    double parameter_inner_product(const ProblemParameterData<1>& left,
+                                   const ProblemParameterData<1>& right) {
+        return left.forcing.dot(right.forcing) +
+               left.transport_values.dot(right.transport_values) +
+               (left.atmospheric_coefficients.array() *
+                right.atmospheric_coefficients.array())
+                   .sum() +
+               left.ground_values.dot(right.ground_values);
+    }
+} // namespace
+
+TEST_CASE("Successive-orders scalar problem matches a dense fixed-point solve",
+          "[successive_orders][problem]") {
+    ScalarProblemFixture fixture;
+    const Eigen::MatrixXd linear =
+        build_linear_matrix(fixture.problem, fixture.workspace);
+    Eigen::VectorXd direct(fixture.problem.state_size());
+    Eigen::VectorXd zero = Eigen::VectorXd::Zero(fixture.problem.state_size());
+    fixture.problem.apply(zero, fixture.forcing, direct, fixture.workspace);
+    const Eigen::VectorXd expected =
+        (Eigen::MatrixXd::Identity(fixture.problem.state_size(),
+                                   fixture.problem.state_size()) -
+         linear)
+            .partialPivLu()
+            .solve(direct);
+
+    Eigen::VectorXd state = zero;
+    const auto diagnostics = fixture.problem.solve(
+        fixture.forcing, state, tight_settings(), fixture.workspace);
+    REQUIRE(diagnostics.converged());
+    REQUIRE(state.isApprox(expected, 2.0e-11));
+}
+
+TEST_CASE("Successive-orders scalar implicit JVP matches finite differences",
+          "[successive_orders][problem][jvp]") {
+    ScalarProblemFixture fixture;
+    Eigen::VectorXd state = Eigen::VectorXd::Zero(fixture.problem.state_size());
+    REQUIRE(
+        fixture.problem
+            .solve(fixture.forcing, state, tight_settings(), fixture.workspace)
+            .converged());
+    const ProblemParameterData<1> tangent = fixture.tangent();
+    Eigen::VectorXd state_tangent;
+    REQUIRE(fixture.problem
+                .solve_jvp(fixture.forcing, state, tangent, state_tangent,
+                           tight_settings(), fixture.workspace)
+                .converged());
+
+    const Eigen::VectorXd transport_values = fixture.transport.values();
+    const Eigen::MatrixXd coefficients =
+        fixture.scattering.atmospheric_coefficients();
+    const Eigen::VectorXd ground_values = fixture.scattering.ground_values();
+    constexpr double step = 1.0e-6;
+
+    fixture.transport.values() =
+        transport_values + step * tangent.transport_values;
+    fixture.scattering.atmospheric_coefficients() =
+        coefficients + step * tangent.atmospheric_coefficients;
+    fixture.scattering.ground_values() =
+        ground_values + step * tangent.ground_values;
+    Eigen::VectorXd plus = state;
+    const Eigen::VectorXd plus_forcing =
+        fixture.forcing + step * tangent.forcing;
+    REQUIRE(fixture.problem
+                .solve(plus_forcing, plus, tight_settings(), fixture.workspace)
+                .converged());
+
+    fixture.transport.values() =
+        transport_values - step * tangent.transport_values;
+    fixture.scattering.atmospheric_coefficients() =
+        coefficients - step * tangent.atmospheric_coefficients;
+    fixture.scattering.ground_values() =
+        ground_values - step * tangent.ground_values;
+    Eigen::VectorXd minus = state;
+    const Eigen::VectorXd minus_forcing =
+        fixture.forcing - step * tangent.forcing;
+    REQUIRE(
+        fixture.problem
+            .solve(minus_forcing, minus, tight_settings(), fixture.workspace)
+            .converged());
+
+    fixture.transport.values() = transport_values;
+    fixture.scattering.atmospheric_coefficients() = coefficients;
+    fixture.scattering.ground_values() = ground_values;
+    const Eigen::VectorXd finite_difference = (plus - minus) / (2.0 * step);
+    REQUIRE((state_tangent - finite_difference).norm() <=
+            2.0e-7 * std::max(1.0, finite_difference.norm()));
+}
+
+TEST_CASE("Successive-orders scalar implicit VJP is adjoint to the JVP",
+          "[successive_orders][problem][jvp][vjp]") {
+    ScalarProblemFixture fixture;
+    Eigen::VectorXd state = Eigen::VectorXd::Zero(fixture.problem.state_size());
+    REQUIRE(
+        fixture.problem
+            .solve(fixture.forcing, state, tight_settings(), fixture.workspace)
+            .converged());
+    const ProblemParameterData<1> tangent = fixture.tangent();
+    Eigen::VectorXd state_tangent;
+    REQUIRE(fixture.problem
+                .solve_jvp(fixture.forcing, state, tangent, state_tangent,
+                           tight_settings(), fixture.workspace)
+                .converged());
+
+    const Eigen::VectorXd state_cotangent =
+        Eigen::VectorXd::LinSpaced(fixture.problem.state_size(), -0.4, 0.65);
+    ProblemParameterData<1> gradient;
+    Eigen::VectorXd adjoint;
+    REQUIRE(fixture.problem
+                .solve_vjp(fixture.forcing, state, state_cotangent, gradient,
+                           tight_settings(), fixture.workspace, adjoint)
+                .converged());
+
+    const double forward = state_tangent.dot(state_cotangent);
+    const double reverse = parameter_inner_product(tangent, gradient);
+    REQUIRE(forward == Catch::Approx(reverse).epsilon(3.0e-10));
+}
+
+TEST_CASE(
+    "Successive-orders coefficient vector problem supports primal products",
+    "[successive_orders][problem][vector]") {
+    sasktran2::math::LebedevSphere sphere(6);
+    auto basis = std::make_shared<const VectorAngularBasis>(sphere, sphere, 3);
+    TransportSparsity sparsity = dense_sparsity(sphere.num_points());
+    TransportOperator transport(sparsity);
+    for (int index = 0; index < transport.values().size(); ++index) {
+        transport.values()(index) = 0.002 * (1 + index % 5);
+    }
+    ScatteringOperator<3> scattering(
+        ScatteringBlockLayout(1, 0, sphere.num_points(), sphere.num_points(), 1,
+                              1, 3),
+        std::move(basis));
+    Eigen::MatrixXd coefficients = Eigen::MatrixXd::Zero(1, 12);
+    coefficients(0, 0) = 0.18;
+    coefficients(0, 4) = 0.025;
+    coefficients(0, 5) = -0.012;
+    coefficients(0, 6) = 0.009;
+    coefficients(0, 7) = 0.006;
+    scattering.set_atmospheric_coefficients(coefficients);
+    Problem<3> problem(transport, scattering);
+    ProblemWorkspace<3> workspace;
+    workspace.resize(transport, scattering);
+    const Eigen::VectorXd forcing =
+        Eigen::VectorXd::LinSpaced(problem.incoming_size(), 0.02, 0.09);
+
+    const Eigen::MatrixXd linear = build_linear_matrix(problem, workspace);
+    Eigen::VectorXd direct(problem.state_size());
+    Eigen::VectorXd zero = Eigen::VectorXd::Zero(problem.state_size());
+    problem.apply(zero, forcing, direct, workspace);
+    const Eigen::VectorXd expected =
+        (Eigen::MatrixXd::Identity(problem.state_size(), problem.state_size()) -
+         linear)
+            .partialPivLu()
+            .solve(direct);
+    Eigen::VectorXd state = zero;
+    REQUIRE(
+        problem.solve(forcing, state, tight_settings(), workspace).converged());
+    REQUIRE(state.isApprox(expected, 2.0e-12));
+
+    ProblemParameterData<3> tangent;
+    tangent.resize(transport, scattering);
+    tangent.set_zero();
+    tangent.forcing =
+        Eigen::VectorXd::LinSpaced(problem.incoming_size(), -0.01, 0.015);
+    Eigen::VectorXd state_tangent;
+    REQUIRE(problem
+                .solve_jvp(forcing, state, tangent, state_tangent,
+                           tight_settings(), workspace)
+                .converged());
+    const Eigen::VectorXd state_cotangent =
+        Eigen::VectorXd::LinSpaced(problem.state_size(), 0.1, 0.6);
+    ProblemParameterData<3> gradient;
+    Eigen::VectorXd adjoint;
+    REQUIRE(problem
+                .solve_vjp(forcing, state, state_cotangent, gradient,
+                           tight_settings(), workspace, adjoint)
+                .converged());
+    REQUIRE(
+        state_tangent.dot(state_cotangent) ==
+        Catch::Approx(tangent.forcing.dot(gradient.forcing)).epsilon(2.0e-11));
+}

--- a/cpp/lib/tests/successive_orders/test_ray_transport.cpp
+++ b/cpp/lib/tests/successive_orders/test_ray_transport.cpp
@@ -1,0 +1,264 @@
+#include "../../successive_orders/ray_transport.h"
+
+#include <sasktran2/test_helper.h>
+
+#include <array>
+#include <cmath>
+#include <vector>
+
+namespace {
+    constexpr int num_locations = 3;
+    constexpr int num_wavelengths = 2;
+    constexpr int num_source_columns = 4;
+
+    struct RayTransportFixture {
+        RayTransportFixture()
+            : atmosphere(sasktran2::atmosphere::AtmosphereGridStorageFull<1>(
+                             num_wavelengths, num_locations, 1),
+                         sasktran2::atmosphere::Surface<1>(num_wavelengths),
+                         true) {
+            atmosphere.storage().total_extinction.col(0) << 0.3, 0.5, 0.2;
+            atmosphere.storage().total_extinction.col(1) << 0.1, 0.4, 0.7;
+            atmosphere.storage().ssa.col(0) << 0.8, 0.6, 0.4;
+            atmosphere.storage().ssa.col(1) << 0.35, 0.55, 0.75;
+
+            traced_rays.resize(2);
+            traced_rays[0].layers.resize(2);
+            traced_rays[0].ground_is_hit = true;
+            set_layer_weights(traced_rays[0], 0, {0, 1}, {0.7, 0.2});
+            set_layer_weights(traced_rays[0], 1, {1, 2}, {0.4, 1.1});
+
+            traced_rays[1].layers.resize(1);
+            set_layer_weights(traced_rays[1], 0, {0, 2}, {0.3, 0.5});
+
+            interpolation.resize(2);
+            interpolation[0].traced_ray = &traced_rays[0];
+            interpolation[0].layers = {{0, 2, 0, 2}, {2, 2, 2, 2}};
+            interpolation[0].atmosphere_weights = {
+                {0, 0.25}, {1, 0.75}, {1, 0.4}, {2, 0.6}};
+            interpolation[0].source_weights = {
+                {0, 0.25, 0}, {2, 0.75, 2}, {1, 0.6, 1}, {2, 0.4, 2}};
+            interpolation[0].ground_weights = {{0, 0.2, 0}, {3, 0.8, 3}};
+            interpolation[0].transport_value_offset = 0;
+            interpolation[0].transport_row_nnz = 4;
+
+            interpolation[1].traced_ray = &traced_rays[1];
+            interpolation[1].layers = {{0, 2, 0, 2}};
+            interpolation[1].atmosphere_weights = {{0, 0.5}, {2, 0.5}};
+            interpolation[1].source_weights = {{1, 0.7, 0}, {3, 0.3, 1}};
+            interpolation[1].transport_value_offset = 4;
+            interpolation[1].transport_row_nnz = 2;
+        }
+
+        RayTransportFixture(const RayTransportFixture&) = delete;
+        RayTransportFixture& operator=(const RayTransportFixture&) = delete;
+
+        sasktran2::successive_orders::RayTransportMap make_map() const {
+            return {interpolation, num_source_columns, row_offsets,
+                    column_indices};
+        }
+
+        void perturb(int wavelength, const Eigen::VectorXd& native_tangent,
+                     double scale) {
+            atmosphere.storage().total_extinction.col(wavelength) +=
+                scale * native_tangent.head(num_locations);
+            atmosphere.storage().ssa.col(wavelength) +=
+                scale * native_tangent.segment(
+                            atmosphere.ssa_deriv_start_index(), num_locations);
+        }
+
+        std::vector<sasktran2::raytracing::TracedRay> traced_rays;
+        std::vector<sasktran2::successive_orders::RayInterpolation>
+            interpolation;
+        const std::vector<int> row_offsets{0, 4, 6};
+        const std::vector<int> column_indices{0, 1, 2, 3, 1, 3};
+        sasktran2::atmosphere::Atmosphere<1> atmosphere;
+
+      private:
+        static void
+        set_layer_weights(sasktran2::raytracing::TracedRay& ray,
+                          std::size_t layer, const std::array<int, 2>& indices,
+                          const std::array<double, 2>& optical_depth_weights) {
+            const std::array<double, 2> entrance{0.5, 0.5};
+            const std::array<double, 2> exit{0.5, 0.5};
+            ray.set_layer_weights(layer, indices, entrance, exit,
+                                  optical_depth_weights);
+        }
+    };
+
+    Eigen::VectorXd expected_values_at_wavelength_one() {
+        const double layer_zero_od = 0.7 * 0.1 + 0.2 * 0.4;
+        const double layer_one_od = 0.4 * 0.4 + 1.1 * 0.7;
+        const double layer_zero_ssa = 0.25 * 0.35 + 0.75 * 0.55;
+        const double layer_one_ssa = 0.4 * 0.55 + 0.6 * 0.75;
+
+        const double layer_one_factor =
+            layer_one_ssa * (1.0 - std::exp(-layer_one_od));
+        const double layer_zero_factor = std::exp(-layer_one_od) *
+                                         layer_zero_ssa *
+                                         (1.0 - std::exp(-layer_zero_od));
+        const double ground_factor = std::exp(-(layer_one_od + layer_zero_od));
+
+        const double second_ray_od = 0.3 * 0.1 + 0.5 * 0.7;
+        const double second_ray_ssa = 0.5 * 0.35 + 0.5 * 0.75;
+        const double second_ray_factor =
+            second_ray_ssa * (1.0 - std::exp(-second_ray_od));
+
+        Eigen::VectorXd expected(6);
+        expected << 0.25 * layer_zero_factor + 0.2 * ground_factor,
+            0.6 * layer_one_factor,
+            0.75 * layer_zero_factor + 0.4 * layer_one_factor,
+            0.8 * ground_factor, 0.7 * second_ray_factor,
+            0.3 * second_ray_factor;
+        return expected;
+    }
+} // namespace
+
+TEST_CASE("Successive-orders packed ray transport assembles layer and ground "
+          "values",
+          "[successive_orders][ray_transport]") {
+    RayTransportFixture fixture;
+    const auto map = fixture.make_map();
+    sasktran2::successive_orders::TransportOperator transport(map.sparsity());
+
+    map.assemble_values(fixture.atmosphere, 1, transport);
+
+    REQUIRE(map.num_rays() == 2);
+    REQUIRE(map.maximum_layers() == 2);
+    REQUIRE(map.sparsity().row_offsets() == fixture.row_offsets);
+    REQUIRE(map.sparsity().column_indices() == fixture.column_indices);
+    REQUIRE(transport.values().isApprox(expected_values_at_wavelength_one(),
+                                        2.0e-14));
+}
+
+TEST_CASE("Successive-orders packed ray transport JVP matches finite "
+          "differences",
+          "[successive_orders][ray_transport][linearization]") {
+    RayTransportFixture fixture;
+    const auto map = fixture.make_map();
+    const int wavelength = 1;
+
+    Eigen::VectorXd tangent =
+        Eigen::VectorXd::Zero(fixture.atmosphere.num_deriv());
+    tangent.head(num_locations) << 0.08, -0.03, 0.06;
+    tangent.segment(fixture.atmosphere.ssa_deriv_start_index(), num_locations)
+        << -0.04,
+        0.07, 0.02;
+
+    Eigen::VectorXd analytic(map.sparsity().nonzeros());
+    map.assemble_jvp(fixture.atmosphere, wavelength, tangent, analytic);
+
+    constexpr double step = 1.0e-6;
+    sasktran2::successive_orders::TransportOperator above(map.sparsity());
+    sasktran2::successive_orders::TransportOperator below(map.sparsity());
+    fixture.perturb(wavelength, tangent, step);
+    map.assemble_values(fixture.atmosphere, wavelength, above);
+    fixture.perturb(wavelength, tangent, -2.0 * step);
+    map.assemble_values(fixture.atmosphere, wavelength, below);
+    fixture.perturb(wavelength, tangent, step);
+
+    const Eigen::VectorXd finite_difference =
+        (above.values() - below.values()) / (2.0 * step);
+    REQUIRE(analytic.isApprox(finite_difference, 2.0e-9));
+}
+
+TEST_CASE("Successive-orders packed ray transport VJP is adjoint and matches "
+          "finite differences",
+          "[successive_orders][ray_transport][linearization]") {
+    RayTransportFixture fixture;
+    const auto map = fixture.make_map();
+    const int wavelength = 1;
+    const Eigen::VectorXd value_gradient =
+        (Eigen::VectorXd(6) << 0.2, -0.35, 0.5, 0.1, -0.4, 0.3).finished();
+    Eigen::VectorXd tangent =
+        Eigen::VectorXd::Zero(fixture.atmosphere.num_deriv());
+    tangent.head(num_locations) << 0.08, -0.03, 0.06;
+    tangent.segment(fixture.atmosphere.ssa_deriv_start_index(), num_locations)
+        << -0.04,
+        0.07, 0.02;
+
+    Eigen::VectorXd value_tangent(map.sparsity().nonzeros());
+    map.assemble_jvp(fixture.atmosphere, wavelength, tangent, value_tangent);
+    Eigen::VectorXd native_gradient =
+        Eigen::VectorXd::Zero(fixture.atmosphere.num_deriv());
+    sasktran2::successive_orders::RayTransportWorkspace workspace;
+    map.accumulate_vjp(fixture.atmosphere, wavelength, value_gradient,
+                       native_gradient, workspace);
+
+    REQUIRE(value_tangent.dot(value_gradient) ==
+            Catch::Approx(tangent.dot(native_gradient)).epsilon(2.0e-13));
+    REQUIRE(workspace.storage_bytes() ==
+            static_cast<std::size_t>(5 * map.maximum_layers()) *
+                sizeof(double));
+
+    constexpr double step = 1.0e-6;
+    for (int derivative = 0; derivative < 2 * num_locations; ++derivative) {
+        Eigen::VectorXd coordinate =
+            Eigen::VectorXd::Zero(fixture.atmosphere.num_deriv());
+        coordinate(derivative) = 1.0;
+        sasktran2::successive_orders::TransportOperator above(map.sparsity());
+        sasktran2::successive_orders::TransportOperator below(map.sparsity());
+        fixture.perturb(wavelength, coordinate, step);
+        map.assemble_values(fixture.atmosphere, wavelength, above);
+        fixture.perturb(wavelength, coordinate, -2.0 * step);
+        map.assemble_values(fixture.atmosphere, wavelength, below);
+        fixture.perturb(wavelength, coordinate, step);
+        const double finite_difference =
+            value_gradient.dot(above.values() - below.values()) / (2.0 * step);
+        REQUIRE(native_gradient(derivative) ==
+                Catch::Approx(finite_difference).margin(2.0e-9));
+    }
+
+    REQUIRE(
+        native_gradient.tail(fixture.atmosphere.num_deriv() - 2 * num_locations)
+            .isZero());
+}
+
+TEST_CASE("Successive-orders packed ray transport preserves very thin layer "
+          "sources and derivatives",
+          "[successive_orders][ray_transport][linearization]") {
+    RayTransportFixture fixture;
+    const auto map = fixture.make_map();
+    constexpr int wavelength = 0;
+    constexpr double extinction = 1.0e-18;
+    fixture.atmosphere.storage()
+        .total_extinction.col(wavelength)
+        .setConstant(extinction);
+
+    sasktran2::successive_orders::TransportOperator transport(map.sparsity());
+    map.assemble_values(fixture.atmosphere, wavelength, transport);
+
+    const double optical_depth = 0.8 * extinction;
+    const double source_fraction = -std::expm1(-optical_depth);
+    const double albedo = 0.6;
+    REQUIRE(transport.values()(4) > 0.0);
+    REQUIRE(transport.values()(4) ==
+            Catch::Approx(0.7 * albedo * source_fraction).margin(1.0e-30));
+    REQUIRE(transport.values()(5) ==
+            Catch::Approx(0.3 * albedo * source_fraction).margin(1.0e-30));
+
+    Eigen::VectorXd tangent =
+        Eigen::VectorXd::Zero(fixture.atmosphere.num_deriv());
+    tangent.segment(fixture.atmosphere.ssa_deriv_start_index(), num_locations)
+        .setOnes();
+    Eigen::VectorXd value_tangent(map.sparsity().nonzeros());
+    map.assemble_jvp(fixture.atmosphere, wavelength, tangent, value_tangent);
+    REQUIRE(value_tangent(4) > 0.0);
+    REQUIRE(value_tangent(4) ==
+            Catch::Approx(0.7 * source_fraction).margin(1.0e-30));
+    REQUIRE(value_tangent(5) ==
+            Catch::Approx(0.3 * source_fraction).margin(1.0e-30));
+
+    Eigen::VectorXd value_gradient =
+        Eigen::VectorXd::Zero(map.sparsity().nonzeros());
+    value_gradient(4) = 1.0;
+    Eigen::VectorXd native_gradient =
+        Eigen::VectorXd::Zero(fixture.atmosphere.num_deriv());
+    sasktran2::successive_orders::RayTransportWorkspace workspace;
+    map.accumulate_vjp(fixture.atmosphere, wavelength, value_gradient,
+                       native_gradient, workspace);
+
+    REQUIRE(native_gradient(fixture.atmosphere.ssa_deriv_start_index()) > 0.0);
+    REQUIRE(value_tangent.dot(value_gradient) ==
+            Catch::Approx(tangent.dot(native_gradient)).margin(1.0e-30));
+}

--- a/cpp/lib/tests/successive_orders/test_scattering.cpp
+++ b/cpp/lib/tests/successive_orders/test_scattering.cpp
@@ -1,0 +1,247 @@
+#include "../../successive_orders/scattering.h"
+
+#include <sasktran2/math/unitsphere.h>
+#include <sasktran2/test_helper.h>
+
+#include <stdexcept>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace {
+    sasktran2::successive_orders::ScatteringOperator<1> scalar_operator() {
+        constexpr int atmospheric_points = 2;
+        constexpr int ground_points = 1;
+        constexpr int num_coefficients = 5;
+        sasktran2::math::LebedevSphere incoming(14);
+        sasktran2::math::LebedevSphere outgoing(26);
+        sasktran2::successive_orders::ScalarAngularBasis basis(
+            incoming, outgoing, num_coefficients);
+        sasktran2::successive_orders::ScatteringBlockLayout layout(
+            atmospheric_points, ground_points, incoming.num_points(),
+            outgoing.num_points(), 3, 2, 1);
+        sasktran2::successive_orders::ScatteringOperator<1> scattering(
+            std::move(layout), std::move(basis));
+
+        Eigen::MatrixXd coefficients(atmospheric_points, num_coefficients);
+        coefficients << 1.0, 0.35, -0.2, 0.08, 0.01, 0.9, -0.15, 0.12, 0.03,
+            -0.005;
+        scattering.set_atmospheric_coefficients(coefficients);
+        Eigen::MatrixXd ground(2, 3);
+        ground << 0.2, -0.1, 0.5, 0.4, 0.3, -0.25;
+        scattering.set_ground_block(0, ground);
+        return scattering;
+    }
+} // namespace
+
+TEST_CASE("Successive-orders scattering layout is point-major with explicit "
+          "ground dimensions",
+          "[successive_orders][scattering]") {
+    const sasktran2::successive_orders::ScatteringBlockLayout layout(2, 1, 4, 5,
+                                                                     2, 3, 1);
+    const std::vector<int> expected_input_offsets{0, 4, 8, 10};
+    const std::vector<int> expected_output_offsets{0, 5, 10, 13};
+    REQUIRE(layout.input_offsets() == expected_input_offsets);
+    REQUIRE(layout.output_offsets() == expected_output_offsets);
+    REQUIRE(layout.atmospheric_blocks() == 2);
+    REQUIRE(layout.ground_blocks() == 1);
+    REQUIRE(layout.input_directions(2) == 2);
+    REQUIRE(layout.output_directions(2) == 3);
+}
+
+TEST_CASE("Scalar successive-orders scattering combines coefficient and "
+          "dense ground blocks",
+          "[successive_orders][scattering]") {
+    auto scattering = scalar_operator();
+    auto workspace = scattering.make_workspace();
+
+    Eigen::VectorXd incoming(scattering.input_size());
+    for (int index = 0; index < incoming.size(); ++index) {
+        incoming(index) = 0.15 + 0.02 * index;
+    }
+    Eigen::VectorXd actual(scattering.output_size());
+    scattering.apply(incoming, actual, workspace);
+
+    Eigen::MatrixXd atmospheric_incoming(2, 14);
+    atmospheric_incoming.row(0) = incoming.segment(0, 14).transpose();
+    atmospheric_incoming.row(1) = incoming.segment(14, 14).transpose();
+    Eigen::MatrixXd atmospheric_outgoing(2, 26);
+    Eigen::MatrixXd moments;
+    scattering.angular_basis().apply(atmospheric_incoming,
+                                     scattering.atmospheric_coefficients(),
+                                     atmospheric_outgoing, moments);
+    Eigen::VectorXd expected(scattering.output_size());
+    expected.segment(0, 26) = atmospheric_outgoing.row(0).transpose();
+    expected.segment(26, 26) = atmospheric_outgoing.row(1).transpose();
+    expected.tail(2) = scattering.ground_block(0) * incoming.tail(3);
+
+    REQUIRE(actual.isApprox(expected, 2.0e-13));
+    const auto memory = scattering.memory_usage(&workspace);
+    REQUIRE(memory.atmospheric_value_bytes == 2 * 5 * sizeof(double));
+    REQUIRE(memory.boundary_value_bytes == 2 * 3 * sizeof(double));
+    REQUIRE(memory.angular_basis_bytes > 0);
+    REQUIRE(memory.workspace_bytes > 0);
+    REQUIRE(memory.total_bytes() ==
+            memory.operator_bytes() + memory.workspace_bytes);
+}
+
+TEST_CASE("Scalar successive-orders scattering transpose is adjoint",
+          "[successive_orders][scattering]") {
+    auto scattering = scalar_operator();
+    auto workspace = scattering.make_workspace();
+    const Eigen::VectorXd incoming =
+        Eigen::VectorXd::Random(scattering.input_size());
+    const Eigen::VectorXd outgoing_cotangent =
+        Eigen::VectorXd::Random(scattering.output_size());
+    Eigen::VectorXd outgoing(scattering.output_size());
+    Eigen::VectorXd incoming_cotangent(scattering.input_size());
+
+    scattering.apply(incoming, outgoing, workspace);
+    scattering.apply_transpose(outgoing_cotangent, incoming_cotangent,
+                               workspace);
+    REQUIRE(outgoing.dot(outgoing_cotangent) ==
+            Catch::Approx(incoming.dot(incoming_cotangent)).epsilon(2.0e-12));
+}
+
+TEST_CASE("Scalar successive-orders scattering JVP and VJP include phase and "
+          "ground values",
+          "[successive_orders][scattering]") {
+    auto scattering = scalar_operator();
+    auto workspace = scattering.make_workspace();
+    const Eigen::VectorXd incoming =
+        Eigen::VectorXd::Random(scattering.input_size());
+    const Eigen::VectorXd incoming_tangent =
+        Eigen::VectorXd::Random(scattering.input_size());
+    const Eigen::MatrixXd coefficient_tangent =
+        Eigen::MatrixXd::Random(scattering.atmospheric_coefficients().rows(),
+                                scattering.atmospheric_coefficients().cols());
+    const Eigen::VectorXd ground_tangent =
+        Eigen::VectorXd::Random(scattering.ground_value_size());
+    const Eigen::VectorXd outgoing_cotangent =
+        Eigen::VectorXd::Random(scattering.output_size());
+
+    Eigen::VectorXd outgoing_tangent(scattering.output_size());
+    scattering.apply_jvp(incoming, incoming_tangent, coefficient_tangent,
+                         ground_tangent, outgoing_tangent, workspace);
+
+    Eigen::VectorXd incoming_cotangent(scattering.input_size());
+    Eigen::MatrixXd coefficient_gradient(
+        scattering.atmospheric_coefficients().rows(),
+        scattering.atmospheric_coefficients().cols());
+    Eigen::VectorXd ground_gradient(scattering.ground_value_size());
+    scattering.apply_vjp(incoming, outgoing_cotangent, incoming_cotangent,
+                         coefficient_gradient, ground_gradient, workspace);
+
+    const double forward = outgoing_tangent.dot(outgoing_cotangent);
+    const double reverse =
+        incoming_tangent.dot(incoming_cotangent) +
+        (coefficient_tangent.array() * coefficient_gradient.array()).sum() +
+        ground_tangent.dot(ground_gradient);
+    REQUIRE(forward == Catch::Approx(reverse).epsilon(3.0e-12));
+}
+
+TEST_CASE("Scalar successive-orders scattering skips inactive parameter "
+          "directions exactly",
+          "[successive_orders][scattering][jvp]") {
+    auto scattering = scalar_operator();
+    auto workspace = scattering.make_workspace();
+    const Eigen::VectorXd incoming =
+        Eigen::VectorXd::Random(scattering.input_size());
+    const Eigen::VectorXd incoming_tangent =
+        Eigen::VectorXd::Random(scattering.input_size());
+    const Eigen::MatrixXd coefficient_tangent =
+        Eigen::MatrixXd::Zero(scattering.atmospheric_coefficients().rows(),
+                              scattering.atmospheric_coefficients().cols());
+    const Eigen::VectorXd ground_tangent =
+        Eigen::VectorXd::Zero(scattering.ground_value_size());
+    Eigen::VectorXd actual(scattering.output_size());
+    Eigen::VectorXd expected(scattering.output_size());
+
+    scattering.apply_jvp(incoming, incoming_tangent, coefficient_tangent,
+                         ground_tangent, actual, workspace);
+    scattering.apply(incoming_tangent, expected, workspace);
+    REQUIRE(actual.isApprox(expected, 2.0e-13));
+}
+
+TEST_CASE("Scalar successive-orders scattering detects trailing zero "
+          "coefficients",
+          "[successive_orders][scattering]") {
+    auto scattering = scalar_operator();
+    auto coefficients = scattering.atmospheric_coefficients();
+    coefficients.rightCols(2).setZero();
+    scattering.set_atmospheric_coefficients(coefficients);
+    REQUIRE(scattering.active_coefficients() == 3);
+
+    coefficients(0, 4) = 0.01;
+    scattering.set_atmospheric_coefficients(coefficients);
+    REQUIRE(scattering.active_coefficients() == 5);
+}
+
+TEST_CASE("Coefficient vector successive-orders scattering products are dual",
+          "[successive_orders][scattering]") {
+    sasktran2::math::LebedevSphere incoming_sphere(6);
+    sasktran2::math::LebedevSphere outgoing_sphere(14);
+    auto basis = std::make_shared<
+        const sasktran2::successive_orders::VectorAngularBasis>(
+        incoming_sphere, outgoing_sphere, 3);
+    sasktran2::successive_orders::ScatteringBlockLayout layout(
+        1, 1, incoming_sphere.num_points(), outgoing_sphere.num_points(), 1, 2,
+        3);
+    sasktran2::successive_orders::ScatteringOperator<3> scattering(
+        std::move(layout), std::move(basis));
+    scattering.set_atmospheric_coefficients(Eigen::MatrixXd::Random(1, 12));
+    scattering.set_ground_block(0, Eigen::MatrixXd::Random(6, 3));
+    auto workspace = scattering.make_workspace();
+
+    const Eigen::VectorXd incoming =
+        Eigen::VectorXd::Random(scattering.input_size());
+    const Eigen::VectorXd incoming_tangent =
+        Eigen::VectorXd::Random(scattering.input_size());
+    const Eigen::MatrixXd atmospheric_tangent =
+        Eigen::MatrixXd::Random(scattering.atmospheric_coefficients().rows(),
+                                scattering.atmospheric_coefficients().cols());
+    const Eigen::VectorXd ground_tangent =
+        Eigen::VectorXd::Random(scattering.ground_value_size());
+    const Eigen::VectorXd outgoing_cotangent =
+        Eigen::VectorXd::Random(scattering.output_size());
+
+    Eigen::VectorXd outgoing(scattering.output_size());
+    Eigen::VectorXd transposed(scattering.input_size());
+    scattering.apply(incoming, outgoing, workspace);
+    scattering.apply_transpose(outgoing_cotangent, transposed, workspace);
+    REQUIRE(outgoing.dot(outgoing_cotangent) ==
+            Catch::Approx(incoming.dot(transposed)).epsilon(2.0e-13));
+
+    Eigen::VectorXd outgoing_tangent(scattering.output_size());
+    scattering.apply_jvp(incoming, incoming_tangent, atmospheric_tangent,
+                         ground_tangent, outgoing_tangent, workspace);
+    Eigen::VectorXd incoming_gradient(scattering.input_size());
+    Eigen::MatrixXd atmospheric_gradient(
+        scattering.atmospheric_coefficients().rows(),
+        scattering.atmospheric_coefficients().cols());
+    Eigen::VectorXd ground_gradient(scattering.ground_value_size());
+    scattering.apply_vjp(incoming, outgoing_cotangent, incoming_gradient,
+                         atmospheric_gradient, ground_gradient, workspace);
+    REQUIRE(
+        outgoing_tangent.dot(outgoing_cotangent) ==
+        Catch::Approx(
+            incoming_tangent.dot(incoming_gradient) +
+            (atmospheric_tangent.array() * atmospheric_gradient.array()).sum() +
+            ground_tangent.dot(ground_gradient))
+            .epsilon(3.0e-13));
+}
+
+TEST_CASE("Successive-orders scattering rejects mismatched dimensions",
+          "[successive_orders][scattering]") {
+    REQUIRE_THROWS_AS(sasktran2::successive_orders::ScatteringBlockLayout(
+                          2, 1, std::vector<int>{0, 2}, std::vector<int>{0, 2}),
+                      std::invalid_argument);
+
+    auto scattering = scalar_operator();
+    auto workspace = scattering.make_workspace();
+    Eigen::VectorXd bad_input(scattering.input_size() - 1);
+    Eigen::VectorXd output(scattering.output_size());
+    REQUIRE_THROWS_AS(scattering.apply(bad_input, output, workspace),
+                      std::invalid_argument);
+    REQUIRE_THROWS_AS(scattering.ground_block(1), std::out_of_range);
+}

--- a/cpp/lib/tests/successive_orders/test_scattering_assembler.cpp
+++ b/cpp/lib/tests/successive_orders/test_scattering_assembler.cpp
@@ -1,0 +1,825 @@
+#include "../../successive_orders/scattering_assembler.h"
+
+#include <sasktran2/hr/diffuse_point.h>
+#include <sasktran2/test_helper.h>
+
+#include <cmath>
+#include <memory>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace {
+    using namespace sasktran2::successive_orders;
+
+    Eigen::MatrixXd
+    materialize_atmospheric_block(const ScatteringOperator<3>& scattering,
+                                  int block) {
+        const int rows = scattering.layout().output_block_size(block);
+        const int columns = scattering.layout().input_block_size(block);
+        Eigen::MatrixXd result(rows, columns);
+        Eigen::VectorXd incoming =
+            Eigen::VectorXd::Zero(scattering.input_size());
+        Eigen::VectorXd outgoing(scattering.output_size());
+        auto workspace = scattering.make_workspace();
+        for (int column = 0; column < columns; ++column) {
+            incoming(scattering.input_offsets()[block] + column) = 1.0;
+            scattering.apply(incoming, outgoing, workspace);
+            result.col(column) =
+                outgoing.segment(scattering.output_offsets()[block], rows);
+            incoming(scattering.input_offsets()[block] + column) = 0.0;
+        }
+        return result;
+    }
+
+    template <int NSTOKES>
+    class FiniteAzimuthBRDF final
+        : public sasktran2::atmosphere::brdf::BRDF<NSTOKES> {
+      public:
+        Eigen::Matrix<double, NSTOKES, NSTOKES>
+        brdf(double, double, double phi_difference,
+             Eigen::Ref<const Eigen::VectorXd> args) const override {
+            if (!std::isfinite(phi_difference)) {
+                throw std::runtime_error("BRDF received a non-finite azimuth");
+            }
+            Eigen::Matrix<double, NSTOKES, NSTOKES> result =
+                Eigen::Matrix<double, NSTOKES, NSTOKES>::Zero();
+            result(0, 0) =
+                args(0) * (1.0 + 0.25 * std::cos(phi_difference)) / EIGEN_PI;
+            return result;
+        }
+
+        int num_deriv() const override { return 0; }
+        int num_args() const override { return 1; }
+    };
+
+    sasktran2::Geometry1D make_geometry() {
+        sasktran2::Coordinates coordinates(
+            0.6, 0.2, 6372000.0, sasktran2::geometrytype::planeparallel);
+        Eigen::VectorXd altitudes(3);
+        altitudes << 0.0, 1000.0, 2000.0;
+        sasktran2::grids::AltitudeGrid altitude_grid(
+            std::move(altitudes), sasktran2::grids::gridspacing::constant,
+            sasktran2::grids::outofbounds::extend,
+            sasktran2::grids::interpolation::linear);
+        return {std::move(coordinates), std::move(altitude_grid)};
+    }
+
+    struct AssemblyFixture {
+        AssemblyFixture()
+            : geometry(make_geometry()), raytracer(geometry),
+              source_geometry(raytracer, geometry),
+              atmosphere(sasktran2::atmosphere::AtmosphereGridStorageFull<1>(
+                             num_wavelengths, geometry.size(), num_legendre),
+                         sasktran2::atmosphere::Surface<1>(num_wavelengths),
+                         true) {
+            SourceGeometrySettings settings;
+            settings.num_incoming = 6;
+            settings.num_outgoing = 6;
+            settings.num_sza = 1;
+            settings.num_threads = 1;
+            settings.altitude_grid_m = {500.0, 1500.0};
+            sasktran2::viewinggeometry::InternalViewingGeometry viewing;
+            source_geometry.initialize(viewing, settings);
+
+            atmosphere.storage().resize_derivatives(num_scattering_groups);
+            for (int wavelength = 0; wavelength < num_wavelengths;
+                 ++wavelength) {
+                for (int location = 0; location < geometry.size(); ++location) {
+                    for (int degree = 0; degree < num_legendre; ++degree) {
+                        atmosphere.storage().leg_coeff(degree, location,
+                                                       wavelength) =
+                            0.12 + 0.025 * degree + 0.04 * location +
+                            0.015 * wavelength;
+                        for (int group = 0; group < num_scattering_groups;
+                             ++group) {
+                            atmosphere.storage().d_leg_coeff(
+                                degree, location, wavelength, group) =
+                                0.01 * (1 + degree + 2 * location + 3 * group +
+                                        wavelength);
+                        }
+                    }
+                }
+            }
+            atmosphere.surface().brdf_args().row(0) << 0.24, 0.37;
+        }
+
+        Eigen::VectorXd native_tangent() const {
+            Eigen::VectorXd tangent =
+                Eigen::VectorXd::Zero(atmosphere.num_deriv());
+            tangent.head(geometry.size()) << 0.2, -0.1, 0.05;
+            tangent.segment(atmosphere.ssa_deriv_start_index(), geometry.size())
+                << -0.03,
+                0.04, 0.07;
+            for (int group = 0; group < num_scattering_groups; ++group) {
+                tangent.segment(atmosphere.scat_deriv_start_index() +
+                                    group * geometry.size(),
+                                geometry.size())
+                    << 0.13 - 0.02 * group,
+                    -0.08 + 0.03 * group, 0.05 + 0.01 * group;
+            }
+            tangent(atmosphere.surface_deriv_start_index()) = -0.17;
+            return tangent;
+        }
+
+        void perturb(int wavelength, const Eigen::VectorXd& tangent,
+                     double scale) {
+            for (int location = 0; location < geometry.size(); ++location) {
+                for (int degree = 0; degree < num_legendre; ++degree) {
+                    double direction = 0.0;
+                    for (int group = 0; group < num_scattering_groups;
+                         ++group) {
+                        direction +=
+                            tangent(atmosphere.scat_deriv_start_index() +
+                                    group * geometry.size() + location) *
+                            atmosphere.storage().d_leg_coeff(degree, location,
+                                                             wavelength, group);
+                    }
+                    atmosphere.storage().leg_coeff(
+                        degree, location, wavelength) += scale * direction;
+                }
+            }
+            atmosphere.surface().brdf_args()(0, wavelength) +=
+                scale * tangent(atmosphere.surface_deriv_start_index());
+        }
+
+        void enable_delta_m_scaling(int order) {
+            atmosphere.storage().total_extinction.setConstant(1.0e-4);
+            atmosphere.storage().ssa.setConstant(0.9);
+            for (int wavelength = 0; wavelength < num_wavelengths;
+                 ++wavelength) {
+                for (int location = 0; location < geometry.size(); ++location) {
+                    atmosphere.storage().leg_coeff(0, location, wavelength) =
+                        1.0;
+                    for (int group = 0; group < num_scattering_groups;
+                         ++group) {
+                        atmosphere.storage().d_leg_coeff(
+                            0, location, wavelength, group) = 0.0;
+                    }
+                }
+            }
+            atmosphere.apply_delta_m_scaling(order);
+        }
+
+        void perturb_delta_scaled(int wavelength,
+                                  const Eigen::VectorXd& tangent,
+                                  double scale) {
+            for (int location = 0; location < geometry.size(); ++location) {
+                double f_direction = 0.0;
+                for (int group = 0; group < num_scattering_groups; ++group) {
+                    const double direction =
+                        tangent(atmosphere.scat_deriv_start_index() +
+                                group * geometry.size() + location);
+                    f_direction += direction * atmosphere.storage().d_f(
+                                                   location, wavelength, group);
+                    for (int degree = 0; degree < num_legendre; ++degree) {
+                        atmosphere.storage().leg_coeff(degree, location,
+                                                       wavelength) +=
+                            scale * direction *
+                            atmosphere.storage().d_leg_coeff(degree, location,
+                                                             wavelength, group);
+                    }
+                }
+                atmosphere.storage().f(location, wavelength) +=
+                    scale * f_direction;
+            }
+            atmosphere.surface().brdf_args()(0, wavelength) +=
+                scale * tangent(atmosphere.surface_deriv_start_index());
+        }
+
+        static constexpr int num_wavelengths = 2;
+        static constexpr int num_legendre = 4;
+        static constexpr int num_scattering_groups = 2;
+
+        sasktran2::Geometry1D geometry;
+        sasktran2::raytracing::PlaneParallelRayTracer raytracer;
+        SourceGeometry1D source_geometry;
+        sasktran2::atmosphere::Atmosphere<1> atmosphere;
+    };
+
+    class CopiedUnitSphere final : public sasktran2::math::UnitSphere {
+      public:
+        explicit CopiedUnitSphere(const sasktran2::math::UnitSphere& source) {
+            m_directions.reserve(source.num_points());
+            m_weights.reserve(source.num_points());
+            for (int index = 0; index < source.num_points(); ++index) {
+                m_directions.push_back(source.get_quad_position(index));
+                m_weights.push_back(source.quadrature_weight(index));
+            }
+        }
+
+        int num_points() const override {
+            return static_cast<int>(m_weights.size());
+        }
+        Eigen::Vector3d get_quad_position(int index) const override {
+            return m_directions.at(index);
+        }
+        double quadrature_weight(int index) const override {
+            return m_weights.at(index);
+        }
+        void interpolate(const Eigen::Vector3d&,
+                         std::vector<std::pair<int, double>>&,
+                         int&) const override {
+            throw std::logic_error(
+                "CopiedUnitSphere interpolation is not used by this test");
+        }
+
+      private:
+        std::vector<Eigen::Vector3d> m_directions;
+        std::vector<double> m_weights;
+    };
+
+    struct VectorAssemblyFixture {
+        VectorAssemblyFixture()
+            : geometry(make_geometry()), raytracer(geometry),
+              source_geometry(raytracer, geometry),
+              atmosphere(sasktran2::atmosphere::AtmosphereGridStorageFull<3>(
+                             num_wavelengths, geometry.size(), num_legendre),
+                         sasktran2::atmosphere::Surface<3>(num_wavelengths),
+                         true) {
+            SourceGeometrySettings settings;
+            settings.num_incoming = 6;
+            settings.num_outgoing = 6;
+            settings.num_sza = 1;
+            settings.num_threads = 1;
+            settings.altitude_grid_m = {500.0, 1500.0};
+            sasktran2::viewinggeometry::InternalViewingGeometry viewing;
+            source_geometry.initialize(viewing, settings);
+
+            atmosphere.storage().resize_derivatives(num_scattering_groups);
+            for (int wavelength = 0; wavelength < num_wavelengths;
+                 ++wavelength) {
+                for (int location = 0; location < geometry.size(); ++location) {
+                    for (int degree = 0; degree < num_legendre; ++degree) {
+                        for (int greek = 0; greek < 4; ++greek) {
+                            const int coefficient = 4 * degree + greek;
+                            atmosphere.storage().leg_coeff(
+                                coefficient, location, wavelength) =
+                                0.09 + 0.017 * degree + 0.011 * greek +
+                                0.023 * location + 0.007 * wavelength;
+                            for (int group = 0; group < num_scattering_groups;
+                                 ++group) {
+                                atmosphere.storage().d_leg_coeff(
+                                    coefficient, location, wavelength, group) =
+                                    0.004 * (1 + coefficient + 2 * location +
+                                             3 * group + wavelength);
+                            }
+                        }
+                    }
+                }
+            }
+            atmosphere.surface().brdf_args().row(0) << 0.19, 0.31;
+        }
+
+        Eigen::VectorXd native_tangent() const {
+            Eigen::VectorXd tangent =
+                Eigen::VectorXd::Zero(atmosphere.num_deriv());
+            tangent.head(geometry.size()) << 0.1, -0.03, 0.02;
+            tangent.segment(atmosphere.ssa_deriv_start_index(), geometry.size())
+                << -0.04,
+                0.06, 0.01;
+            for (int group = 0; group < num_scattering_groups; ++group) {
+                tangent.segment(atmosphere.scat_deriv_start_index() +
+                                    group * geometry.size(),
+                                geometry.size())
+                    << 0.12 - 0.03 * group,
+                    -0.07 + 0.02 * group, 0.045 + 0.01 * group;
+            }
+            tangent(atmosphere.surface_deriv_start_index()) = -0.14;
+            return tangent;
+        }
+
+        void perturb(int wavelength, const Eigen::VectorXd& tangent,
+                     double scale) {
+            for (int location = 0; location < geometry.size(); ++location) {
+                for (int coefficient = 0; coefficient < 4 * num_legendre;
+                     ++coefficient) {
+                    double direction = 0.0;
+                    for (int group = 0; group < num_scattering_groups;
+                         ++group) {
+                        direction +=
+                            tangent(atmosphere.scat_deriv_start_index() +
+                                    group * geometry.size() + location) *
+                            atmosphere.storage().d_leg_coeff(
+                                coefficient, location, wavelength, group);
+                    }
+                    atmosphere.storage().leg_coeff(
+                        coefficient, location, wavelength) += scale * direction;
+                }
+            }
+            atmosphere.surface().brdf_args()(0, wavelength) +=
+                scale * tangent(atmosphere.surface_deriv_start_index());
+        }
+
+        void enable_delta_m_scaling(int order) {
+            atmosphere.storage().total_extinction.setConstant(1.0e-4);
+            atmosphere.storage().ssa.setConstant(0.9);
+            for (int wavelength = 0; wavelength < num_wavelengths;
+                 ++wavelength) {
+                for (int location = 0; location < geometry.size(); ++location) {
+                    for (int greek = 0; greek < 3; ++greek) {
+                        atmosphere.storage().leg_coeff(greek, location,
+                                                       wavelength) = 1.0;
+                        for (int group = 0; group < num_scattering_groups;
+                             ++group) {
+                            atmosphere.storage().d_leg_coeff(
+                                greek, location, wavelength, group) = 0.0;
+                        }
+                    }
+                }
+            }
+            atmosphere.apply_delta_m_scaling(order);
+        }
+
+        void perturb_delta_scaled(int wavelength,
+                                  const Eigen::VectorXd& tangent,
+                                  double scale) {
+            for (int location = 0; location < geometry.size(); ++location) {
+                double f_direction = 0.0;
+                for (int group = 0; group < num_scattering_groups; ++group) {
+                    const double direction =
+                        tangent(atmosphere.scat_deriv_start_index() +
+                                group * geometry.size() + location);
+                    f_direction += direction * atmosphere.storage().d_f(
+                                                   location, wavelength, group);
+                    for (int coefficient = 0; coefficient < 4 * num_legendre;
+                         ++coefficient) {
+                        atmosphere.storage().leg_coeff(coefficient, location,
+                                                       wavelength) +=
+                            scale * direction *
+                            atmosphere.storage().d_leg_coeff(
+                                coefficient, location, wavelength, group);
+                    }
+                }
+                atmosphere.storage().f(location, wavelength) +=
+                    scale * f_direction;
+            }
+            atmosphere.surface().brdf_args()(0, wavelength) +=
+                scale * tangent(atmosphere.surface_deriv_start_index());
+        }
+
+        Eigen::MatrixXd legacy_block(int point_index, int wavelength,
+                                     int num_coefficients) const {
+            const auto& point = source_geometry.source_point(point_index);
+            sasktran2::hr::IncomingOutgoingSpherePair<3> legacy(
+                num_coefficients,
+                std::make_unique<CopiedUnitSphere>(point.incoming_sphere()),
+                std::make_unique<CopiedUnitSphere>(point.outgoing_sphere()));
+            std::vector<std::pair<int, double>> weights;
+            weights.reserve(point.atmosphere_weights().size());
+            for (const auto& weight : point.atmosphere_weights()) {
+                weights.emplace_back(weight.index, weight.weight);
+            }
+            Eigen::MatrixXd result(3 * point.num_outgoing(),
+                                   3 * point.num_incoming());
+            if (point.is_ground()) {
+                legacy.calculate_ground_scattering_matrix(
+                    atmosphere.surface(), weights, point.location(), wavelength,
+                    result.data());
+            } else {
+                legacy.calculate_scattering_matrix(
+                    atmosphere.storage(), wavelength, weights, result.data());
+            }
+            return result;
+        }
+
+        static constexpr int num_wavelengths = 2;
+        static constexpr int num_legendre = 4;
+        static constexpr int num_scattering_groups = 2;
+
+        sasktran2::Geometry1D geometry;
+        sasktran2::raytracing::PlaneParallelRayTracer raytracer;
+        SourceGeometry1D source_geometry;
+        sasktran2::atmosphere::Atmosphere<3> atmosphere;
+    };
+} // namespace
+
+TEST_CASE("Scalar scattering assembler maps atmosphere points and legacy "
+          "ground normalization",
+          "[successive_orders][scattering_assembler]") {
+    AssemblyFixture fixture;
+    constexpr int wavelength = 1;
+    ScalarScatteringAssembler assembler(fixture.source_geometry, 3);
+    auto scattering = assembler.create_operator();
+    assembler.assemble_values(fixture.atmosphere, wavelength, scattering);
+
+    REQUIRE(scattering.input_offsets() ==
+            fixture.source_geometry.incoming_point_offsets());
+    REQUIRE(scattering.output_offsets() ==
+            fixture.source_geometry.outgoing_point_offsets());
+    for (int point = 0; point < fixture.source_geometry.num_interior_points();
+         ++point) {
+        for (int degree = 0; degree < assembler.num_coefficients(); ++degree) {
+            double expected = 0.0;
+            for (const auto& weight :
+                 fixture.source_geometry.source_point(point)
+                     .atmosphere_weights()) {
+                expected +=
+                    weight.weight * fixture.atmosphere.storage().leg_coeff(
+                                        degree, weight.index, wavelength);
+            }
+            REQUIRE(scattering.atmospheric_coefficients()(point, degree) ==
+                    Catch::Approx(expected).epsilon(2.0e-14));
+        }
+    }
+
+    REQUIRE(fixture.source_geometry.num_ground_points() == 1);
+    const int ground_point = fixture.source_geometry.num_interior_points();
+    const auto& point = fixture.source_geometry.source_point(ground_point);
+    const auto ground = scattering.ground_block(0);
+    const double albedo =
+        fixture.atmosphere.surface().brdf_args()(0, wavelength);
+    for (int input = 0; input < point.num_incoming(); ++input) {
+        const double mu_in = point.location().cos_zenith_angle(
+            point.incoming_sphere().get_quad_position(input));
+        const double expected =
+            4.0 * albedo * mu_in *
+            point.incoming_sphere().quadrature_weight(input);
+        for (int output = 0; output < point.num_outgoing(); ++output) {
+            REQUIRE(ground(output, input) ==
+                    Catch::Approx(expected).epsilon(2.0e-14));
+        }
+    }
+    REQUIRE(assembler.storage_bytes() >
+            scattering.memory_usage().angular_basis_bytes);
+}
+
+TEST_CASE("Ground scattering supplies finite azimuths for vertical directions",
+          "[successive_orders][scattering_assembler][ground]") {
+    SECTION("scalar") {
+        AssemblyFixture fixture;
+        const int ground_point = fixture.source_geometry.num_interior_points();
+        const auto& point = fixture.source_geometry.source_point(ground_point);
+        const Eigen::Vector3d normal = point.location().position.normalized();
+        bool has_vertical_direction = false;
+        for (int input = 0; input < point.num_incoming(); ++input) {
+            const Eigen::Vector3d direction =
+                point.incoming_sphere().get_quad_position(input);
+            has_vertical_direction =
+                has_vertical_direction ||
+                (direction - direction.dot(normal) * normal).norm() < 1.0e-14;
+        }
+        REQUIRE(has_vertical_direction);
+
+        fixture.atmosphere.surface().set_brdf_object(
+            std::make_shared<FiniteAzimuthBRDF<1>>());
+        fixture.atmosphere.surface().brdf_args().setConstant(0.2);
+        ScalarScatteringAssembler assembler(fixture.source_geometry, 3);
+        auto scattering = assembler.create_operator();
+        REQUIRE_NOTHROW(
+            assembler.assemble_values(fixture.atmosphere, 0, scattering));
+        REQUIRE(scattering.ground_values().allFinite());
+    }
+
+    SECTION("vector") {
+        VectorAssemblyFixture fixture;
+        fixture.atmosphere.surface().set_brdf_object(
+            std::make_shared<FiniteAzimuthBRDF<3>>());
+        fixture.atmosphere.surface().brdf_args().setConstant(0.2);
+        VectorScatteringAssembler assembler(fixture.source_geometry, 3);
+        auto scattering = assembler.create_operator();
+        REQUIRE_NOTHROW(
+            assembler.assemble_values(fixture.atmosphere, 0, scattering));
+        REQUIRE(scattering.ground_values().allFinite());
+    }
+}
+
+TEST_CASE("Scalar scattering assembler native JVP matches finite differences",
+          "[successive_orders][scattering_assembler][jvp]") {
+    AssemblyFixture fixture;
+    constexpr int wavelength = 1;
+    ScalarScatteringAssembler assembler(fixture.source_geometry, 3);
+    const Eigen::VectorXd tangent = fixture.native_tangent();
+    Eigen::MatrixXd coefficient_tangent;
+    Eigen::VectorXd ground_tangent;
+    assembler.assemble_jvp(fixture.atmosphere, wavelength, tangent,
+                           coefficient_tangent, ground_tangent);
+
+    constexpr double step = 1.0e-5;
+    fixture.perturb(wavelength, tangent, step);
+    auto above = assembler.create_operator();
+    assembler.assemble_values(fixture.atmosphere, wavelength, above);
+    fixture.perturb(wavelength, tangent, -2.0 * step);
+    auto below = assembler.create_operator();
+    assembler.assemble_values(fixture.atmosphere, wavelength, below);
+    fixture.perturb(wavelength, tangent, step);
+
+    const Eigen::MatrixXd coefficient_difference =
+        (above.atmospheric_coefficients() - below.atmospheric_coefficients()) /
+        (2.0 * step);
+    const Eigen::VectorXd ground_difference =
+        (above.ground_values() - below.ground_values()) / (2.0 * step);
+    REQUIRE(
+        (coefficient_tangent - coefficient_difference).cwiseAbs().maxCoeff() <
+        2.0e-10);
+    REQUIRE(ground_tangent.isApprox(ground_difference, 2.0e-10));
+}
+
+TEST_CASE("Scalar scattering assembler native VJP is adjoint",
+          "[successive_orders][scattering_assembler][jvp][vjp]") {
+    AssemblyFixture fixture;
+    constexpr int wavelength = 0;
+    ScalarScatteringAssembler assembler(fixture.source_geometry, 3);
+    const Eigen::VectorXd tangent = fixture.native_tangent();
+    Eigen::MatrixXd coefficient_tangent;
+    Eigen::VectorXd ground_tangent;
+    assembler.assemble_jvp(fixture.atmosphere, wavelength, tangent,
+                           coefficient_tangent, ground_tangent);
+
+    const Eigen::MatrixXd coefficient_gradient =
+        Eigen::MatrixXd::Random(fixture.source_geometry.num_interior_points(),
+                                assembler.num_coefficients());
+    const Eigen::VectorXd ground_gradient =
+        Eigen::VectorXd::Random(assembler.ground_value_size());
+    Eigen::VectorXd native_gradient =
+        Eigen::VectorXd::Zero(fixture.atmosphere.num_deriv());
+    assembler.accumulate_vjp(fixture.atmosphere, wavelength,
+                             coefficient_gradient, ground_gradient,
+                             native_gradient);
+
+    const double parameter_forward =
+        (coefficient_tangent.array() * coefficient_gradient.array()).sum() +
+        ground_tangent.dot(ground_gradient);
+    REQUIRE(parameter_forward ==
+            Catch::Approx(tangent.dot(native_gradient)).epsilon(3.0e-13));
+    REQUIRE(native_gradient.head(2 * fixture.geometry.size()).isZero());
+}
+
+TEST_CASE("Scalar scattering assembler completes delta-M scaling",
+          "[successive_orders][scattering_assembler][delta_m][jvp][vjp]") {
+    AssemblyFixture fixture;
+    constexpr int wavelength = 1;
+    constexpr int delta_m_order = 3;
+    fixture.enable_delta_m_scaling(delta_m_order);
+
+    ScalarScatteringAssembler assembler(fixture.source_geometry, delta_m_order);
+    auto scattering = assembler.create_operator();
+    assembler.assemble_values(fixture.atmosphere, wavelength, scattering);
+
+    const auto& storage = fixture.atmosphere.storage();
+    for (int point = 0; point < fixture.source_geometry.num_interior_points();
+         ++point) {
+        for (int degree = 0; degree < assembler.num_coefficients(); ++degree) {
+            double expected = 0.0;
+            for (const auto& weight :
+                 fixture.source_geometry.source_point(point)
+                     .atmosphere_weights()) {
+                const double f = storage.f(weight.index, wavelength);
+                expected +=
+                    weight.weight *
+                    (storage.leg_coeff(degree, weight.index, wavelength) -
+                     (2.0 * degree + 1.0) * f / (1.0 - f));
+            }
+            REQUIRE(scattering.atmospheric_coefficients()(point, degree) ==
+                    Catch::Approx(expected).epsilon(2.0e-14));
+        }
+        REQUIRE(scattering.atmospheric_coefficients()(point, 0) ==
+                Catch::Approx(1.0).epsilon(2.0e-14));
+    }
+
+    const Eigen::VectorXd tangent = fixture.native_tangent();
+    Eigen::MatrixXd coefficient_tangent;
+    Eigen::VectorXd ground_tangent;
+    assembler.assemble_jvp(fixture.atmosphere, wavelength, tangent,
+                           coefficient_tangent, ground_tangent);
+    REQUIRE(coefficient_tangent.col(0).isZero(2.0e-14));
+
+    constexpr double step = 1.0e-5;
+    fixture.perturb_delta_scaled(wavelength, tangent, step);
+    auto above = assembler.create_operator();
+    assembler.assemble_values(fixture.atmosphere, wavelength, above);
+    fixture.perturb_delta_scaled(wavelength, tangent, -2.0 * step);
+    auto below = assembler.create_operator();
+    assembler.assemble_values(fixture.atmosphere, wavelength, below);
+    fixture.perturb_delta_scaled(wavelength, tangent, step);
+
+    const Eigen::MatrixXd coefficient_difference =
+        (above.atmospheric_coefficients() - below.atmospheric_coefficients()) /
+        (2.0 * step);
+    const Eigen::VectorXd ground_difference =
+        (above.ground_values() - below.ground_values()) / (2.0 * step);
+    REQUIRE(
+        (coefficient_tangent - coefficient_difference).cwiseAbs().maxCoeff() <
+        2.0e-10);
+    REQUIRE(ground_tangent.isApprox(ground_difference, 2.0e-10));
+
+    const Eigen::MatrixXd coefficient_gradient =
+        Eigen::MatrixXd::Random(fixture.source_geometry.num_interior_points(),
+                                assembler.num_coefficients());
+    const Eigen::VectorXd ground_gradient =
+        Eigen::VectorXd::Random(assembler.ground_value_size());
+    Eigen::VectorXd native_gradient =
+        Eigen::VectorXd::Zero(fixture.atmosphere.num_deriv());
+    assembler.accumulate_vjp(fixture.atmosphere, wavelength,
+                             coefficient_gradient, ground_gradient,
+                             native_gradient);
+    const double parameter_forward =
+        (coefficient_tangent.array() * coefficient_gradient.array()).sum() +
+        ground_tangent.dot(ground_gradient);
+    REQUIRE(parameter_forward ==
+            Catch::Approx(tangent.dot(native_gradient)).epsilon(3.0e-13));
+}
+
+TEST_CASE("Vector scattering assembler matches legacy atmospheric and ground "
+          "blocks",
+          "[successive_orders][scattering_assembler][vector]") {
+    VectorAssemblyFixture fixture;
+    constexpr int wavelength = 1;
+    constexpr int num_coefficients = 3;
+    VectorScatteringAssembler assembler(fixture.source_geometry,
+                                        num_coefficients);
+    auto scattering = assembler.create_operator();
+    assembler.assemble_values(fixture.atmosphere, wavelength, scattering);
+
+    std::vector<int> expected_input_offsets =
+        fixture.source_geometry.incoming_point_offsets();
+    std::vector<int> expected_output_offsets =
+        fixture.source_geometry.outgoing_point_offsets();
+    for (auto& offset : expected_input_offsets) {
+        offset *= 3;
+    }
+    for (auto& offset : expected_output_offsets) {
+        offset *= 3;
+    }
+    REQUIRE(scattering.input_offsets() == expected_input_offsets);
+    REQUIRE(scattering.output_offsets() == expected_output_offsets);
+
+    for (int point = 0; point < fixture.source_geometry.num_interior_points();
+         ++point) {
+        const Eigen::MatrixXd expected =
+            fixture.legacy_block(point, wavelength, num_coefficients);
+        const Eigen::MatrixXd actual =
+            materialize_atmospheric_block(scattering, point);
+        INFO("point=" << point << " max error="
+                      << (actual - expected).cwiseAbs().maxCoeff());
+        REQUIRE(actual.isApprox(expected, 5.0e-13));
+    }
+    for (int ground = 0; ground < fixture.source_geometry.num_ground_points();
+         ++ground) {
+        const int point =
+            fixture.source_geometry.num_interior_points() + ground;
+        const Eigen::MatrixXd expected =
+            fixture.legacy_block(point, wavelength, num_coefficients);
+        REQUIRE(scattering.ground_block(ground).isApprox(expected, 5.0e-13));
+    }
+
+    const auto& atmospheric_point = fixture.source_geometry.source_point(0);
+    const std::size_t legacy_dense_basis_bytes =
+        static_cast<std::size_t>(4 * num_coefficients) * 3 *
+        atmospheric_point.num_outgoing() * 3 *
+        atmospheric_point.num_incoming() * sizeof(double);
+    REQUIRE(assembler.storage_bytes() < legacy_dense_basis_bytes);
+    REQUIRE(scattering.memory_usage().atmospheric_value_bytes ==
+            static_cast<std::size_t>(assembler.coefficient_value_size()) *
+                sizeof(double));
+}
+
+TEST_CASE("Vector scattering assembler native JVP matches finite differences",
+          "[successive_orders][scattering_assembler][vector][jvp]") {
+    VectorAssemblyFixture fixture;
+    constexpr int wavelength = 1;
+    VectorScatteringAssembler assembler(fixture.source_geometry, 3);
+    const Eigen::VectorXd tangent = fixture.native_tangent();
+    Eigen::MatrixXd atmospheric_tangent;
+    Eigen::VectorXd ground_tangent;
+    assembler.assemble_jvp(fixture.atmosphere, wavelength, tangent,
+                           atmospheric_tangent, ground_tangent);
+
+    constexpr double step = 1.0e-5;
+    fixture.perturb(wavelength, tangent, step);
+    auto above = assembler.create_operator();
+    assembler.assemble_values(fixture.atmosphere, wavelength, above);
+    fixture.perturb(wavelength, tangent, -2.0 * step);
+    auto below = assembler.create_operator();
+    assembler.assemble_values(fixture.atmosphere, wavelength, below);
+    fixture.perturb(wavelength, tangent, step);
+
+    const Eigen::MatrixXd atmospheric_difference =
+        (above.atmospheric_coefficients() - below.atmospheric_coefficients()) /
+        (2.0 * step);
+    const Eigen::VectorXd ground_difference =
+        (above.ground_values() - below.ground_values()) / (2.0 * step);
+    REQUIRE(
+        (atmospheric_tangent - atmospheric_difference).cwiseAbs().maxCoeff() <
+        3.0e-10);
+    REQUIRE((ground_tangent - ground_difference).cwiseAbs().maxCoeff() <
+            3.0e-10);
+}
+
+TEST_CASE("Vector scattering assembler native VJP is adjoint",
+          "[successive_orders][scattering_assembler][vector][jvp][vjp]") {
+    VectorAssemblyFixture fixture;
+    constexpr int wavelength = 0;
+    VectorScatteringAssembler assembler(fixture.source_geometry, 3);
+    const Eigen::VectorXd tangent = fixture.native_tangent();
+    Eigen::MatrixXd atmospheric_tangent;
+    Eigen::VectorXd ground_tangent;
+    assembler.assemble_jvp(fixture.atmosphere, wavelength, tangent,
+                           atmospheric_tangent, ground_tangent);
+
+    const Eigen::MatrixXd atmospheric_gradient =
+        Eigen::MatrixXd::Random(fixture.source_geometry.num_interior_points(),
+                                4 * assembler.num_coefficients());
+    const Eigen::VectorXd ground_gradient =
+        Eigen::VectorXd::Random(assembler.ground_value_size());
+    Eigen::VectorXd native_gradient =
+        Eigen::VectorXd::Zero(fixture.atmosphere.num_deriv());
+    assembler.accumulate_vjp(fixture.atmosphere, wavelength,
+                             atmospheric_gradient, ground_gradient,
+                             native_gradient);
+
+    const double parameter_forward =
+        (atmospheric_tangent.array() * atmospheric_gradient.array()).sum() +
+        ground_tangent.dot(ground_gradient);
+    REQUIRE(parameter_forward ==
+            Catch::Approx(tangent.dot(native_gradient)).epsilon(5.0e-12));
+    REQUIRE(native_gradient.head(2 * fixture.geometry.size()).isZero());
+}
+
+TEST_CASE("Vector scattering assembler completes delta-M scaling",
+          "[successive_orders][scattering_assembler][vector][delta_m][jvp]"
+          "[vjp]") {
+    VectorAssemblyFixture fixture;
+    constexpr int wavelength = 1;
+    constexpr int delta_m_order = 3;
+    fixture.enable_delta_m_scaling(delta_m_order);
+
+    VectorScatteringAssembler assembler(fixture.source_geometry, delta_m_order);
+    auto scattering = assembler.create_operator();
+    assembler.assemble_values(fixture.atmosphere, wavelength, scattering);
+
+    const auto& storage = fixture.atmosphere.storage();
+    for (int point = 0; point < fixture.source_geometry.num_interior_points();
+         ++point) {
+        for (int coefficient = 0;
+             coefficient < scattering.atmospheric_coefficients().cols();
+             ++coefficient) {
+            const int degree = coefficient / 4;
+            const bool subtract_delta_peak = coefficient % 4 != 3;
+            double expected = 0.0;
+            for (const auto& weight :
+                 fixture.source_geometry.source_point(point)
+                     .atmosphere_weights()) {
+                const double f = storage.f(weight.index, wavelength);
+                const double correction =
+                    subtract_delta_peak ? (2.0 * degree + 1.0) * f / (1.0 - f)
+                                        : 0.0;
+                expected +=
+                    weight.weight *
+                    (storage.leg_coeff(coefficient, weight.index, wavelength) -
+                     correction);
+            }
+            REQUIRE(scattering.atmospheric_coefficients()(point, coefficient) ==
+                    Catch::Approx(expected).epsilon(2.0e-14));
+        }
+        for (int greek = 0; greek < 3; ++greek) {
+            REQUIRE(scattering.atmospheric_coefficients()(point, greek) ==
+                    Catch::Approx(1.0).epsilon(2.0e-14));
+        }
+    }
+
+    const Eigen::VectorXd tangent = fixture.native_tangent();
+    Eigen::MatrixXd coefficient_tangent;
+    Eigen::VectorXd ground_tangent;
+    assembler.assemble_jvp(fixture.atmosphere, wavelength, tangent,
+                           coefficient_tangent, ground_tangent);
+    for (int greek = 0; greek < 3; ++greek) {
+        REQUIRE(coefficient_tangent.col(greek).isZero(2.0e-14));
+    }
+
+    constexpr double step = 1.0e-5;
+    fixture.perturb_delta_scaled(wavelength, tangent, step);
+    auto above = assembler.create_operator();
+    assembler.assemble_values(fixture.atmosphere, wavelength, above);
+    fixture.perturb_delta_scaled(wavelength, tangent, -2.0 * step);
+    auto below = assembler.create_operator();
+    assembler.assemble_values(fixture.atmosphere, wavelength, below);
+    fixture.perturb_delta_scaled(wavelength, tangent, step);
+
+    const Eigen::MatrixXd coefficient_difference =
+        (above.atmospheric_coefficients() - below.atmospheric_coefficients()) /
+        (2.0 * step);
+    const Eigen::VectorXd ground_difference =
+        (above.ground_values() - below.ground_values()) / (2.0 * step);
+    REQUIRE(
+        (coefficient_tangent - coefficient_difference).cwiseAbs().maxCoeff() <
+        3.0e-10);
+    REQUIRE((ground_tangent - ground_difference).cwiseAbs().maxCoeff() <
+            3.0e-10);
+
+    const Eigen::MatrixXd coefficient_gradient =
+        Eigen::MatrixXd::Random(fixture.source_geometry.num_interior_points(),
+                                4 * assembler.num_coefficients());
+    const Eigen::VectorXd ground_gradient =
+        Eigen::VectorXd::Random(assembler.ground_value_size());
+    Eigen::VectorXd native_gradient =
+        Eigen::VectorXd::Zero(fixture.atmosphere.num_deriv());
+    assembler.accumulate_vjp(fixture.atmosphere, wavelength,
+                             coefficient_gradient, ground_gradient,
+                             native_gradient);
+    const double parameter_forward =
+        (coefficient_tangent.array() * coefficient_gradient.array()).sum() +
+        ground_tangent.dot(ground_gradient);
+    REQUIRE(parameter_forward ==
+            Catch::Approx(tangent.dot(native_gradient)).epsilon(5.0e-12));
+}

--- a/cpp/lib/tests/successive_orders/test_source.cpp
+++ b/cpp/lib/tests/successive_orders/test_source.cpp
@@ -1,0 +1,229 @@
+#include <sasktran2.h>
+#include <sasktran2/test_helper.h>
+
+#include <cmath>
+#include <memory>
+#include <optional>
+#include <utility>
+
+namespace {
+    constexpr int NumAltitudes = 9;
+    constexpr int NumWavelengths = 2;
+    constexpr int NumLos = 3;
+
+    sasktran2::Config successive_orders_config() {
+        sasktran2::Config config;
+        config.set_num_threads(2);
+        config.set_threading_model(
+            sasktran2::Config::ThreadingModel::wavelength);
+        config.set_single_scatter_source(
+            sasktran2::Config::SingleScatterSource::exact);
+        config.set_multiple_scatter_source(
+            sasktran2::Config::MultipleScatterSource::successive_orders_cpp);
+        config.set_num_hr_incoming(14);
+        config.set_num_hr_outgoing(14);
+        config.set_num_hr_spherical_iterations(30);
+        config.set_successive_orders_relative_tolerance(1.0e-8);
+        config.set_successive_orders_absolute_tolerance(1.0e-12);
+        config.set_successive_orders_anderson_depth(3);
+        config.set_num_do_streams(8);
+        config.set_num_singlescatter_moments(8);
+        config.set_apply_delta_scaling(false);
+        return config;
+    }
+
+    sasktran2::Geometry1D successive_orders_geometry() {
+        sasktran2::Coordinates coordinates(0.55, 0.15, 6372000.0,
+                                           sasktran2::geometrytype::spherical);
+        Eigen::VectorXd altitudes(NumAltitudes);
+        for (int altitude = 0; altitude < NumAltitudes; ++altitude) {
+            altitudes(altitude) = altitude * 5000.0;
+        }
+        sasktran2::grids::AltitudeGrid altitude_grid(
+            std::move(altitudes), sasktran2::grids::gridspacing::constant,
+            sasktran2::grids::outofbounds::extend,
+            sasktran2::grids::interpolation::linear);
+        return {std::move(coordinates), std::move(altitude_grid)};
+    }
+
+    sasktran2::viewinggeometry::ViewingGeometryContainer
+    successive_orders_viewing() {
+        sasktran2::viewinggeometry::ViewingGeometryContainer viewing;
+        viewing.observer_rays().emplace_back(
+            std::make_unique<sasktran2::viewinggeometry::GroundViewingSolar>(
+                0.55, 0.35, 0.72, 100000.0));
+        viewing.observer_rays().emplace_back(
+            std::make_unique<sasktran2::viewinggeometry::TangentAltitudeSolar>(
+                10000.0, -0.4, 100000.0, 0.55));
+        viewing.observer_rays().emplace_back(
+            std::make_unique<sasktran2::viewinggeometry::TangentAltitudeSolar>(
+                22500.0, 0.6, 100000.0, 0.55));
+        return viewing;
+    }
+
+    void initialize_atmosphere(sasktran2::atmosphere::Atmosphere<1>& atmosphere,
+                               int atmosphere_lifetime) {
+        atmosphere.storage().resize_derivatives(atmosphere_lifetime);
+        for (int wavelength = 0; wavelength < NumWavelengths; ++wavelength) {
+            for (int altitude = 0; altitude < NumAltitudes; ++altitude) {
+                atmosphere.storage().total_extinction(altitude, wavelength) =
+                    (1.4e-5 * std::exp(-altitude / 1.7) + 2.0e-9) *
+                    (0.9 + 0.2 * wavelength) *
+                    (1.0 + 0.15 * atmosphere_lifetime);
+                atmosphere.storage().ssa(altitude, wavelength) =
+                    0.90 - 0.008 * wavelength - 0.002 * altitude -
+                    0.03 * atmosphere_lifetime;
+            }
+        }
+        atmosphere.storage().leg_coeff.chip(0, 0).setConstant(1.0);
+        atmosphere.storage().leg_coeff.chip(1, 0).setConstant(0.08);
+        atmosphere.storage().leg_coeff.chip(2, 0).setConstant(0.5);
+        atmosphere.surface().brdf_args().row(0).setConstant(
+            0.12 + 0.05 * atmosphere_lifetime);
+
+        auto& mapping =
+            atmosphere.storage().get_derivative_mapping("retrieval_state");
+        mapping.allocate_extinction_derivatives();
+        mapping.allocate_ssa_derivatives();
+        mapping.native_mapping().d_extinction->setConstant(1.0e-5);
+        mapping.native_mapping().d_ssa->setConstant(1.0e-2);
+    }
+} // namespace
+
+TEST_CASE("Successive-orders revision-zero atmosphere remains directly "
+          "mutable",
+          "[successive_orders][engine][linearization][cache]") {
+    const auto config = successive_orders_config();
+    auto geometry = successive_orders_geometry();
+    const auto viewing = successive_orders_viewing();
+    Sasktran2<1> reused_engine(config, &geometry, viewing);
+    sasktran2::atmosphere::Atmosphere<1> atmosphere(NumWavelengths, geometry,
+                                                    config, true);
+    initialize_atmosphere(atmosphere, 0);
+    REQUIRE(atmosphere.revision() == 0);
+
+    const auto calculate = [&](Sasktran2<1>& engine) {
+        Eigen::VectorXd radiance =
+            Eigen::VectorXd::Zero(NumWavelengths * NumLos);
+        const Eigen::VectorXd cotangent =
+            Eigen::VectorXd::LinSpaced(NumWavelengths * NumLos, 0.4, 1.1);
+        Eigen::VectorXd gradient = Eigen::VectorXd::Zero(NumAltitudes);
+        Eigen::Map<Eigen::VectorXd> radiance_map(radiance.data(),
+                                                 radiance.size());
+        Eigen::Map<const Eigen::VectorXd> cotangent_map(cotangent.data(),
+                                                        cotangent.size());
+        Eigen::Map<Eigen::VectorXd> gradient_map(gradient.data(),
+                                                 gradient.size());
+        sasktran2::OutputVJP<1> output(radiance_map, cotangent_map);
+        output.set_derivative_gradient_memory("retrieval_state", gradient_map);
+        engine.calculate_vjp(atmosphere, output);
+        output.finalize();
+        return std::make_pair(std::move(radiance), std::move(gradient));
+    };
+
+    const auto initial = calculate(reused_engine);
+    atmosphere.storage().total_extinction *= 1.25;
+    atmosphere.storage().ssa.array() -= 0.04;
+    const auto reused = calculate(reused_engine);
+    Sasktran2<1> fresh_engine(config, &geometry, viewing);
+    const auto fresh = calculate(fresh_engine);
+
+    REQUIRE_FALSE(reused.first.isApprox(initial.first, 1.0e-7));
+    REQUIRE(reused.first.isApprox(fresh.first, 1.0e-7));
+    REQUIRE(reused.second.isApprox(fresh.second, 1.0e-7));
+}
+
+TEST_CASE("Successive-orders scalar VJP survives repeated atmosphere and "
+          "engine lifetimes",
+          "[successive_orders][engine][linearization][lifetime]") {
+    const auto config = successive_orders_config();
+    auto geometry = successive_orders_geometry();
+    const auto viewing = successive_orders_viewing();
+
+    constexpr int evaluations_per_atmosphere = 32;
+    constexpr int atmosphere_lifetimes = 2;
+    constexpr int engine_lifetimes = 2;
+    constexpr int output_size = NumWavelengths * NumLos;
+
+    for (int engine_lifetime = 0; engine_lifetime < engine_lifetimes;
+         ++engine_lifetime) {
+        Sasktran2<1> engine(config, &geometry, viewing);
+        std::optional<sasktran2::atmosphere::Atmosphere<1>> atmosphere_slot;
+
+        for (int atmosphere_lifetime = 0;
+             atmosphere_lifetime < atmosphere_lifetimes;
+             ++atmosphere_lifetime) {
+            atmosphere_slot.emplace(NumWavelengths, geometry, config, true);
+            auto& atmosphere = *atmosphere_slot;
+            initialize_atmosphere(atmosphere, atmosphere_lifetime);
+            const Eigen::MatrixXd base_extinction =
+                atmosphere.storage().total_extinction;
+            const Eigen::MatrixXd base_ssa = atmosphere.storage().ssa;
+
+            // Reproduce allocator-address reuse with the same local revision
+            // as the preceding atmosphere. A cache key made only from object
+            // address and revision cannot distinguish these two lifetimes.
+            if (atmosphere_lifetime != 0) {
+                for (int revision = 1; revision < evaluations_per_atmosphere;
+                     ++revision) {
+                    atmosphere.mark_changed();
+                }
+            }
+
+            Eigen::VectorXd radiance = Eigen::VectorXd::Zero(output_size);
+            Eigen::VectorXd cotangent =
+                Eigen::VectorXd::LinSpaced(output_size, 0.4, 1.1);
+            Eigen::VectorXd gradient = Eigen::VectorXd::Zero(NumAltitudes);
+
+            for (int evaluation = 0; evaluation < evaluations_per_atmosphere;
+                 ++evaluation) {
+                const double extinction_scale =
+                    1.0 + 2.0e-3 * std::sin(0.37 * evaluation);
+                const double ssa_shift = 5.0e-4 * std::cos(0.23 * evaluation);
+                atmosphere.storage().total_extinction =
+                    extinction_scale * base_extinction;
+                atmosphere.storage().ssa =
+                    (base_ssa.array() + ssa_shift).matrix();
+                atmosphere.mark_changed();
+
+                gradient.setZero();
+                Eigen::Map<Eigen::VectorXd> radiance_map(radiance.data(),
+                                                         radiance.size());
+                Eigen::Map<const Eigen::VectorXd> cotangent_map(
+                    cotangent.data(), cotangent.size());
+                Eigen::Map<Eigen::VectorXd> gradient_map(gradient.data(),
+                                                         gradient.size());
+                sasktran2::OutputVJP<1> output(radiance_map, cotangent_map);
+                output.set_derivative_gradient_memory("retrieval_state",
+                                                      gradient_map);
+                engine.calculate_vjp(atmosphere, output);
+                output.finalize();
+
+                REQUIRE(radiance.allFinite());
+                REQUIRE(gradient.allFinite());
+
+                if (evaluation == 0) {
+                    Sasktran2<1> reference_engine(config, &geometry, viewing);
+                    Eigen::VectorXd reference_radiance =
+                        Eigen::VectorXd::Zero(output_size);
+                    Eigen::VectorXd reference_gradient =
+                        Eigen::VectorXd::Zero(NumAltitudes);
+                    Eigen::Map<Eigen::VectorXd> reference_radiance_map(
+                        reference_radiance.data(), reference_radiance.size());
+                    Eigen::Map<Eigen::VectorXd> reference_gradient_map(
+                        reference_gradient.data(), reference_gradient.size());
+                    sasktran2::OutputVJP<1> reference_output(
+                        reference_radiance_map, cotangent_map);
+                    reference_output.set_derivative_gradient_memory(
+                        "retrieval_state", reference_gradient_map);
+                    reference_engine.calculate_vjp(atmosphere,
+                                                   reference_output);
+                    reference_output.finalize();
+
+                    REQUIRE(radiance.isApprox(reference_radiance, 1.0e-7));
+                    REQUIRE(gradient.isApprox(reference_gradient, 1.0e-7));
+                }
+            }
+        }
+    }
+}

--- a/cpp/lib/tests/successive_orders/test_source.cpp
+++ b/cpp/lib/tests/successive_orders/test_source.cpp
@@ -19,7 +19,7 @@ namespace {
         config.set_single_scatter_source(
             sasktran2::Config::SingleScatterSource::exact);
         config.set_multiple_scatter_source(
-            sasktran2::Config::MultipleScatterSource::successive_orders_cpp);
+            sasktran2::Config::MultipleScatterSource::successive_orders);
         config.set_num_hr_incoming(14);
         config.set_num_hr_outgoing(14);
         config.set_num_hr_spherical_iterations(30);

--- a/cpp/lib/tests/successive_orders/test_transport.cpp
+++ b/cpp/lib/tests/successive_orders/test_transport.cpp
@@ -1,0 +1,84 @@
+#include "../../successive_orders/transport.h"
+
+#include <sasktran2/test_helper.h>
+
+namespace {
+    sasktran2::successive_orders::TransportSparsity test_sparsity() {
+        return {4, {0, 2, 5, 7}, {0, 2, 0, 1, 3, 1, 2}};
+    }
+} // namespace
+
+TEST_CASE("Successive-orders CSR transport applies forward and transpose",
+          "[successive_orders][transport]") {
+    const auto sparsity = test_sparsity();
+    sasktran2::successive_orders::TransportOperator transport(sparsity);
+    transport.values() << 0.2, 0.4, -0.1, 0.3, 0.8, 0.5, -0.25;
+
+    const Eigen::VectorXd state =
+        (Eigen::VectorXd(4) << 0.6, -0.2, 0.9, 0.3).finished();
+    const Eigen::VectorXd cotangent =
+        (Eigen::VectorXd(3) << -0.4, 0.7, 0.1).finished();
+    Eigen::VectorXd incoming(3);
+    Eigen::VectorXd state_cotangent(4);
+    transport.apply(state, incoming);
+    transport.apply_transpose(cotangent, state_cotangent);
+
+    REQUIRE(incoming.dot(cotangent) ==
+            Catch::Approx(state.dot(state_cotangent)).epsilon(1.0e-14));
+}
+
+TEST_CASE("Successive-orders CSR transport JVP and VJP are adjoint",
+          "[successive_orders][transport]") {
+    const auto sparsity = test_sparsity();
+    sasktran2::successive_orders::TransportOperator transport(sparsity);
+    transport.values() << 0.2, 0.4, -0.1, 0.3, 0.8, 0.5, -0.25;
+
+    const Eigen::VectorXd state = Eigen::VectorXd::Random(4);
+    const Eigen::VectorXd state_tangent = Eigen::VectorXd::Random(4);
+    const Eigen::VectorXd value_tangent = Eigen::VectorXd::Random(7);
+    const Eigen::VectorXd incoming_cotangent = Eigen::VectorXd::Random(3);
+    Eigen::VectorXd incoming_tangent(3);
+    Eigen::VectorXd state_cotangent(4);
+    Eigen::VectorXd value_gradient(7);
+    transport.apply_jvp(state, state_tangent, value_tangent, incoming_tangent);
+    transport.apply_vjp(state, incoming_cotangent, state_cotangent,
+                        value_gradient);
+
+    const double forward = incoming_tangent.dot(incoming_cotangent);
+    const double reverse =
+        state_tangent.dot(state_cotangent) + value_tangent.dot(value_gradient);
+    REQUIRE(forward == Catch::Approx(reverse).epsilon(1.0e-13));
+}
+
+TEST_CASE("Successive-orders CSR transport shares geometry across Stokes",
+          "[successive_orders][transport]") {
+    const auto sparsity = test_sparsity();
+    sasktran2::successive_orders::TransportOperator transport(sparsity);
+    transport.values() << 0.2, 0.4, -0.1, 0.3, 0.8, 0.5, -0.25;
+
+    constexpr int nstokes = 3;
+    const Eigen::VectorXd state = Eigen::VectorXd::Random(4 * nstokes);
+    const Eigen::VectorXd state_tangent = Eigen::VectorXd::Random(4 * nstokes);
+    const Eigen::VectorXd value_tangent = Eigen::VectorXd::Random(7);
+    const Eigen::VectorXd incoming_cotangent =
+        Eigen::VectorXd::Random(3 * nstokes);
+    Eigen::VectorXd incoming(3 * nstokes);
+    Eigen::VectorXd state_cotangent(4 * nstokes);
+    Eigen::VectorXd incoming_tangent(3 * nstokes);
+    Eigen::VectorXd value_gradient(7);
+
+    transport.apply_stokes<nstokes>(state, incoming);
+    transport.apply_transpose_stokes<nstokes>(incoming_cotangent,
+                                              state_cotangent);
+    REQUIRE(incoming.dot(incoming_cotangent) ==
+            Catch::Approx(state.dot(state_cotangent)).epsilon(1.0e-13));
+
+    transport.apply_jvp_stokes<nstokes>(state, state_tangent, value_tangent,
+                                        incoming_tangent);
+    transport.apply_vjp_stokes<nstokes>(state, incoming_cotangent,
+                                        state_cotangent, value_gradient);
+    REQUIRE(incoming_tangent.dot(incoming_cotangent) ==
+            Catch::Approx(state_tangent.dot(state_cotangent) +
+                          value_tangent.dot(value_gradient))
+                .epsilon(1.0e-13));
+}

--- a/docs/sphinx/source/components/source_terms/successive_orders.md
+++ b/docs/sphinx/source/components/source_terms/successive_orders.md
@@ -4,36 +4,31 @@ file_format: mystnb
 
 (_source_succesive_orders)=
 # The Successive Orders of Scattering Source
-SASKTRAN2 provides two implementations of the successive orders of scattering
-method. The newer, self-contained C++ source can be enabled with
+The successive orders of scattering source is an implementation of the multiple scattering source using the successive orders
+of scattering method. It can be enabled with
 
 ```{code-cell}
 import sasktran2 as sk
 
 config = sk.Config()
 
-config.multiple_scatter_source = sk.MultipleScatterSource.SuccessiveOrdersCpp
+config.multiple_scatter_source = sk.MultipleScatterSource.SuccessiveOrders
 ```
-
-The existing implementation remains available as
-`sk.MultipleScatterSource.SuccessiveOrders`.
 
 ## Advantages
 
- - Multiple scattering that fully accounts for spherical source geometry
- - Full-Jacobian calculations and native JVP/VJP products
- - An explicit source-altitude grid can reduce cost independently of the atmosphere grid
+ - Fully accounts for sphericity of the atmosphere
+ - Supports full weighting-function calculations
 
 ## Disadvantages
 
- - Currently supports one-dimensional atmospheres only
- - Can use a large amount of RAM for large polarized calculations
+ - Can use a large amount of RAM for large, polarized calculations
  - May require sub-layering in optically thick areas of the atmosphere
 
 
-## Iteration and convergence
+## Iteration Options
 
-The C++ source starts from the exact single-scatter illumination and repeatedly
+The successive orders method starts from the exact single-scatter illumination and repeatedly
 applies its transport and scattering operators. The maximum iteration count is
 configured with
 {py:attr}`sasktran2.Config.num_successive_orders_iterations`. By default it
@@ -41,21 +36,11 @@ stops early when the configured absolute or relative residual tolerance is
 met, and Anderson acceleration is enabled.
 
 Set both tolerances to zero to perform exactly the configured number of
-iterations. In this mode each new atmospheric state starts from zero so the
-result is independent of engine history. Native JVPs and VJPs differentiate
-the converged fixed-point system; when tolerances are disabled they need not
-equal the derivative of the finite iteration sequence.
+iterations.
 
 The explicit {py:attr}`sasktran2.Config.successive_orders_altitude_grid_m`
 option decouples the source grid from the atmosphere altitude grid. When it is
 not set, the source uses the midpoints of the atmosphere layers.
-
-## Legacy initialization option
-
-The discrete-ordinates initialization controlled by
-{py:attr}`sasktran2.Config.init_successive_orders_with_discrete_ordinates`
-applies only to the legacy `SuccessiveOrders` source. It is not used by
-`SuccessiveOrdersCpp`.
 
 ## Relevant Configuration Options
 
@@ -72,7 +57,6 @@ applies only to the legacy `SuccessiveOrders` source. It is not used by
   sasktran2.Config.successive_orders_anderson_depth
   sasktran2.Config.successive_orders_damping
   sasktran2.Config.successive_orders_altitude_grid_m
-  sasktran2.Config.init_successive_orders_with_discrete_ordinates
   sasktran2.Config.num_stokes
 
 ```

--- a/docs/sphinx/source/components/source_terms/successive_orders.md
+++ b/docs/sphinx/source/components/source_terms/successive_orders.md
@@ -4,43 +4,58 @@ file_format: mystnb
 
 (_source_succesive_orders)=
 # The Successive Orders of Scattering Source
-The successive orders of scattering source is an implementation of the multiple scattering source using the successive orders
-of scattering method.  It can be enabled with
+SASKTRAN2 provides two implementations of the successive orders of scattering
+method. The newer, self-contained C++ source can be enabled with
 
 ```{code-cell}
 import sasktran2 as sk
 
 config = sk.Config()
 
-config.multiple_scatter_source = sk.MultipleScatterSource.SuccessiveOrders
+config.multiple_scatter_source = sk.MultipleScatterSource.SuccessiveOrdersCpp
 ```
+
+The existing implementation remains available as
+`sk.MultipleScatterSource.SuccessiveOrders`.
 
 ## Advantages
 
- - The only available multiple scattering source that fully accounts for sphericity of the atmosphere
+ - Multiple scattering that fully accounts for spherical source geometry
+ - Full-Jacobian calculations and native JVP/VJP products
+ - An explicit source-altitude grid can reduce cost independently of the atmosphere grid
 
 ## Disadvantages
 
- - Weighting function calculations are only approximate
- - Can use a large amount of RAM for large, polarized, calculations
+ - Currently supports one-dimensional atmospheres only
+ - Can use a large amount of RAM for large polarized calculations
  - May require sub-layering in optically thick areas of the atmosphere
 
 
-## Initialization Options
-The successive orders method is an iterative method which repeatedly refines the solution.  When the method is initialized
-with the single scatter source function, each iteration physically represents including an additional "order of scatter" into
-the solution.  The number of these iterations can be configured with {py:attr}`sasktran2.Config.num_successive_orders_iterations`.
+## Iteration and convergence
 
-Alternatively, the successive orders method can be initialized with the source function calculated with a discrete ordinates solution.
-This has two advantages: the first is that fewer iterations are required to reach convergence, typically only 1--2 instead of sometimes 50;
-the second advantage is that the discrete ordinates method can provide a reasonable approximation for the weighting functions, whereas
-full weighting function calculations in a successive orders model are extremely computationally expensive.
-This option can be enabled with the {py:attr}`sasktran2.Config.init_successive_orders_with_discrete_ordinates` option.  If it is set then
-all of the standard discrete ordinates options apply to the source used to initialize the solution.
+The C++ source starts from the exact single-scatter illumination and repeatedly
+applies its transport and scattering operators. The maximum iteration count is
+configured with
+{py:attr}`sasktran2.Config.num_successive_orders_iterations`. By default it
+stops early when the configured absolute or relative residual tolerance is
+met, and Anderson acceleration is enabled.
 
-## Notes
+Set both tolerances to zero to perform exactly the configured number of
+iterations. In this mode each new atmospheric state starts from zero so the
+result is independent of engine history. Native JVPs and VJPs differentiate
+the converged fixed-point system; when tolerances are disabled they need not
+equal the derivative of the finite iteration sequence.
 
- - The succesive orders of scattering source is not fully linearized, which means that weighting functions returned back will only be approximate.
+The explicit {py:attr}`sasktran2.Config.successive_orders_altitude_grid_m`
+option decouples the source grid from the atmosphere altitude grid. When it is
+not set, the source uses the midpoints of the atmosphere layers.
+
+## Legacy initialization option
+
+The discrete-ordinates initialization controlled by
+{py:attr}`sasktran2.Config.init_successive_orders_with_discrete_ordinates`
+applies only to the legacy `SuccessiveOrders` source. It is not used by
+`SuccessiveOrdersCpp`.
 
 ## Relevant Configuration Options
 
@@ -50,6 +65,13 @@ all of the standard discrete ordinates options apply to the source used to initi
   sasktran2.Config.multiple_scatter_source
   sasktran2.Config.num_sza
   sasktran2.Config.num_successive_orders_iterations
+  sasktran2.Config.num_successive_orders_incoming
+  sasktran2.Config.num_successive_orders_outgoing
+  sasktran2.Config.successive_orders_relative_tolerance
+  sasktran2.Config.successive_orders_absolute_tolerance
+  sasktran2.Config.successive_orders_anderson_depth
+  sasktran2.Config.successive_orders_damping
+  sasktran2.Config.successive_orders_altitude_grid_m
   sasktran2.Config.init_successive_orders_with_discrete_ordinates
   sasktran2.Config.num_stokes
 

--- a/docs/sphinx/source/examples/wf/amf.md
+++ b/docs/sphinx/source/examples/wf/amf.md
@@ -8,8 +8,7 @@ SASKTRAN2 contains built in capability to calculate box air mass factors.
 
 ```{note}
 Air mass factors in SASKTRAN2 are estimated using the analytic weighting function capability implemented inside the model.
-This means they are exact as long as the sources you are using are linearized, which is currently all sources except for
-`sk.MultipleScatterSource.SuccessiveOrders`.  If you use the successive orders source the AMFs are only approximate.
+This means they are exact to the accuracy of the analytic source linearizations.
 ```
 
 We can set up a standard nadir viewing

--- a/docs/sphinx/source/users_guide/performance.md
+++ b/docs/sphinx/source/users_guide/performance.md
@@ -35,11 +35,6 @@ This threading is usually significantly less efficient than the wavelength dimen
 multi-threading, but has the advantage that it works well for a small number of wavelengths, and also
 may use significantly less RAM.
 
-```{note}
-The `sk.ThreadingModel.Source` works well for the `sk.MultipleScatterSource.SuccessiveOrders` source,
-but may not offer much improvement for the `sk.MultipleScatterSource.DiscreteOrdinates` source.
-```
-
 ## Installation Method
 For maximum performance, we recommend installing SASKTRAN2 through the `conda` packages rather than
 the `pip` wheels.  The conda packages are able to use accelerated LAPACK/BLAS libraries for your system

--- a/docs/sphinx/source/users_guide/refraction.md
+++ b/docs/sphinx/source/users_guide/refraction.md
@@ -113,7 +113,3 @@ Typically solar refraction is unimportant until the solar zenith angle is above 
 {py:attr}`sasktran2.Config.solar_refraction`.  Note that currently this option is considered experimental, and only works when
 both the single scatter source and multiple scatter source are set to DiscreteOrdinates, and thus only works for nadir viewing
 applications.
-
-## Multiple Scatter Refraction
-Refraction effects during the multiple scatter calculation are usually negligible.  The option {py:attr}`sasktran2.Config.multiple_scatter_refraction`
-is included to estimate them.  The option only works when the multiple scatter source is set to SuccessiveOrders.

--- a/docs/sphinx/source/weighting_functions.md
+++ b/docs/sphinx/source/weighting_functions.md
@@ -156,7 +156,6 @@ rather than automatically generated for maximum computational efficiency.  Gener
 calculation including full derivatives to be somewhere in the range of 2-5x slower than the calculation
 without derivatives.
 
-The accuracy of the weighting functions depends on which source terms are included in the calculation.
-With the exception of the `sk.MultipleScatterSource.SuccessiveOrders` source, all other sources are
-"perfectly linearized", which means that the weighting function calculation is accurate to relative machine
-precision.  Typically we estimate this to be around 6 decimal places for most applications.
+The source terms in SASKTRAN2 are fully linearized, which means that the weighting function
+calculation is accurate to relative machine precision. Typically we estimate this to be around
+6 decimal places for most applications.

--- a/rust/sasktran2-py-ext/src/config.rs
+++ b/rust/sasktran2-py-ext/src/config.rs
@@ -9,6 +9,7 @@ pub enum MultipleScatterSource {
     SuccessiveOrders,
     TwoStream,
     NoSource,
+    SuccessiveOrdersCpp,
 }
 
 #[pyclass(eq, eq_int)]
@@ -120,6 +121,9 @@ impl PyConfig {
             }
             config::MultipleScatterSource::TwoStream => MultipleScatterSource::TwoStream,
             config::MultipleScatterSource::None => MultipleScatterSource::NoSource,
+            config::MultipleScatterSource::SuccessiveOrdersCpp => {
+                MultipleScatterSource::SuccessiveOrdersCpp
+            }
         }
     }
 
@@ -137,6 +141,9 @@ impl PyConfig {
             }
             MultipleScatterSource::TwoStream => config::MultipleScatterSource::TwoStream,
             MultipleScatterSource::NoSource => config::MultipleScatterSource::None,
+            MultipleScatterSource::SuccessiveOrdersCpp => {
+                config::MultipleScatterSource::SuccessiveOrdersCpp
+            }
         };
         self.config
             .with_multiple_scatter_source(source)
@@ -462,6 +469,84 @@ impl PyConfig {
             .with_num_successive_orders_iterations(num_iterations)
             .into_pyresult()?;
 
+        Ok(())
+    }
+
+    #[getter]
+    fn successive_orders_relative_tolerance(&self) -> PyResult<f64> {
+        self.config
+            .successive_orders_relative_tolerance()
+            .into_pyresult()
+    }
+
+    #[setter]
+    fn set_successive_orders_relative_tolerance(&mut self, tolerance: f64) -> PyResult<()> {
+        self.config
+            .with_successive_orders_relative_tolerance(tolerance)
+            .into_pyresult()?;
+        Ok(())
+    }
+
+    #[getter]
+    fn successive_orders_absolute_tolerance(&self) -> PyResult<f64> {
+        self.config
+            .successive_orders_absolute_tolerance()
+            .into_pyresult()
+    }
+
+    #[setter]
+    fn set_successive_orders_absolute_tolerance(&mut self, tolerance: f64) -> PyResult<()> {
+        self.config
+            .with_successive_orders_absolute_tolerance(tolerance)
+            .into_pyresult()?;
+        Ok(())
+    }
+
+    #[getter]
+    fn successive_orders_anderson_depth(&self) -> PyResult<usize> {
+        self.config
+            .successive_orders_anderson_depth()
+            .into_pyresult()
+    }
+
+    #[setter]
+    fn set_successive_orders_anderson_depth(&mut self, depth: usize) -> PyResult<()> {
+        self.config
+            .with_successive_orders_anderson_depth(depth)
+            .into_pyresult()?;
+        Ok(())
+    }
+
+    #[getter]
+    fn successive_orders_damping(&self) -> PyResult<f64> {
+        self.config.successive_orders_damping().into_pyresult()
+    }
+
+    #[setter]
+    fn set_successive_orders_damping(&mut self, damping: f64) -> PyResult<()> {
+        self.config
+            .with_successive_orders_damping(damping)
+            .into_pyresult()?;
+        Ok(())
+    }
+
+    #[getter]
+    fn successive_orders_altitude_grid_m(&self) -> PyResult<Option<Vec<f64>>> {
+        let altitude_grid_m = self
+            .config
+            .successive_orders_altitude_grid_m()
+            .into_pyresult()?;
+        Ok((!altitude_grid_m.is_empty()).then_some(altitude_grid_m))
+    }
+
+    #[setter]
+    fn set_successive_orders_altitude_grid_m(
+        &mut self,
+        altitude_grid_m: Option<Vec<f64>>,
+    ) -> PyResult<()> {
+        self.config
+            .with_successive_orders_altitude_grid_m(altitude_grid_m.as_deref().unwrap_or_default())
+            .into_pyresult()?;
         Ok(())
     }
 

--- a/rust/sasktran2-py-ext/src/config.rs
+++ b/rust/sasktran2-py-ext/src/config.rs
@@ -5,11 +5,11 @@ use sasktran2_rs::bindings::config;
 #[pyclass(eq, eq_int)]
 #[derive(PartialEq, Clone)]
 pub enum MultipleScatterSource {
-    DiscreteOrdinates,
-    SuccessiveOrders,
-    TwoStream,
-    NoSource,
-    SuccessiveOrdersCpp,
+    DiscreteOrdinates = 0,
+    SuccessiveOrdersLegacy = 1,
+    TwoStream = 2,
+    NoSource = 3,
+    SuccessiveOrders = 4,
 }
 
 #[pyclass(eq, eq_int)]
@@ -116,13 +116,13 @@ impl PyConfig {
             config::MultipleScatterSource::DiscreteOrdinates => {
                 MultipleScatterSource::DiscreteOrdinates
             }
-            config::MultipleScatterSource::SuccessiveOrders => {
-                MultipleScatterSource::SuccessiveOrders
+            config::MultipleScatterSource::SuccessiveOrdersLegacy => {
+                MultipleScatterSource::SuccessiveOrdersLegacy
             }
             config::MultipleScatterSource::TwoStream => MultipleScatterSource::TwoStream,
             config::MultipleScatterSource::None => MultipleScatterSource::NoSource,
-            config::MultipleScatterSource::SuccessiveOrdersCpp => {
-                MultipleScatterSource::SuccessiveOrdersCpp
+            config::MultipleScatterSource::SuccessiveOrders => {
+                MultipleScatterSource::SuccessiveOrders
             }
         }
     }
@@ -136,13 +136,13 @@ impl PyConfig {
             MultipleScatterSource::DiscreteOrdinates => {
                 config::MultipleScatterSource::DiscreteOrdinates
             }
-            MultipleScatterSource::SuccessiveOrders => {
-                config::MultipleScatterSource::SuccessiveOrders
+            MultipleScatterSource::SuccessiveOrdersLegacy => {
+                config::MultipleScatterSource::SuccessiveOrdersLegacy
             }
             MultipleScatterSource::TwoStream => config::MultipleScatterSource::TwoStream,
             MultipleScatterSource::NoSource => config::MultipleScatterSource::None,
-            MultipleScatterSource::SuccessiveOrdersCpp => {
-                config::MultipleScatterSource::SuccessiveOrdersCpp
+            MultipleScatterSource::SuccessiveOrders => {
+                config::MultipleScatterSource::SuccessiveOrders
             }
         };
         self.config

--- a/rust/sasktran2-rs/src/bindings/config.rs
+++ b/rust/sasktran2-rs/src/bindings/config.rs
@@ -6,10 +6,10 @@ use sasktran2_sys::ffi;
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum MultipleScatterSource {
     DiscreteOrdinates = 0,
-    SuccessiveOrders = 1,
+    SuccessiveOrdersLegacy = 1,
     TwoStream = 2,
     None = 3,
-    SuccessiveOrdersCpp = 4,
+    SuccessiveOrders = 4,
 }
 
 #[repr(i32)]
@@ -1270,19 +1270,19 @@ mod tests {
         assert_eq!(config.threading_lib(), ThreadingLib::Rayon);
 
         config
+            .with_multiple_scatter_source(MultipleScatterSource::SuccessiveOrdersLegacy)
+            .unwrap();
+        assert_eq!(
+            config.multiple_scatter_source().unwrap(),
+            MultipleScatterSource::SuccessiveOrdersLegacy
+        );
+
+        config
             .with_multiple_scatter_source(MultipleScatterSource::SuccessiveOrders)
             .unwrap();
         assert_eq!(
             config.multiple_scatter_source().unwrap(),
             MultipleScatterSource::SuccessiveOrders
-        );
-
-        config
-            .with_multiple_scatter_source(MultipleScatterSource::SuccessiveOrdersCpp)
-            .unwrap();
-        assert_eq!(
-            config.multiple_scatter_source().unwrap(),
-            MultipleScatterSource::SuccessiveOrdersCpp
         );
 
         config

--- a/rust/sasktran2-rs/src/bindings/config.rs
+++ b/rust/sasktran2-rs/src/bindings/config.rs
@@ -9,6 +9,7 @@ pub enum MultipleScatterSource {
     SuccessiveOrders = 1,
     TwoStream = 2,
     None = 3,
+    SuccessiveOrdersCpp = 4,
 }
 
 #[repr(i32)]
@@ -648,6 +649,194 @@ impl Config {
         }
     }
 
+    pub fn successive_orders_relative_tolerance(&self) -> Result<f64> {
+        let mut tolerance = 0.0;
+        let error_code = unsafe {
+            ffi::sk_config_get_successive_orders_relative_tolerance(self.config, &mut tolerance)
+        };
+
+        if error_code != 0 {
+            Err(anyhow!(
+                "Error getting successive-orders relative tolerance: error code {}",
+                error_code
+            ))
+        } else {
+            Ok(tolerance)
+        }
+    }
+
+    pub fn with_successive_orders_relative_tolerance(
+        &mut self,
+        tolerance: f64,
+    ) -> Result<&mut Self> {
+        let error_code = unsafe {
+            ffi::sk_config_set_successive_orders_relative_tolerance(self.config, tolerance)
+        };
+
+        if error_code != 0 {
+            Err(anyhow!(
+                "Successive-orders relative tolerance must be finite and non-negative"
+            ))
+        } else {
+            Ok(self)
+        }
+    }
+
+    pub fn successive_orders_absolute_tolerance(&self) -> Result<f64> {
+        let mut tolerance = 0.0;
+        let error_code = unsafe {
+            ffi::sk_config_get_successive_orders_absolute_tolerance(self.config, &mut tolerance)
+        };
+
+        if error_code != 0 {
+            Err(anyhow!(
+                "Error getting successive-orders absolute tolerance: error code {}",
+                error_code
+            ))
+        } else {
+            Ok(tolerance)
+        }
+    }
+
+    pub fn with_successive_orders_absolute_tolerance(
+        &mut self,
+        tolerance: f64,
+    ) -> Result<&mut Self> {
+        let error_code = unsafe {
+            ffi::sk_config_set_successive_orders_absolute_tolerance(self.config, tolerance)
+        };
+
+        if error_code != 0 {
+            Err(anyhow!(
+                "Successive-orders absolute tolerance must be finite and non-negative"
+            ))
+        } else {
+            Ok(self)
+        }
+    }
+
+    pub fn successive_orders_anderson_depth(&self) -> Result<usize> {
+        let mut depth = 0i32;
+        let error_code =
+            unsafe { ffi::sk_config_get_successive_orders_anderson_depth(self.config, &mut depth) };
+
+        if error_code != 0 {
+            Err(anyhow!(
+                "Error getting successive-orders Anderson depth: error code {}",
+                error_code
+            ))
+        } else {
+            Ok(depth as usize)
+        }
+    }
+
+    pub fn with_successive_orders_anderson_depth(&mut self, depth: usize) -> Result<&mut Self> {
+        if depth > i32::MAX as usize {
+            return Err(anyhow!("Successive-orders Anderson depth is too large"));
+        }
+        let error_code = unsafe {
+            ffi::sk_config_set_successive_orders_anderson_depth(self.config, depth as i32)
+        };
+
+        if error_code != 0 {
+            Err(anyhow!(
+                "Successive-orders Anderson depth must be non-negative"
+            ))
+        } else {
+            Ok(self)
+        }
+    }
+
+    pub fn successive_orders_damping(&self) -> Result<f64> {
+        let mut damping = 0.0;
+        let error_code =
+            unsafe { ffi::sk_config_get_successive_orders_damping(self.config, &mut damping) };
+
+        if error_code != 0 {
+            Err(anyhow!(
+                "Error getting successive-orders damping: error code {}",
+                error_code
+            ))
+        } else {
+            Ok(damping)
+        }
+    }
+
+    pub fn with_successive_orders_damping(&mut self, damping: f64) -> Result<&mut Self> {
+        let error_code =
+            unsafe { ffi::sk_config_set_successive_orders_damping(self.config, damping) };
+
+        if error_code != 0 {
+            Err(anyhow!(
+                "Successive-orders damping must be finite and in the interval (0, 1]"
+            ))
+        } else {
+            Ok(self)
+        }
+    }
+
+    pub fn successive_orders_altitude_grid_m(&self) -> Result<Vec<f64>> {
+        let mut num_altitudes = 0i32;
+        let error_code = unsafe {
+            ffi::sk_config_get_num_successive_orders_altitudes(self.config, &mut num_altitudes)
+        };
+        if error_code != 0 || num_altitudes < 0 {
+            return Err(anyhow!(
+                "Error getting successive-orders altitude-grid size: error code {}",
+                error_code
+            ));
+        }
+
+        let mut altitude_grid_m = vec![0.0; num_altitudes as usize];
+        let destination = if altitude_grid_m.is_empty() {
+            std::ptr::null_mut()
+        } else {
+            altitude_grid_m.as_mut_ptr()
+        };
+        let error_code = unsafe {
+            ffi::sk_config_get_successive_orders_altitude_grid_m(self.config, destination)
+        };
+        if error_code != 0 {
+            Err(anyhow!(
+                "Error getting successive-orders altitude grid: error code {}",
+                error_code
+            ))
+        } else {
+            Ok(altitude_grid_m)
+        }
+    }
+
+    pub fn with_successive_orders_altitude_grid_m(
+        &mut self,
+        altitude_grid_m: &[f64],
+    ) -> Result<&mut Self> {
+        if altitude_grid_m.len() > i32::MAX as usize {
+            return Err(anyhow!(
+                "Successive-orders altitude grid contains too many points"
+            ));
+        }
+        let source = if altitude_grid_m.is_empty() {
+            std::ptr::null()
+        } else {
+            altitude_grid_m.as_ptr()
+        };
+        let error_code = unsafe {
+            ffi::sk_config_set_successive_orders_altitude_grid_m(
+                self.config,
+                source,
+                altitude_grid_m.len() as i32,
+            )
+        };
+
+        if error_code != 0 {
+            Err(anyhow!(
+                "Successive-orders altitude grid must be finite and strictly increasing"
+            ))
+        } else {
+            Ok(self)
+        }
+    }
+
     pub fn init_successive_orders_with_discrete_ordinates(&self) -> Result<bool> {
         let mut init = 0i32;
         let error_code =
@@ -1035,6 +1224,20 @@ mod tests {
         );
         assert_eq!(config.stokes_basis().unwrap(), StokesBasis::Standard);
         assert_eq!(config.log_level().unwrap(), LogLevel::Warn);
+        assert_eq!(
+            config.successive_orders_relative_tolerance().unwrap(),
+            1.0e-6
+        );
+        assert_eq!(
+            config.successive_orders_absolute_tolerance().unwrap(),
+            1.0e-12
+        );
+        assert_eq!(config.successive_orders_anderson_depth().unwrap(), 3);
+        assert_eq!(config.successive_orders_damping().unwrap(), 1.0);
+        assert!(config
+            .successive_orders_altitude_grid_m()
+            .unwrap()
+            .is_empty());
     }
 
     #[test]
@@ -1072,6 +1275,14 @@ mod tests {
         assert_eq!(
             config.multiple_scatter_source().unwrap(),
             MultipleScatterSource::SuccessiveOrders
+        );
+
+        config
+            .with_multiple_scatter_source(MultipleScatterSource::SuccessiveOrdersCpp)
+            .unwrap();
+        assert_eq!(
+            config.multiple_scatter_source().unwrap(),
+            MultipleScatterSource::SuccessiveOrdersCpp
         );
 
         config
@@ -1142,6 +1353,45 @@ mod tests {
 
         config.with_num_successive_orders_outgoing(30).unwrap();
         assert_eq!(config.num_successive_orders_outgoing().unwrap(), 30);
+
+        config
+            .with_successive_orders_relative_tolerance(2.0e-7)
+            .unwrap()
+            .with_successive_orders_absolute_tolerance(3.0e-13)
+            .unwrap()
+            .with_successive_orders_anderson_depth(4)
+            .unwrap()
+            .with_successive_orders_damping(0.85)
+            .unwrap()
+            .with_successive_orders_altitude_grid_m(&[500.0, 2_500.0, 10_000.0])
+            .unwrap();
+        assert_eq!(
+            config.successive_orders_relative_tolerance().unwrap(),
+            2.0e-7
+        );
+        assert_eq!(
+            config.successive_orders_absolute_tolerance().unwrap(),
+            3.0e-13
+        );
+        assert_eq!(config.successive_orders_anderson_depth().unwrap(), 4);
+        assert_eq!(config.successive_orders_damping().unwrap(), 0.85);
+        assert_eq!(
+            config.successive_orders_altitude_grid_m().unwrap(),
+            [500.0, 2_500.0, 10_000.0]
+        );
+
+        assert!(config
+            .with_successive_orders_relative_tolerance(f64::NAN)
+            .is_err());
+        assert!(config.with_successive_orders_damping(0.0).is_err());
+        assert!(config
+            .with_successive_orders_altitude_grid_m(&[2_000.0, 1_000.0])
+            .is_err());
+        config.with_successive_orders_altitude_grid_m(&[]).unwrap();
+        assert!(config
+            .successive_orders_altitude_grid_m()
+            .unwrap()
+            .is_empty());
     }
 
     #[test]

--- a/rust/sasktran2-sys/src/bindings.rs
+++ b/rust/sasktran2-sys/src/bindings.rs
@@ -763,6 +763,73 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    pub fn sk_config_get_successive_orders_relative_tolerance(
+        config: *mut Config,
+        tolerance: *mut f64,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn sk_config_set_successive_orders_relative_tolerance(
+        config: *mut Config,
+        tolerance: f64,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn sk_config_get_successive_orders_absolute_tolerance(
+        config: *mut Config,
+        tolerance: *mut f64,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn sk_config_set_successive_orders_absolute_tolerance(
+        config: *mut Config,
+        tolerance: f64,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn sk_config_get_successive_orders_anderson_depth(
+        config: *mut Config,
+        depth: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn sk_config_set_successive_orders_anderson_depth(
+        config: *mut Config,
+        depth: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn sk_config_get_successive_orders_damping(
+        config: *mut Config,
+        damping: *mut f64,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn sk_config_set_successive_orders_damping(
+        config: *mut Config,
+        damping: f64,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn sk_config_get_num_successive_orders_altitudes(
+        config: *mut Config,
+        num_altitudes: *mut ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn sk_config_get_successive_orders_altitude_grid_m(
+        config: *mut Config,
+        altitude_grid_m: *mut f64,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn sk_config_set_successive_orders_altitude_grid_m(
+        config: *mut Config,
+        altitude_grid_m: *const f64,
+        num_altitudes: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
     pub fn sk_config_get_occultation_source(
         config: *mut Config,
         occultation_source: *mut ::std::os::raw::c_int,

--- a/src/sasktran2/config.py
+++ b/src/sasktran2/config.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import numpy as np
+
 from sasktran2._core_rust import (
     EmissionSource,
     FluxType,
@@ -269,6 +271,9 @@ class Config:
             The successive orders of scattering method is used to estimate the multiple scatter
             signal
 
+        `sasktran2.MultipleScatterSource.SuccessiveOrdersCpp`
+            The self-contained C++ successive-orders implementation is used.
+
         """
         return self._config.multiple_scatter_source
 
@@ -286,6 +291,9 @@ class Config:
         `sasktran2.MultipleScatterSource.SuccessiveOrders`
             The successive orders of scattering method is used to estimate the multiple scatter
             signal
+
+        `sasktran2.MultipleScatterSource.SuccessiveOrdersCpp`
+            The self-contained C++ successive-orders implementation is used.
 
         """
         self._config.multiple_scatter_source = value
@@ -403,34 +411,113 @@ class Config:
     @property
     def num_successive_orders_iterations(self) -> int:
         """
-        The number of iterations to perform when using the successive orders of scattering multiple scatter
-        source.
+        The number of iterations used by the legacy successive-orders source and the maximum
+        number used by the C++ successive-orders source.
         """
         return self._config.num_successive_orders_iterations
 
     @num_successive_orders_iterations.setter
     def num_successive_orders_iterations(self, value: int):
         """
-        The number of iterations to perform when using the successive orders of scattering multiple scatter
-        source.
+        The number of iterations used by the legacy successive-orders source and the maximum
+        number used by the C++ successive-orders source.
         """
         self._config.num_successive_orders_iterations = value
 
     @property
+    def successive_orders_relative_tolerance(self) -> float:
+        """Relative residual tolerance for ``SuccessiveOrdersCpp``.
+
+        Set this and :attr:`successive_orders_absolute_tolerance` to zero to
+        use a fixed iteration count. Defaults to ``1e-6``.
+        """
+        return self._config.successive_orders_relative_tolerance
+
+    @successive_orders_relative_tolerance.setter
+    def successive_orders_relative_tolerance(self, value: float):
+        self._config.successive_orders_relative_tolerance = value
+
+    @property
+    def successive_orders_absolute_tolerance(self) -> float:
+        """Absolute residual tolerance for ``SuccessiveOrdersCpp``.
+
+        Defaults to ``1e-12``.
+        """
+        return self._config.successive_orders_absolute_tolerance
+
+    @successive_orders_absolute_tolerance.setter
+    def successive_orders_absolute_tolerance(self, value: float):
+        self._config.successive_orders_absolute_tolerance = value
+
+    @property
+    def successive_orders_anderson_depth(self) -> int:
+        """Anderson history depth for ``SuccessiveOrdersCpp``.
+
+        Zero selects damped Picard iteration. Defaults to 3.
+        """
+        return self._config.successive_orders_anderson_depth
+
+    @successive_orders_anderson_depth.setter
+    def successive_orders_anderson_depth(self, value: int):
+        self._config.successive_orders_anderson_depth = value
+
+    @property
+    def successive_orders_damping(self) -> float:
+        """Fixed-point damping for ``SuccessiveOrdersCpp`` in ``(0, 1]``."""
+        return self._config.successive_orders_damping
+
+    @successive_orders_damping.setter
+    def successive_orders_damping(self, value: float):
+        self._config.successive_orders_damping = value
+
+    @property
+    def successive_orders_altitude_grid_m(self) -> np.ndarray | None:
+        """Explicit source-altitude grid for ``SuccessiveOrdersCpp``, in metres.
+
+        ``None`` selects the atmosphere-derived default. Explicit values must
+        be finite, one-dimensional, and strictly increasing.
+        """
+        altitude_grid_m = self._config.successive_orders_altitude_grid_m
+        if altitude_grid_m is None:
+            return None
+        return np.asarray(altitude_grid_m, dtype=np.float64)
+
+    @successive_orders_altitude_grid_m.setter
+    def successive_orders_altitude_grid_m(self, value: np.ndarray | None):
+        if value is None:
+            self._config.successive_orders_altitude_grid_m = None
+            return
+
+        altitude_grid_m = np.asarray(value, dtype=np.float64)
+        if altitude_grid_m.ndim != 1:
+            msg = "successive_orders_altitude_grid_m must be one-dimensional"
+            raise ValueError(msg)
+        if altitude_grid_m.size == 0:
+            self._config.successive_orders_altitude_grid_m = None
+            return
+        if not np.all(np.isfinite(altitude_grid_m)):
+            msg = "successive_orders_altitude_grid_m must contain only finite values"
+            raise ValueError(msg)
+        if np.any(np.diff(altitude_grid_m) <= 0):
+            msg = "successive_orders_altitude_grid_m must be strictly increasing"
+            raise ValueError(msg)
+        self._config.successive_orders_altitude_grid_m = altitude_grid_m.tolist()
+
+    @property
     def init_successive_orders_with_discrete_ordinates(self) -> bool:
         """
-        If set to true, when using the successive orders source, it will be initialized with a source calculated with
+        If set to true, the legacy successive orders source is initialized with a source calculated with
         the discrete ordinates source instead of a single scattering source.  This greatly reduces the number
-        of iterations required for the method, as well as provides a better weighting function approximation.
+        of iterations required for the legacy method. This setting is not used by ``SuccessiveOrdersCpp``.
         """
         return self._config.init_successive_orders_with_discrete_ordinates
 
     @init_successive_orders_with_discrete_ordinates.setter
     def init_successive_orders_with_discrete_ordinates(self, value: bool):
         """
-        If set to true, when using the successive orders source, it will be initialized with a source calculated with
+        If set to true, the legacy successive orders source is initialized with a source calculated with
         the discrete ordinates source instead of a single scattering source.  This greatly reduces the number
-        of iterations required for the method, as well as provides a better weighting function approximation.
+        of iterations required for the legacy method. This setting is not used by ``SuccessiveOrdersCpp``.
         """
         self._config.init_successive_orders_with_discrete_ordinates = value
 

--- a/src/sasktran2/config.py
+++ b/src/sasktran2/config.py
@@ -271,9 +271,6 @@ class Config:
             The successive orders of scattering method is used to estimate the multiple scatter
             signal
 
-        `sasktran2.MultipleScatterSource.SuccessiveOrdersCpp`
-            The self-contained C++ successive-orders implementation is used.
-
         """
         return self._config.multiple_scatter_source
 
@@ -291,9 +288,6 @@ class Config:
         `sasktran2.MultipleScatterSource.SuccessiveOrders`
             The successive orders of scattering method is used to estimate the multiple scatter
             signal
-
-        `sasktran2.MultipleScatterSource.SuccessiveOrdersCpp`
-            The self-contained C++ successive-orders implementation is used.
 
         """
         self._config.multiple_scatter_source = value
@@ -426,7 +420,7 @@ class Config:
 
     @property
     def successive_orders_relative_tolerance(self) -> float:
-        """Relative residual tolerance for ``SuccessiveOrdersCpp``.
+        """Relative residual tolerance for ``SuccessiveOrders``.
 
         Set this and :attr:`successive_orders_absolute_tolerance` to zero to
         use a fixed iteration count. Defaults to ``1e-6``.
@@ -439,7 +433,7 @@ class Config:
 
     @property
     def successive_orders_absolute_tolerance(self) -> float:
-        """Absolute residual tolerance for ``SuccessiveOrdersCpp``.
+        """Absolute residual tolerance for ``SuccessiveOrders``.
 
         Defaults to ``1e-12``.
         """
@@ -451,7 +445,7 @@ class Config:
 
     @property
     def successive_orders_anderson_depth(self) -> int:
-        """Anderson history depth for ``SuccessiveOrdersCpp``.
+        """Anderson history depth for ``SuccessiveOrders``.
 
         Zero selects damped Picard iteration. Defaults to 3.
         """
@@ -463,7 +457,7 @@ class Config:
 
     @property
     def successive_orders_damping(self) -> float:
-        """Fixed-point damping for ``SuccessiveOrdersCpp`` in ``(0, 1]``."""
+        """Fixed-point damping for ``SuccessiveOrders`` in ``(0, 1]``."""
         return self._config.successive_orders_damping
 
     @successive_orders_damping.setter
@@ -472,7 +466,7 @@ class Config:
 
     @property
     def successive_orders_altitude_grid_m(self) -> np.ndarray | None:
-        """Explicit source-altitude grid for ``SuccessiveOrdersCpp``, in metres.
+        """Explicit source-altitude grid for ``SuccessiveOrders``, in metres.
 
         ``None`` selects the atmosphere-derived default. Explicit values must
         be finite, one-dimensional, and strictly increasing.
@@ -508,7 +502,7 @@ class Config:
         """
         If set to true, the legacy successive orders source is initialized with a source calculated with
         the discrete ordinates source instead of a single scattering source.  This greatly reduces the number
-        of iterations required for the legacy method. This setting is not used by ``SuccessiveOrdersCpp``.
+        of iterations required for the legacy method. This setting is not used by ``SuccessiveOrders``.
         """
         return self._config.init_successive_orders_with_discrete_ordinates
 
@@ -517,7 +511,7 @@ class Config:
         """
         If set to true, the legacy successive orders source is initialized with a source calculated with
         the discrete ordinates source instead of a single scattering source.  This greatly reduces the number
-        of iterations required for the legacy method. This setting is not used by ``SuccessiveOrdersCpp``.
+        of iterations required for the legacy method. This setting is not used by ``SuccessiveOrders``.
         """
         self._config.init_successive_orders_with_discrete_ordinates = value
 

--- a/tests/config/test_config_basic.py
+++ b/tests/config/test_config_basic.py
@@ -77,16 +77,21 @@ def test_config_multiple_instances():
 
 def test_multiple_scatter_source_preserves_public_integer_values():
     assert sk.MultipleScatterSource.DiscreteOrdinates == 0
-    assert sk.MultipleScatterSource.SuccessiveOrders == 1
+    assert sk.MultipleScatterSource.SuccessiveOrdersLegacy == 1
     assert sk.MultipleScatterSource.TwoStream == 2
     assert sk.MultipleScatterSource.NoSource == 3
-    assert sk.MultipleScatterSource.SuccessiveOrdersCpp == 4
+    assert sk.MultipleScatterSource.SuccessiveOrders == 4
+    assert not hasattr(sk.MultipleScatterSource, "SuccessiveOrdersCpp")
 
     config = sk.Config()
-    config.multiple_scatter_source = sk.MultipleScatterSource.SuccessiveOrdersCpp
+    config.multiple_scatter_source = sk.MultipleScatterSource.SuccessiveOrdersLegacy
     assert (
-        config.multiple_scatter_source == sk.MultipleScatterSource.SuccessiveOrdersCpp
+        config.multiple_scatter_source
+        == sk.MultipleScatterSource.SuccessiveOrdersLegacy
     )
+
+    config.multiple_scatter_source = sk.MultipleScatterSource.SuccessiveOrders
+    assert config.multiple_scatter_source == sk.MultipleScatterSource.SuccessiveOrders
 
 
 def test_num_successive_order_points_round_trip():

--- a/tests/config/test_config_basic.py
+++ b/tests/config/test_config_basic.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import numpy as np
 import pytest
 import sasktran2 as sk
 
@@ -74,6 +75,20 @@ def test_config_multiple_instances():
     assert config2.log_level == sk.LogLevel.Error
 
 
+def test_multiple_scatter_source_preserves_public_integer_values():
+    assert sk.MultipleScatterSource.DiscreteOrdinates == 0
+    assert sk.MultipleScatterSource.SuccessiveOrders == 1
+    assert sk.MultipleScatterSource.TwoStream == 2
+    assert sk.MultipleScatterSource.NoSource == 3
+    assert sk.MultipleScatterSource.SuccessiveOrdersCpp == 4
+
+    config = sk.Config()
+    config.multiple_scatter_source = sk.MultipleScatterSource.SuccessiveOrdersCpp
+    assert (
+        config.multiple_scatter_source == sk.MultipleScatterSource.SuccessiveOrdersCpp
+    )
+
+
 def test_num_successive_order_points_round_trip():
     """The Python property maps to the pluralized native config field."""
     config = sk.Config()
@@ -92,3 +107,69 @@ def test_wavelength_batch_size_round_trip_and_validation():
 
     with pytest.raises(RuntimeError, match="at least 1"):
         config.wavelength_batch_size = 0
+
+
+def test_cpp_successive_orders_controls_round_trip_and_validation():
+    config = sk.Config()
+
+    assert config.num_successive_orders_iterations == 50
+    assert config.num_successive_orders_incoming == 110
+    assert config.num_successive_orders_outgoing == 110
+    assert config.successive_orders_relative_tolerance == 1.0e-6
+    assert config.successive_orders_absolute_tolerance == 1.0e-12
+    assert config.successive_orders_anderson_depth == 3
+    assert config.successive_orders_damping == 1.0
+
+    config.num_successive_orders_iterations = 31
+    config.num_successive_orders_incoming = 74
+    config.num_successive_orders_outgoing = 86
+    config.successive_orders_relative_tolerance = 2.0e-7
+    config.successive_orders_absolute_tolerance = 3.0e-13
+    config.successive_orders_anderson_depth = 4
+    config.successive_orders_damping = 0.85
+
+    assert config.num_successive_orders_iterations == 31
+    assert config.num_successive_orders_incoming == 74
+    assert config.num_successive_orders_outgoing == 86
+    assert config.successive_orders_relative_tolerance == 2.0e-7
+    assert config.successive_orders_absolute_tolerance == 3.0e-13
+    assert config.successive_orders_anderson_depth == 4
+    assert config.successive_orders_damping == 0.85
+
+    for invalid in (-1.0, np.nan, np.inf):
+        with pytest.raises(RuntimeError, match="finite and non-negative"):
+            config.successive_orders_relative_tolerance = invalid
+        with pytest.raises(RuntimeError, match="finite and non-negative"):
+            config.successive_orders_absolute_tolerance = invalid
+
+    for invalid in (0.0, -0.1, 1.1, np.nan, np.inf):
+        with pytest.raises(RuntimeError, match="interval"):
+            config.successive_orders_damping = invalid
+
+
+def test_cpp_successive_orders_altitude_grid_round_trip_and_validation():
+    config = sk.Config()
+    assert config.successive_orders_altitude_grid_m is None
+
+    expected = np.array([500.0, 2_500.0, 10_000.0])
+    config.successive_orders_altitude_grid_m = expected
+    np.testing.assert_array_equal(config.successive_orders_altitude_grid_m, expected)
+
+    returned = config.successive_orders_altitude_grid_m
+    returned[0] = -1.0
+    np.testing.assert_array_equal(config.successive_orders_altitude_grid_m, expected)
+
+    for invalid in (
+        np.array([[1_000.0, 2_000.0]]),
+        np.array([1_000.0, 1_000.0]),
+        np.array([2_000.0, 1_000.0]),
+        np.array([1_000.0, np.nan]),
+    ):
+        with pytest.raises(ValueError, match="successive_orders_altitude_grid_m"):
+            config.successive_orders_altitude_grid_m = invalid
+
+    config.successive_orders_altitude_grid_m = np.array([])
+    assert config.successive_orders_altitude_grid_m is None
+    config.successive_orders_altitude_grid_m = expected
+    config.successive_orders_altitude_grid_m = None
+    assert config.successive_orders_altitude_grid_m is None

--- a/tests/engine/test_1d_solver_regression.py
+++ b/tests/engine/test_1d_solver_regression.py
@@ -39,7 +39,7 @@ def _setup_1d(
         default_num_wavelengths = 3
     elif source == "successive_orders":
         config.single_scatter_source = sk.SingleScatterSource.Exact
-        config.multiple_scatter_source = sk.MultipleScatterSource.SuccessiveOrders
+        config.multiple_scatter_source = sk.MultipleScatterSource.SuccessiveOrdersLegacy
         config.num_successive_orders_iterations = 3
         config.num_successive_orders_incoming = 26
         config.num_successive_orders_outgoing = 26

--- a/tests/engine/test_refraction.py
+++ b/tests/engine/test_refraction.py
@@ -100,7 +100,7 @@ def test_multiple_scatter_refraction_refractive_one():
 
     config = sk.Config()
     config.multiple_scatter_refraction = True
-    config.multiple_scatter_source = sk.MultipleScatterSource.SuccessiveOrders
+    config.multiple_scatter_source = sk.MultipleScatterSource.SuccessiveOrdersLegacy
 
     wavel = np.array([500.0])
     atmosphere = sk.Atmosphere(model_geometry, config, wavelengths_nm=wavel)
@@ -121,7 +121,7 @@ def test_multiple_scatter_refraction_refractive_one():
 
     config = sk.Config()
     config.multiple_scatter_refraction = False
-    config.multiple_scatter_source = sk.MultipleScatterSource.SuccessiveOrders
+    config.multiple_scatter_source = sk.MultipleScatterSource.SuccessiveOrdersLegacy
 
     atmosphere = sk.Atmosphere(model_geometry, config, wavelengths_nm=wavel)
 

--- a/tests/engine/test_successive_orders_cpp.py
+++ b/tests/engine/test_successive_orders_cpp.py
@@ -1,0 +1,588 @@
+from __future__ import annotations
+
+import gc
+
+import numpy as np
+import pytest
+import sasktran2 as sk
+import xarray as xr
+
+EARTH_RADIUS_M = 6_372_000.0
+ALTITUDES_M = np.arange(0.0, 30_001.0, 5_000.0)
+WAVELENGTHS_NM = np.array([510.0, 690.0])
+
+
+def _config(
+    source: sk.MultipleScatterSource,
+    *,
+    num_stokes: int = 1,
+    iterations: int = 4,
+    relative_tolerance: float = 0.0,
+    absolute_tolerance: float = 0.0,
+    anderson_depth: int = 0,
+) -> sk.Config:
+    config = sk.Config()
+    config.num_threads = 1
+    config.num_stokes = num_stokes
+    config.num_streams = 8
+    config.num_singlescatter_moments = 8
+    config.num_sza = 1
+    config.single_scatter_source = sk.SingleScatterSource.Exact
+    config.multiple_scatter_source = source
+    config.num_successive_orders_incoming = 26
+    config.num_successive_orders_outgoing = 26
+    config.num_successive_orders_iterations = iterations
+    config.successive_orders_relative_tolerance = relative_tolerance
+    config.successive_orders_absolute_tolerance = absolute_tolerance
+    config.successive_orders_anderson_depth = anderson_depth
+    config.successive_orders_damping = 1.0
+    config.delta_m_scaling = False
+    return config
+
+
+def _geometry() -> sk.Geometry1D:
+    return sk.Geometry1D(
+        cos_sza=0.55,
+        solar_azimuth=0.15,
+        earth_radius_m=EARTH_RADIUS_M,
+        altitude_grid_m=ALTITUDES_M,
+        interpolation_method=sk.InterpolationMethod.LinearInterpolation,
+        geometry_type=sk.GeometryType.Spherical,
+    )
+
+
+def _viewing_geometry() -> sk.ViewingGeometry:
+    viewing = sk.ViewingGeometry()
+    viewing.add_ray(
+        sk.GroundViewingSolar(
+            cos_sza=0.55,
+            relative_azimuth=0.35,
+            cos_viewing_zenith=0.72,
+            observer_altitude_m=100_000.0,
+        )
+    )
+    viewing.add_ray(
+        sk.TangentAltitudeSolar(
+            tangent_altitude_m=11_000.0,
+            relative_azimuth=-0.4,
+            observer_altitude_m=100_000.0,
+            cos_sza=0.55,
+        )
+    )
+    return viewing
+
+
+def _atmosphere(
+    geometry: sk.Geometry1D,
+    config: sk.Config,
+    *,
+    calculate_derivatives: bool = False,
+    extinction_shift: np.ndarray | None = None,
+    ssa_shift: np.ndarray | None = None,
+    surface_albedo: float = 0.12,
+) -> sk.Atmosphere:
+    atmosphere = sk.Atmosphere(
+        geometry,
+        config,
+        wavelengths_nm=WAVELENGTHS_NM,
+        calculate_derivatives=calculate_derivatives,
+    )
+
+    altitude_factor = np.exp(-ALTITUDES_M / 7_600.0)[:, np.newaxis]
+    spectral_factor = np.array([0.9, 1.1])[np.newaxis, :]
+    atmosphere.storage.total_extinction[:] = (
+        1.4e-5 * altitude_factor + 2.0e-9
+    ) * spectral_factor
+    atmosphere.storage.ssa[:] = (
+        0.86 + 0.04 * np.exp(-ALTITUDES_M / 14_000.0)[:, np.newaxis]
+    ) - np.array([0.0, 0.015])[np.newaxis, :]
+
+    if extinction_shift is not None:
+        atmosphere.storage.total_extinction[:] += extinction_shift[:, np.newaxis]
+    if ssa_shift is not None:
+        atmosphere.storage.ssa[:] += ssa_shift[:, np.newaxis]
+
+    atmosphere.leg_coeff.a1[0, :, :] = 1.0
+    atmosphere.leg_coeff.a1[1, :, :] = 0.08
+    atmosphere.leg_coeff.a1[2, :, :] = 0.5
+    if config.num_stokes == 3:
+        atmosphere.leg_coeff.a2[2, :, :] = 3.0
+        atmosphere.leg_coeff.b1[2, :, :] = -np.sqrt(6.0) / 2.0
+    atmosphere.surface.albedo[:] = surface_albedo
+    return atmosphere
+
+
+def _add_forward_delta_peak(
+    atmosphere: sk.Atmosphere, num_stokes: int, fraction: float
+) -> None:
+    for degree in range(atmosphere.leg_coeff.a1.shape[0]):
+        delta_coefficient = (2 * degree + 1) * fraction
+        atmosphere.leg_coeff.a1[degree] = (1 - fraction) * atmosphere.leg_coeff.a1[
+            degree
+        ] + delta_coefficient
+        if num_stokes == 3:
+            atmosphere.leg_coeff.a2[degree] = (1 - fraction) * atmosphere.leg_coeff.a2[
+                degree
+            ] + delta_coefficient
+            atmosphere.leg_coeff.a3[degree] = (1 - fraction) * atmosphere.leg_coeff.a3[
+                degree
+            ] + delta_coefficient
+            atmosphere.leg_coeff.b1[degree] *= 1 - fraction
+
+
+def _calculate(
+    config: sk.Config,
+    geometry: sk.Geometry1D | None = None,
+    **atmosphere_kwargs,
+) -> xr.Dataset:
+    if geometry is None:
+        geometry = _geometry()
+    engine = sk.Engine(config, geometry, _viewing_geometry())
+    return engine.calculate_radiance(_atmosphere(geometry, config, **atmosphere_kwargs))
+
+
+def test_scalar_1d_primal_is_finite_and_nonnegative():
+    config = _config(sk.MultipleScatterSource.SuccessiveOrdersCpp)
+    result = _calculate(config)
+
+    assert result.radiance.shape == (WAVELENGTHS_NM.size, 2, 1)
+    assert np.all(np.isfinite(result.radiance))
+    assert np.min(result.radiance.values) >= -2.0e-13
+    assert np.max(result.radiance.values) > 1.0e-6
+
+
+@pytest.mark.parametrize(
+    ("num_stokes", "relative_tolerance", "absolute_tolerance"),
+    [(1, 2.0e-3, 2.0e-7), (3, 2.0e-3, 2.0e-7)],
+)
+def test_fixed_iteration_solution_agrees_with_legacy_successive_orders(
+    num_stokes: int,
+    relative_tolerance: float,
+    absolute_tolerance: float,
+):
+    cpp_config = _config(
+        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        num_stokes=num_stokes,
+        iterations=3,
+    )
+    legacy_config = _config(
+        sk.MultipleScatterSource.SuccessiveOrders,
+        num_stokes=num_stokes,
+        iterations=3,
+    )
+
+    cpp = _calculate(cpp_config, surface_albedo=0.0).radiance
+    legacy = _calculate(legacy_config, surface_albedo=0.0).radiance
+
+    xr.testing.assert_allclose(
+        cpp,
+        legacy,
+        rtol=relative_tolerance,
+        atol=absolute_tolerance,
+    )
+    if num_stokes == 3:
+        assert np.any(np.abs(cpp.sel(stokes="Q")) > 1.0e-8)
+        assert np.any(np.abs(cpp.sel(stokes="U")) > 1.0e-8)
+
+
+def test_explicit_midpoint_altitudes_preserve_default_and_coarse_grid_is_used():
+    default_config = _config(
+        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        iterations=3,
+    )
+    midpoint_config = _config(
+        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        iterations=3,
+    )
+    midpoint_config.successive_orders_altitude_grid_m = (
+        ALTITUDES_M[:-1] + ALTITUDES_M[1:]
+    ) / 2.0
+    coarse_config = _config(
+        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        iterations=3,
+    )
+    coarse_config.successive_orders_altitude_grid_m = np.array(
+        [2_000.0, 9_000.0, 19_000.0, 28_000.0]
+    )
+
+    default = _calculate(default_config).radiance
+    midpoint = _calculate(midpoint_config).radiance
+    coarse = _calculate(coarse_config).radiance
+
+    xr.testing.assert_allclose(midpoint, default, rtol=2.0e-12, atol=2.0e-14)
+    assert np.all(np.isfinite(coarse))
+    assert not np.allclose(coarse, default, rtol=1.0e-7, atol=1.0e-12)
+
+
+def test_explicit_altitudes_must_be_inside_the_model_atmosphere():
+    config = _config(sk.MultipleScatterSource.SuccessiveOrdersCpp)
+    config.successive_orders_altitude_grid_m = np.array([-1.0, 10_000.0])
+
+    with pytest.raises(RuntimeError, match="Failed to create Engine"):
+        sk.Engine(config, _geometry(), _viewing_geometry())
+
+
+def test_zero_tolerances_use_the_configured_fixed_iteration_count():
+    one_iteration = _config(
+        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        iterations=1,
+    )
+    two_iterations = _config(
+        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        iterations=2,
+    )
+    early_exit = _config(
+        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        iterations=8,
+        absolute_tolerance=1.0e100,
+    )
+
+    one = _calculate(one_iteration).radiance
+    two = _calculate(two_iterations).radiance
+    early = _calculate(early_exit).radiance
+
+    xr.testing.assert_allclose(early, one, rtol=2.0e-13, atol=2.0e-14)
+    difference = np.linalg.norm((two - one).values)
+    assert difference > 1.0e-7 * np.linalg.norm(one.values)
+
+
+def test_fixed_iteration_result_does_not_depend_on_engine_history():
+    config = _config(
+        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        iterations=3,
+    )
+    geometry = _geometry()
+    viewing = _viewing_geometry()
+    reused_engine = sk.Engine(config, geometry, viewing)
+
+    reused_engine.calculate_radiance(_atmosphere(geometry, config))
+    shifted_atmosphere = _atmosphere(
+        geometry,
+        config,
+        extinction_shift=np.linspace(0.0, 3.0e-7, ALTITUDES_M.size),
+        ssa_shift=np.linspace(-0.02, 0.01, ALTITUDES_M.size),
+    )
+    reused = reused_engine.calculate_radiance(shifted_atmosphere).radiance
+    fresh = (
+        sk.Engine(config, geometry, viewing)
+        .calculate_radiance(shifted_atmosphere)
+        .radiance
+    )
+
+    xr.testing.assert_allclose(reused, fresh, rtol=2.0e-12, atol=2.0e-14)
+
+
+@pytest.mark.parametrize("num_stokes", [1, 3])
+def test_native_jvp_vjp_match_finite_difference_jacobian_and_adjoint(num_stokes):
+    config = _config(
+        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        num_stokes=num_stokes,
+        iterations=60,
+        relative_tolerance=1.0e-11,
+        absolute_tolerance=1.0e-13,
+        anderson_depth=3,
+    )
+    geometry = _geometry()
+    atmosphere = _atmosphere(geometry, config, calculate_derivatives=True)
+    engine = sk.Engine(config, geometry, _viewing_geometry())
+    linearization = engine.linearize(atmosphere)
+
+    assert linearization.backends == {
+        "jvp": sk.LinearizationBackend.Native,
+        "vjp": sk.LinearizationBackend.Native,
+    }
+
+    tangent = linearization.tangent_template[["extinction", "ssa"]]
+    tangent["extinction"].data[:] = 0.08 * np.mean(
+        atmosphere.storage.total_extinction, axis=1
+    )
+    tangent["ssa"].data[:] = np.linspace(-0.015, 0.02, ALTITUDES_M.size)
+    jvp = linearization.jvp(tangent)
+
+    cotangent = xr.ones_like(linearization.value)
+    cotangent.data[:] = np.linspace(0.35, 1.1, cotangent.size).reshape(cotangent.shape)
+    gradient = linearization.vjp(
+        cotangent,
+        parameters=("extinction", "ssa"),
+    )
+
+    lhs = float((jvp * cotangent).sum())
+    rhs = float(
+        (tangent["extinction"] * gradient["extinction"]).sum()
+        + (tangent["ssa"] * gradient["ssa"]).sum()
+    )
+    np.testing.assert_allclose(lhs, rhs, rtol=2.0e-8, atol=2.0e-11)
+
+    jacobian = linearization.jacobian
+    jacobian_jvp = (
+        jacobian["extinction"] * tangent["extinction"]
+        + jacobian["ssa"] * tangent["ssa"]
+    ).sum("altitude")
+    xr.testing.assert_allclose(
+        jacobian_jvp.transpose(*jvp.dims),
+        jvp,
+        rtol=2.0e-7,
+        atol=2.0e-11,
+    )
+    for parameter in ("extinction", "ssa"):
+        expected_gradient = (jacobian[parameter] * cotangent).sum(
+            linearization.value.dims
+        )
+        xr.testing.assert_allclose(
+            gradient[parameter],
+            expected_gradient,
+            rtol=2.0e-7,
+            atol=2.0e-10,
+        )
+
+    epsilon = 2.0e-3
+    perturbed = []
+    for sign in (-1.0, 1.0):
+        shifted_atmosphere = _atmosphere(
+            geometry,
+            config,
+            extinction_shift=(sign * epsilon * tangent["extinction"].values),
+            ssa_shift=sign * epsilon * tangent["ssa"].values,
+        )
+        perturbed.append(engine.calculate_radiance(shifted_atmosphere).radiance.values)
+    finite_difference = (perturbed[1] - perturbed[0]) / (2.0 * epsilon)
+    np.testing.assert_allclose(
+        jvp.values,
+        finite_difference,
+        rtol=2.0e-4,
+        atol=2.0e-9,
+    )
+
+
+@pytest.mark.parametrize("num_stokes", [1, 3])
+def test_delta_m_native_products_match_finite_difference_and_are_adjoint(num_stokes):
+    config = _config(
+        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        num_stokes=num_stokes,
+        iterations=80,
+        relative_tolerance=1.0e-11,
+        absolute_tolerance=1.0e-13,
+        anderson_depth=3,
+    )
+    config.num_singlescatter_moments = 9
+    config.delta_m_scaling = True
+    geometry = _geometry()
+    atmosphere = _atmosphere(geometry, config, calculate_derivatives=True)
+    _add_forward_delta_peak(atmosphere, num_stokes, 0.1)
+    engine = sk.Engine(config, geometry, _viewing_geometry())
+    linearization = engine.linearize(atmosphere)
+
+    coefficient_index = 8 if num_stokes == 1 else 4 * 8
+    parameter = f"leg_coeff_{coefficient_index}"
+    tangent = linearization.tangent_template[[parameter]]
+    tangent[parameter].data[:] = np.linspace(-0.04, 0.06, ALTITUDES_M.size)
+    jvp = linearization.jvp(tangent)
+
+    cotangent = xr.ones_like(linearization.value)
+    cotangent.data[:] = np.linspace(0.3, 1.2, cotangent.size).reshape(cotangent.shape)
+    gradient = linearization.vjp(cotangent, parameters=(parameter,))
+    lhs = float((jvp * cotangent).sum())
+    rhs = float((tangent[parameter] * gradient[parameter]).sum())
+    np.testing.assert_allclose(lhs, rhs, rtol=3.0e-8, atol=3.0e-11)
+
+    epsilon = 2.0e-4
+    perturbed = []
+    for sign in (-1.0, 1.0):
+        shifted_atmosphere = _atmosphere(geometry, config)
+        _add_forward_delta_peak(shifted_atmosphere, num_stokes, 0.1)
+        shifted_atmosphere.leg_coeff.a1[8] += (
+            sign * epsilon * tangent[parameter].values[:, np.newaxis]
+        )
+        perturbed.append(engine.calculate_radiance(shifted_atmosphere).radiance.values)
+    finite_difference = (perturbed[1] - perturbed[0]) / (2.0 * epsilon)
+    np.testing.assert_allclose(
+        jvp.values,
+        finite_difference,
+        rtol=3.0e-4,
+        atol=3.0e-9,
+    )
+
+
+@pytest.mark.parametrize(
+    "threading_model",
+    [sk.ThreadingModel.Wavelength, sk.ThreadingModel.Source],
+)
+def test_scalar_threading_models_match_single_thread(threading_model):
+    reference_config = _config(
+        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        iterations=4,
+    )
+    threaded_config = _config(
+        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        iterations=4,
+    )
+    threaded_config.num_threads = 2
+    threaded_config.threading_model = threading_model
+
+    reference = _calculate(reference_config).radiance
+    threaded = _calculate(threaded_config).radiance
+    xr.testing.assert_allclose(threaded, reference, rtol=2.0e-12, atol=2.0e-14)
+
+
+@pytest.mark.parametrize(
+    "threading_model",
+    [sk.ThreadingModel.Wavelength, sk.ThreadingModel.Source],
+)
+@pytest.mark.parametrize("num_stokes", [1, 3])
+def test_threaded_native_products_are_adjoint(threading_model, num_stokes):
+    config = _config(
+        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        num_stokes=num_stokes,
+        iterations=60,
+        relative_tolerance=1.0e-11,
+        absolute_tolerance=1.0e-13,
+        anderson_depth=3,
+    )
+    config.num_threads = 2
+    config.threading_model = threading_model
+    geometry = _geometry()
+    atmosphere = _atmosphere(geometry, config, calculate_derivatives=True)
+    linearization = sk.Engine(config, geometry, _viewing_geometry()).linearize(
+        atmosphere
+    )
+
+    tangent = linearization.tangent_template[["extinction", "ssa"]]
+    tangent["extinction"].data[:] = 0.03 * np.mean(
+        atmosphere.storage.total_extinction, axis=1
+    )
+    tangent["ssa"].data[:] = np.linspace(-0.01, 0.012, ALTITUDES_M.size)
+    jvp = linearization.jvp(tangent)
+    cotangent = xr.ones_like(linearization.value)
+    cotangent.data[:] = np.linspace(0.4, 1.2, cotangent.size).reshape(cotangent.shape)
+    gradient = linearization.vjp(cotangent, parameters=("extinction", "ssa"))
+
+    lhs = float((jvp * cotangent).sum())
+    rhs = float(
+        (tangent["extinction"] * gradient["extinction"]).sum()
+        + (tangent["ssa"] * gradient["ssa"]).sum()
+    )
+    assert np.all(np.isfinite(jvp))
+    assert all(np.all(np.isfinite(value)) for value in gradient.data_vars.values())
+    np.testing.assert_allclose(lhs, rhs, rtol=3.0e-8, atol=3.0e-11)
+
+
+def test_native_vjp_returns_a_finite_result_without_convergence():
+    config = _config(
+        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        iterations=1,
+        relative_tolerance=1.0e-15,
+        absolute_tolerance=1.0e-15,
+        anderson_depth=0,
+    )
+    geometry = _geometry()
+    atmosphere = _atmosphere(geometry, config, calculate_derivatives=True)
+    linearization = sk.Engine(config, geometry, _viewing_geometry()).linearize(
+        atmosphere
+    )
+    gradient = linearization.vjp(
+        xr.ones_like(linearization.value), parameters=("extinction", "ssa")
+    )
+
+    assert all(np.all(np.isfinite(value)) for value in gradient.data_vars.values())
+
+
+def test_homogeneous_scalar_fast_paths_preserve_native_adjoint():
+    config = _config(
+        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        iterations=60,
+        relative_tolerance=1.0e-11,
+        absolute_tolerance=1.0e-13,
+        anderson_depth=3,
+    )
+    geometry = _geometry()
+    atmosphere = _atmosphere(geometry, config, calculate_derivatives=True)
+    atmosphere.storage.ssa[:] = 0.91
+    atmosphere.mark_changed()
+    linearization = sk.Engine(config, geometry, _viewing_geometry()).linearize(
+        atmosphere
+    )
+
+    tangent = linearization.tangent_template[["extinction", "ssa"]]
+    tangent["extinction"].data[:] = 0.04 * np.mean(
+        atmosphere.storage.total_extinction, axis=1
+    )
+    tangent["ssa"].data[:] = 0.012
+    jvp = linearization.jvp(tangent)
+    cotangent = xr.ones_like(linearization.value)
+    gradient = linearization.vjp(cotangent, parameters=("extinction", "ssa"))
+
+    lhs = float((jvp * cotangent).sum())
+    rhs = float(
+        (tangent["extinction"] * gradient["extinction"]).sum()
+        + (tangent["ssa"] * gradient["ssa"]).sum()
+    )
+    np.testing.assert_allclose(lhs, rhs, rtol=3.0e-8, atol=3.0e-11)
+
+
+def test_scalar_repeated_vjp_survives_atmosphere_and_engine_lifetimes():
+    """Exercise the compact LOS metadata across retrieval-like lifetimes.
+
+    This intentionally performs enough primal/VJP pairs to cover the failure
+    window of the original repeated-evaluation crash. It swaps atmosphere
+    objects without rebuilding the engine, then destroys and recreates the
+    engine, so source caches and derivative scratch must remain scoped to the
+    active calculation objects.
+    """
+    config = _config(
+        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        iterations=40,
+        relative_tolerance=1.0e-9,
+        absolute_tolerance=1.0e-12,
+        anderson_depth=3,
+    )
+    config.num_threads = 1
+    config.threading_model = sk.ThreadingModel.Wavelength
+    geometry = _geometry()
+    viewing = _viewing_geometry()
+
+    product_count = 0
+    for engine_index in range(2):
+        engine = sk.Engine(config, geometry, viewing)
+        for atmosphere_index in range(2):
+            atmosphere = _atmosphere(
+                geometry,
+                config,
+                calculate_derivatives=True,
+                surface_albedo=0.08 + 0.01 * atmosphere_index,
+            )
+            base_extinction = atmosphere.storage.total_extinction.copy()
+            base_ssa = atmosphere.storage.ssa.copy()
+
+            for evaluation in range(50):
+                scale = 1.0 + 2.0e-3 * np.sin(0.37 * evaluation + 0.11 * engine_index)
+                atmosphere.storage.total_extinction[:] = base_extinction * scale
+                atmosphere.storage.ssa[:] = np.clip(
+                    base_ssa
+                    + 5.0e-4 * np.cos(0.23 * evaluation + 0.17 * atmosphere_index),
+                    0.0,
+                    1.0,
+                )
+                atmosphere.mark_changed()
+
+                linearization = engine.linearize(atmosphere)
+                cotangent = xr.ones_like(linearization.value)
+                cotangent.data[:] = np.linspace(
+                    0.4 + 1.0e-4 * evaluation,
+                    1.1 + 1.0e-4 * evaluation,
+                    cotangent.size,
+                ).reshape(cotangent.shape)
+                gradient = linearization.vjp(
+                    cotangent, parameters=("extinction", "ssa")
+                )
+
+                assert np.all(np.isfinite(linearization.value))
+                assert np.all(np.isfinite(gradient["extinction"]))
+                assert np.all(np.isfinite(gradient["ssa"]))
+                product_count += 1
+
+            del atmosphere, linearization, gradient
+
+        del engine
+        gc.collect()
+
+    assert product_count == 200

--- a/tests/engine/test_successive_orders_cpp.py
+++ b/tests/engine/test_successive_orders_cpp.py
@@ -142,7 +142,7 @@ def _calculate(
 
 
 def test_scalar_1d_primal_is_finite_and_nonnegative():
-    config = _config(sk.MultipleScatterSource.SuccessiveOrdersCpp)
+    config = _config(sk.MultipleScatterSource.SuccessiveOrders)
     result = _calculate(config)
 
     assert result.radiance.shape == (WAVELENGTHS_NM.size, 2, 1)
@@ -161,12 +161,12 @@ def test_fixed_iteration_solution_agrees_with_legacy_successive_orders(
     absolute_tolerance: float,
 ):
     cpp_config = _config(
-        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        sk.MultipleScatterSource.SuccessiveOrders,
         num_stokes=num_stokes,
         iterations=3,
     )
     legacy_config = _config(
-        sk.MultipleScatterSource.SuccessiveOrders,
+        sk.MultipleScatterSource.SuccessiveOrdersLegacy,
         num_stokes=num_stokes,
         iterations=3,
     )
@@ -187,18 +187,18 @@ def test_fixed_iteration_solution_agrees_with_legacy_successive_orders(
 
 def test_explicit_midpoint_altitudes_preserve_default_and_coarse_grid_is_used():
     default_config = _config(
-        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        sk.MultipleScatterSource.SuccessiveOrders,
         iterations=3,
     )
     midpoint_config = _config(
-        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        sk.MultipleScatterSource.SuccessiveOrders,
         iterations=3,
     )
     midpoint_config.successive_orders_altitude_grid_m = (
         ALTITUDES_M[:-1] + ALTITUDES_M[1:]
     ) / 2.0
     coarse_config = _config(
-        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        sk.MultipleScatterSource.SuccessiveOrders,
         iterations=3,
     )
     coarse_config.successive_orders_altitude_grid_m = np.array(
@@ -215,7 +215,7 @@ def test_explicit_midpoint_altitudes_preserve_default_and_coarse_grid_is_used():
 
 
 def test_explicit_altitudes_must_be_inside_the_model_atmosphere():
-    config = _config(sk.MultipleScatterSource.SuccessiveOrdersCpp)
+    config = _config(sk.MultipleScatterSource.SuccessiveOrders)
     config.successive_orders_altitude_grid_m = np.array([-1.0, 10_000.0])
 
     with pytest.raises(RuntimeError, match="Failed to create Engine"):
@@ -224,15 +224,15 @@ def test_explicit_altitudes_must_be_inside_the_model_atmosphere():
 
 def test_zero_tolerances_use_the_configured_fixed_iteration_count():
     one_iteration = _config(
-        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        sk.MultipleScatterSource.SuccessiveOrders,
         iterations=1,
     )
     two_iterations = _config(
-        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        sk.MultipleScatterSource.SuccessiveOrders,
         iterations=2,
     )
     early_exit = _config(
-        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        sk.MultipleScatterSource.SuccessiveOrders,
         iterations=8,
         absolute_tolerance=1.0e100,
     )
@@ -248,7 +248,7 @@ def test_zero_tolerances_use_the_configured_fixed_iteration_count():
 
 def test_fixed_iteration_result_does_not_depend_on_engine_history():
     config = _config(
-        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        sk.MultipleScatterSource.SuccessiveOrders,
         iterations=3,
     )
     geometry = _geometry()
@@ -275,7 +275,7 @@ def test_fixed_iteration_result_does_not_depend_on_engine_history():
 @pytest.mark.parametrize("num_stokes", [1, 3])
 def test_native_jvp_vjp_match_finite_difference_jacobian_and_adjoint(num_stokes):
     config = _config(
-        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        sk.MultipleScatterSource.SuccessiveOrders,
         num_stokes=num_stokes,
         iterations=60,
         relative_tolerance=1.0e-11,
@@ -357,7 +357,7 @@ def test_native_jvp_vjp_match_finite_difference_jacobian_and_adjoint(num_stokes)
 @pytest.mark.parametrize("num_stokes", [1, 3])
 def test_delta_m_native_products_match_finite_difference_and_are_adjoint(num_stokes):
     config = _config(
-        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        sk.MultipleScatterSource.SuccessiveOrders,
         num_stokes=num_stokes,
         iterations=80,
         relative_tolerance=1.0e-11,
@@ -409,11 +409,11 @@ def test_delta_m_native_products_match_finite_difference_and_are_adjoint(num_sto
 )
 def test_scalar_threading_models_match_single_thread(threading_model):
     reference_config = _config(
-        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        sk.MultipleScatterSource.SuccessiveOrders,
         iterations=4,
     )
     threaded_config = _config(
-        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        sk.MultipleScatterSource.SuccessiveOrders,
         iterations=4,
     )
     threaded_config.num_threads = 2
@@ -431,7 +431,7 @@ def test_scalar_threading_models_match_single_thread(threading_model):
 @pytest.mark.parametrize("num_stokes", [1, 3])
 def test_threaded_native_products_are_adjoint(threading_model, num_stokes):
     config = _config(
-        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        sk.MultipleScatterSource.SuccessiveOrders,
         num_stokes=num_stokes,
         iterations=60,
         relative_tolerance=1.0e-11,
@@ -468,7 +468,7 @@ def test_threaded_native_products_are_adjoint(threading_model, num_stokes):
 
 def test_native_vjp_returns_a_finite_result_without_convergence():
     config = _config(
-        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        sk.MultipleScatterSource.SuccessiveOrders,
         iterations=1,
         relative_tolerance=1.0e-15,
         absolute_tolerance=1.0e-15,
@@ -488,7 +488,7 @@ def test_native_vjp_returns_a_finite_result_without_convergence():
 
 def test_homogeneous_scalar_fast_paths_preserve_native_adjoint():
     config = _config(
-        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        sk.MultipleScatterSource.SuccessiveOrders,
         iterations=60,
         relative_tolerance=1.0e-11,
         absolute_tolerance=1.0e-13,
@@ -529,7 +529,7 @@ def test_scalar_repeated_vjp_survives_atmosphere_and_engine_lifetimes():
     active calculation objects.
     """
     config = _config(
-        sk.MultipleScatterSource.SuccessiveOrdersCpp,
+        sk.MultipleScatterSource.SuccessiveOrders,
         iterations=40,
         relative_tolerance=1.0e-9,
         absolute_tolerance=1.0e-12,


### PR DESCRIPTION
## Summary

- add SuccessiveOrdersCpp as a separate scalar and polarized multiple-scattering source
- keep source geometry, exact first-order illumination, transport, coefficient-space scattering, fixed-point iteration, and linearization state private under cpp/lib/successive_orders
- expose only a private factory returning SourceTermInterface to the engine; no concrete source header is installed
- support explicit source-altitude grids, convergence tolerances, damping, Anderson acceleration, full Jacobians, and native JVP/VJP products
- retain safe source-owned retrieval-loop warm starts using atmosphere lifetime and revision

## Black-box boundary

Outside the private source directory, the C++ engine change is one factory include and one source-selection branch. The remaining exterior changes are source-specific configuration, binding exposure, build registration, documentation, and tests.

This PR deliberately excludes Rayon native-product scheduling, selective exact-single-scatter and VJP work pruning, the generic SourceIntegrator atmosphere cache, and two-stream initialization.

## Split stack

- prerequisite: #286
- this source-only PR: #285
- selective derivative optimization on this source: #289
- independent generic SourceIntegrator cache: #287
- independent generic Rayon scheduling: #288

## Validation

- project build passed
- C++ successive-orders suite: 44 cases and 975 assertions passed
- Python source and configuration suite: 30 tests passed
- Rust configuration bindings: 6 tests passed
- full Rust clippy passed
- pre-commit passed
- the complete five-PR stack merges without conflicts, builds, and passes 74 focused Python tests