### PR TITLE
Cache SourceIntegrator atmosphere state safely

### DIFF
--- a/cpp/include/sasktran2/source_integrator.h
+++ b/cpp/include/sasktran2/source_integrator.h
@@ -4,6 +4,7 @@
 #include <sasktran2/raytracing.h>
 #include <sasktran2/source_interface.h>
 #include <algorithm>
+#include <cstdint>
 
 namespace sasktran2 {
 
@@ -76,6 +77,10 @@ namespace sasktran2 {
 
         const sasktran2::atmosphere::Atmosphere<NSTOKES>* m_atmosphere =
             nullptr;
+        std::uint64_t m_atmosphere_instance_id = 0;
+        std::uint64_t m_atmosphere_revision = 0;
+        int m_atmosphere_block_capacity = 0;
+        bool m_has_atmosphere_revision = false;
         int m_num_geometry_locations = 0;
         int m_num_geometry_dimensions = 1;
         bool m_use_sparse_derivative_tracking = false;

--- a/cpp/lib/sourceintegrator/sourceintegrator.cpp
+++ b/cpp/lib/sourceintegrator/sourceintegrator.cpp
@@ -14,6 +14,8 @@ namespace sasktran2 {
         const Geometry& geometry) {
         m_use_sparse_derivative_tracking = false;
         m_attenuation_active_derivative_ranges.clear();
+        m_atmosphere = nullptr;
+        m_has_atmosphere_revision = false;
 
         // Construct the optical depth matrices.
         // This is the matrix so that matrix @ extinction = layer od, one matrix
@@ -34,14 +36,26 @@ namespace sasktran2 {
     template <int NSTOKES>
     void SourceIntegrator<NSTOKES>::initialize_atmosphere(
         const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmo) {
-        m_use_sparse_derivative_tracking = false;
-        m_attenuation_active_derivative_ranges.clear();
-
         if (atmo.storage().total_extinction.rows() !=
             m_num_geometry_locations) {
             throw std::invalid_argument(
                 "Atmosphere extinction size does not match ray geometry");
         }
+        m_calculate_derivatives = m_derivatives_enabled && atmo.num_deriv() > 0;
+
+        // Revision zero is the legacy directly-mutable C++ mode. Rebuild in
+        // that mode because storage changes cannot be observed. Once a caller
+        // uses mark_changed(), revision-aware reuse is safe and intentional.
+        if (atmo.revision() != 0 && m_atmosphere == &atmo &&
+            m_has_atmosphere_revision &&
+            m_atmosphere_instance_id == atmo.instance_id() &&
+            m_atmosphere_revision == atmo.revision() &&
+            m_atmosphere_block_capacity == m_wavelength_block_capacity) {
+            return;
+        }
+
+        m_use_sparse_derivative_tracking = false;
+        m_attenuation_active_derivative_ranges.clear();
         if (m_wavelength_block_capacity == 1) {
             m_scalar_shell_od.resize(m_traced_ray_od_matrix.size());
             m_shell_od.clear();
@@ -72,11 +86,14 @@ namespace sasktran2 {
         }
 
         m_atmosphere = &atmo;
+        m_atmosphere_instance_id = atmo.instance_id();
+        m_atmosphere_revision = atmo.revision();
+        m_atmosphere_block_capacity = m_wavelength_block_capacity;
+        m_has_atmosphere_revision = true;
 
         // This object may be reused with derivative-free and derivative-enabled
         // atmospheres. Do not let a derivative-free call permanently disable
         // attenuation derivatives for later calculations.
-        m_calculate_derivatives = m_derivatives_enabled && atmo.num_deriv() > 0;
     }
 
     template <int NSTOKES>

--- a/cpp/lib/tests/sourceintegrator/test_occultation2d.cpp
+++ b/cpp/lib/tests/sourceintegrator/test_occultation2d.cpp
@@ -2,7 +2,9 @@
 
 #include <sasktran2.h>
 #include <sasktran2/solartransmission.h>
+#include <cstdint>
 #include <numeric>
+#include <optional>
 
 namespace {
     constexpr double earth_radius = 10.0;
@@ -643,6 +645,81 @@ TEST_CASE("2D occultation transmission handles extreme OD and validates "
         REQUIRE_THROWS_AS(integrator.initialize_atmosphere(mismatched),
                           std::invalid_argument);
     }
+}
+
+TEST_CASE("SourceIntegrator atmosphere cache tracks revisions and lifetimes",
+          "[sourceintegrator][cache]") {
+    const auto geometry = geometry2d();
+    sasktran2::Config config;
+    std::vector<sasktran2::raytracing::TracedRay> rays(1);
+    add_layer(rays[0], geometry, 0, 0, {1.0, 2.0, 3.0, 4.0});
+
+    sasktran2::SourceIntegrator<1> integrator(false);
+    integrator.initialize_geometry(rays, geometry);
+    sasktran2::solartransmission::OccultationSource<1> source;
+    initialize_source_geometry(source, rays);
+    std::vector<SourceTermInterface<1>*> sources = {&source};
+
+    const auto integrate_transmission = [&]() {
+        sasktran2::Dual<double, sasktran2::dualstorage::dense, 1> transmission(
+            1, 0, true);
+        integrate_scalar(integrator, transmission, sources, 0, 0, 0, 0);
+        return transmission.value[0];
+    };
+
+    using Atmosphere = sasktran2::atmosphere::Atmosphere<1>;
+    std::optional<Atmosphere> atmosphere;
+    atmosphere.emplace(1, geometry, config, false);
+    const auto first_address = reinterpret_cast<std::uintptr_t>(&*atmosphere);
+    const auto first_instance_id = atmosphere->instance_id();
+
+    // Revision zero remains compatible with directly-mutated C++ storage: it
+    // must rebuild every time because no change notification is available.
+    atmosphere->storage().total_extinction.setConstant(0.01);
+    integrator.initialize_atmosphere(*atmosphere);
+    REQUIRE(integrate_transmission() ==
+            Catch::Approx(std::exp(-0.1)).epsilon(1e-13));
+    atmosphere->storage().total_extinction.setConstant(0.02);
+    integrator.initialize_atmosphere(*atmosphere);
+    REQUIRE(integrate_transmission() ==
+            Catch::Approx(std::exp(-0.2)).epsilon(1e-13));
+
+    // Once mark_changed() establishes a revision, an unchanged revision is
+    // reusable. Direct storage mutation then requires another mark_changed().
+    atmosphere->mark_changed();
+    integrator.initialize_atmosphere(*atmosphere);
+    atmosphere->storage().total_extinction.setConstant(0.03);
+    integrator.initialize_atmosphere(*atmosphere);
+    REQUIRE(integrate_transmission() ==
+            Catch::Approx(std::exp(-0.2)).epsilon(1e-13));
+
+    // Reconstructing an atmosphere in the same optional storage produces the
+    // same address and revision, but it is a distinct lifetime and must not
+    // reuse the previous optical-depth cache.
+    atmosphere.reset();
+    atmosphere.emplace(1, geometry, config, false);
+    REQUIRE(reinterpret_cast<std::uintptr_t>(&*atmosphere) == first_address);
+    REQUIRE(atmosphere->instance_id() != first_instance_id);
+    atmosphere->storage().total_extinction.setConstant(0.04);
+    atmosphere->mark_changed();
+    integrator.initialize_atmosphere(*atmosphere);
+    REQUIRE(integrate_transmission() ==
+            Catch::Approx(std::exp(-0.4)).epsilon(1e-13));
+
+    // Changing either storage shape or ray geometry invalidates the cache even
+    // when the atmosphere itself is unchanged.
+    integrator.initialize_thread_storage(1, 2);
+    integrator.initialize_atmosphere(*atmosphere);
+    REQUIRE(integrate_transmission() ==
+            Catch::Approx(std::exp(-0.4)).epsilon(1e-13));
+
+    std::vector<sasktran2::raytracing::TracedRay> shorter_rays(1);
+    add_layer(shorter_rays[0], geometry, 0, 0, {1.0, 1.0, 1.0, 1.0});
+    integrator.initialize_geometry(shorter_rays, geometry);
+    initialize_source_geometry(source, shorter_rays);
+    integrator.initialize_atmosphere(*atmosphere);
+    REQUIRE(integrate_transmission() ==
+            Catch::Approx(std::exp(-0.16)).epsilon(1e-13));
 }
 
 TEST_CASE("Regular 2D integration rejects interior sources before mutation",


### PR DESCRIPTION
## Summary

- reuse SourceIntegrator atmosphere work when lifetime identity, revision, derivative mode, and block capacity all match
- invalidate the cache when geometry or storage capacity changes
- preserve revision-zero direct-mutation compatibility by rebuilding those atmospheres
- add a generic lifetime and invalidation regression test

## Scope

This is independent of SuccessiveOrdersCpp and contains only three SourceIntegrator and test files. It depends on #286 for stable atmosphere lifetime identity.

## Validation

- project build passed
- SourceIntegrator C++ suite: 16 cases and 169 assertions passed
- atmosphere lifetime identity test passed
- pre-commit passed