### PR TITLE
Thread native JVP and VJP products with Rayon

### DIFF
--- a/cpp/c_api/engine.cpp
+++ b/cpp/c_api/engine.cpp
@@ -250,6 +250,85 @@ int sk_engine_calculate_jvp(Engine* engine, Atmosphere* atmosphere,
     }
 }
 
+int sk_engine_initialize_jvp(Engine* engine, Atmosphere* atmosphere,
+                             OutputJVP* output) {
+    if (engine == nullptr || !engine->impl || engine->_config == nullptr ||
+        atmosphere == nullptr || !atmosphere->impl || output == nullptr ||
+        !output->impl) {
+        return -1;
+    }
+    try {
+        if (engine->_config->impl.num_stokes() == 1) {
+            auto* impl = dynamic_cast<Sasktran2<1>*>(engine->impl.get());
+            auto* native_atmosphere =
+                dynamic_cast<sasktran2::atmosphere::Atmosphere<1>*>(
+                    atmosphere->impl.get());
+            auto* native_output =
+                dynamic_cast<sasktran2::OutputJVP<1>*>(output->impl.get());
+            if (impl == nullptr || native_atmosphere == nullptr ||
+                native_output == nullptr) {
+                return -2;
+            }
+            impl->initialize_jvp(*native_atmosphere, *native_output);
+            return 0;
+        }
+        if (engine->_config->impl.num_stokes() == 3) {
+            auto* impl = dynamic_cast<Sasktran2<3>*>(engine->impl.get());
+            auto* native_atmosphere =
+                dynamic_cast<sasktran2::atmosphere::Atmosphere<3>*>(
+                    atmosphere->impl.get());
+            auto* native_output =
+                dynamic_cast<sasktran2::OutputJVP<3>*>(output->impl.get());
+            if (impl == nullptr || native_atmosphere == nullptr ||
+                native_output == nullptr) {
+                return -2;
+            }
+            impl->initialize_jvp(*native_atmosphere, *native_output);
+            return 0;
+        }
+        return -2;
+    } catch (const std::exception& error) {
+        spdlog::error("Error initializing JVP: {}", error.what());
+        return -3;
+    }
+}
+
+int sk_engine_calculate_jvp_wavelength_thread(Engine* engine, OutputJVP* output,
+                                              int wavelength, int thread_idx) {
+    if (engine == nullptr || !engine->impl || engine->_config == nullptr ||
+        output == nullptr || !output->impl) {
+        return -1;
+    }
+    try {
+        if (engine->_config->impl.num_stokes() == 1) {
+            auto* impl = dynamic_cast<Sasktran2<1>*>(engine->impl.get());
+            auto* native_output =
+                dynamic_cast<sasktran2::OutputJVP<1>*>(output->impl.get());
+            if (impl == nullptr || native_output == nullptr) {
+                return -2;
+            }
+            impl->calculate_jvp_wavelength_thread(*native_output, wavelength,
+                                                  thread_idx);
+            return 0;
+        }
+        if (engine->_config->impl.num_stokes() == 3) {
+            auto* impl = dynamic_cast<Sasktran2<3>*>(engine->impl.get());
+            auto* native_output =
+                dynamic_cast<sasktran2::OutputJVP<3>*>(output->impl.get());
+            if (impl == nullptr || native_output == nullptr) {
+                return -2;
+            }
+            impl->calculate_jvp_wavelength_thread(*native_output, wavelength,
+                                                  thread_idx);
+            return 0;
+        }
+        return -2;
+    } catch (const std::exception& error) {
+        spdlog::error("Error calculating JVP wavelength: {}", error.what());
+        return -3;
+    }
+}
+
 int sk_engine_calculate_vjp(Engine* engine, Atmosphere* atmosphere,
                             OutputVJP* output) {
     if (engine == nullptr || !engine->impl || engine->_config == nullptr ||
@@ -300,6 +379,88 @@ int sk_engine_calculate_vjp(Engine* engine, Atmosphere* atmosphere,
         return -2;
     } catch (const std::exception& error) {
         spdlog::error("Error calculating VJP: {}", error.what());
+        return -3;
+    }
+}
+
+int sk_engine_initialize_vjp(Engine* engine, Atmosphere* atmosphere,
+                             OutputVJP* output) {
+    if (engine == nullptr || !engine->impl || engine->_config == nullptr ||
+        atmosphere == nullptr || !atmosphere->impl || output == nullptr ||
+        !output->impl) {
+        return -1;
+    }
+    try {
+        if (engine->_config->impl.num_stokes() == 1) {
+            auto* impl = dynamic_cast<Sasktran2<1>*>(engine->impl.get());
+            auto* native_atmosphere =
+                dynamic_cast<sasktran2::atmosphere::Atmosphere<1>*>(
+                    atmosphere->impl.get());
+            auto* native_output =
+                dynamic_cast<sasktran2::OutputVJP<1>*>(output->impl.get());
+            if (impl == nullptr || native_atmosphere == nullptr ||
+                native_output == nullptr) {
+                return -2;
+            }
+            impl->initialize_vjp(*native_atmosphere, *native_output);
+            return 0;
+        }
+        if (engine->_config->impl.num_stokes() == 3) {
+            auto* impl = dynamic_cast<Sasktran2<3>*>(engine->impl.get());
+            auto* native_atmosphere =
+                dynamic_cast<sasktran2::atmosphere::Atmosphere<3>*>(
+                    atmosphere->impl.get());
+            auto* native_output =
+                dynamic_cast<sasktran2::OutputVJP<3>*>(output->impl.get());
+            if (impl == nullptr || native_atmosphere == nullptr ||
+                native_output == nullptr) {
+                return -2;
+            }
+            impl->initialize_vjp(*native_atmosphere, *native_output);
+            return 0;
+        }
+        return -2;
+    } catch (const std::exception& error) {
+        spdlog::error("Error initializing VJP: {}", error.what());
+        return -3;
+    }
+}
+
+int sk_engine_calculate_vjp_block_thread(Engine* engine, OutputVJP* output,
+                                         int wavelength_start,
+                                         int wavelength_count, int thread_idx) {
+    if (engine == nullptr || !engine->impl || engine->_config == nullptr ||
+        output == nullptr || !output->impl || wavelength_start < 0 ||
+        wavelength_count < 1 || thread_idx < 0) {
+        return -1;
+    }
+    try {
+        const sasktran2::WavelengthBlock block{wavelength_start,
+                                               wavelength_count};
+        if (engine->_config->impl.num_stokes() == 1) {
+            auto* impl = dynamic_cast<Sasktran2<1>*>(engine->impl.get());
+            auto* native_output =
+                dynamic_cast<sasktran2::OutputVJP<1>*>(output->impl.get());
+            if (impl == nullptr || native_output == nullptr) {
+                return -2;
+            }
+            impl->calculate_vjp_block_thread(*native_output, block, thread_idx);
+            return 0;
+        }
+        if (engine->_config->impl.num_stokes() == 3) {
+            auto* impl = dynamic_cast<Sasktran2<3>*>(engine->impl.get());
+            auto* native_output =
+                dynamic_cast<sasktran2::OutputVJP<3>*>(output->impl.get());
+            if (impl == nullptr || native_output == nullptr) {
+                return -2;
+            }
+            impl->calculate_vjp_block_thread(*native_output, block, thread_idx);
+            return 0;
+        }
+        return -2;
+    } catch (const std::exception& error) {
+        spdlog::error("Error calculating VJP wavelength block: {}",
+                      error.what());
         return -3;
     }
 }

--- a/cpp/include/c_api/engine.h
+++ b/cpp/include/c_api/engine.h
@@ -28,8 +28,17 @@ int sk_engine_supports_linearization(Engine* engine, int mode, int* supported);
 int sk_engine_linearization_backend(Engine* engine, int mode, int* backend);
 int sk_engine_calculate_jvp(Engine* engine, Atmosphere* atmosphere,
                             OutputJVP* output);
+int sk_engine_initialize_jvp(Engine* engine, Atmosphere* atmosphere,
+                             OutputJVP* output);
+int sk_engine_calculate_jvp_wavelength_thread(Engine* engine, OutputJVP* output,
+                                              int wavelength, int thread_idx);
 int sk_engine_calculate_vjp(Engine* engine, Atmosphere* atmosphere,
                             OutputVJP* output);
+int sk_engine_initialize_vjp(Engine* engine, Atmosphere* atmosphere,
+                             OutputVJP* output);
+int sk_engine_calculate_vjp_block_thread(Engine* engine, OutputVJP* output,
+                                         int wavelength_start,
+                                         int wavelength_count, int thread_idx);
 int sk_engine_calculate_radiance_block_thread(Engine* engine, OutputC* output,
                                               int wavelength_start,
                                               int wavelength_count,

--- a/cpp/include/sasktran2/engine.h
+++ b/cpp/include/sasktran2/engine.h
@@ -69,6 +69,16 @@ template <int NSTOKES> class Sasktran2 : public Sasktran2Interface {
 
     std::vector<sasktran2::WavelengthBlockDual<NSTOKES>> m_thread_radiance;
 
+    // Persistent native-product storage permits an external scheduler to
+    // initialize a product once and dispatch independent wavelength blocks.
+    // The same storage is used by the ordinary OpenMP path.
+    mutable std::vector<Eigen::VectorXd> m_native_jvp_tangents;
+    mutable std::vector<Eigen::MatrixXd> m_native_vjp_gradients;
+    using NativeProductStokesBlock =
+        Eigen::Matrix<double, NSTOKES, Eigen::Dynamic, Eigen::RowMajor>;
+    mutable std::vector<NativeProductStokesBlock> m_native_vjp_radiance;
+    mutable std::vector<NativeProductStokesBlock> m_native_vjp_cotangent;
+
     // Thread storage to avoid reallocs on the derivatives of flux
     // Can't reuse radiance storage because flux NSTOKES is always 1 for flux
     std::vector<sasktran2::Dual<double, sasktran2::dualstorage::dense, 1>>
@@ -144,8 +154,23 @@ template <int NSTOKES> class Sasktran2 : public Sasktran2Interface {
                   sasktran2::OutputJVP<NSTOKES>& output) const;
 
     void
+    initialize_jvp(const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere,
+                   sasktran2::OutputJVP<NSTOKES>& output) const;
+
+    void calculate_jvp_wavelength_thread(sasktran2::OutputJVP<NSTOKES>& output,
+                                         int wavelength, int thread_idx) const;
+
+    void
     calculate_vjp(const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere,
                   sasktran2::OutputVJP<NSTOKES>& output) const;
+
+    void
+    initialize_vjp(const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere,
+                   sasktran2::OutputVJP<NSTOKES>& output) const;
+
+    void calculate_vjp_block_thread(sasktran2::OutputVJP<NSTOKES>& output,
+                                    const sasktran2::WavelengthBlock<>& block,
+                                    int thread_idx) const;
 
     int effective_wavelength_batch_size(int num_wavelengths) const;
 

--- a/cpp/lib/engine/engine.cpp
+++ b/cpp/lib/engine/engine.cpp
@@ -563,7 +563,7 @@ void Sasktran2<NSTOKES>::calculate_radiance(
 }
 
 template <int NSTOKES>
-void Sasktran2<NSTOKES>::calculate_jvp(
+void Sasktran2<NSTOKES>::initialize_jvp(
     const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere,
     sasktran2::OutputJVP<NSTOKES>& output) const {
 #ifdef SKTRAN_OPENMP_SUPPORT
@@ -600,10 +600,53 @@ void Sasktran2<NSTOKES>::calculate_jvp(
     output.initialize(m_config, *m_geometry, m_internal_viewing_geometry,
                       atmosphere);
 
-    std::vector<Eigen::VectorXd> native_tangents(m_config.num_threads());
-    for (auto& tangent : native_tangents) {
+    m_native_jvp_tangents.resize(m_config.num_threads());
+    for (auto& tangent : m_native_jvp_tangents) {
         tangent.resize(atmosphere.num_deriv());
     }
+}
+
+template <int NSTOKES>
+void Sasktran2<NSTOKES>::calculate_jvp_wavelength_thread(
+    sasktran2::OutputJVP<NSTOKES>& output, int wavelength,
+    int wavelength_threadidx) const {
+    if (wavelength < 0 || wavelength >= output.num_wavel() ||
+        wavelength_threadidx < 0 ||
+        wavelength_threadidx >= m_config.num_wavelength_threads() ||
+        wavelength_threadidx >=
+            static_cast<int>(m_native_jvp_tangents.size())) {
+        throw std::invalid_argument(
+            "Invalid wavelength or worker for native JVP");
+    }
+    const sasktran2::WavelengthBlock<> block{wavelength, 1};
+    auto& native_tangent = m_native_jvp_tangents[wavelength_threadidx];
+    output.native_tangent(wavelength, native_tangent);
+    // Source-wide directional state must be complete before LOS workers
+    // consume it concurrently.
+    for (auto& source : m_source_terms) {
+        source->calculate_jvp(block, wavelength_threadidx, native_tangent);
+    }
+#pragma omp parallel for num_threads(m_config.num_source_threads())            \
+    schedule(dynamic)
+    for (int ray = 0; ray < m_internal_viewing_geometry.num_rays(); ++ray) {
+#ifdef SKTRAN_OPENMP_SUPPORT
+        const int ray_threadidx = omp_get_thread_num() + wavelength_threadidx;
+#else
+        const int ray_threadidx = wavelength_threadidx;
+#endif
+        sasktran2::RadianceJVP<NSTOKES> radiance;
+        m_source_integrator->integrate_jvp(
+            radiance, m_los_source_terms, wavelength, ray, wavelength_threadidx,
+            ray_threadidx, native_tangent);
+        output.assign_native(ray, wavelength, radiance.value, radiance.jvp);
+    }
+}
+
+template <int NSTOKES>
+void Sasktran2<NSTOKES>::calculate_jvp(
+    const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere,
+    sasktran2::OutputJVP<NSTOKES>& output) const {
+    initialize_jvp(atmosphere, output);
     const int num_wavelength_threads = m_config.num_wavelength_threads();
 #pragma omp parallel for num_threads(num_wavelength_threads)
     for (int wavelength = 0; wavelength < atmosphere.num_wavel();
@@ -613,32 +656,13 @@ void Sasktran2<NSTOKES>::calculate_jvp(
 #else
         const int wavelength_threadidx = 0;
 #endif
-        const sasktran2::WavelengthBlock<> block{wavelength, 1};
-        auto& native_tangent = native_tangents[wavelength_threadidx];
-        output.native_tangent(wavelength, native_tangent);
-        for (auto& source : m_source_terms) {
-            source->calculate_jvp(block, wavelength_threadidx, native_tangent);
-        }
-#pragma omp parallel for num_threads(m_config.num_source_threads())            \
-    schedule(dynamic)
-        for (int ray = 0; ray < m_internal_viewing_geometry.num_rays(); ++ray) {
-#ifdef SKTRAN_OPENMP_SUPPORT
-            const int ray_threadidx =
-                omp_get_thread_num() + wavelength_threadidx;
-#else
-            const int ray_threadidx = wavelength_threadidx;
-#endif
-            sasktran2::RadianceJVP<NSTOKES> radiance;
-            m_source_integrator->integrate_jvp(
-                radiance, m_los_source_terms, wavelength, ray,
-                wavelength_threadidx, ray_threadidx, native_tangent);
-            output.assign_native(ray, wavelength, radiance.value, radiance.jvp);
-        }
+        calculate_jvp_wavelength_thread(output, wavelength,
+                                        wavelength_threadidx);
     }
 }
 
 template <int NSTOKES>
-void Sasktran2<NSTOKES>::calculate_vjp(
+void Sasktran2<NSTOKES>::initialize_vjp(
     const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere,
     sasktran2::OutputVJP<NSTOKES>& output) const {
 #ifdef SKTRAN_OPENMP_SUPPORT
@@ -675,19 +699,94 @@ void Sasktran2<NSTOKES>::calculate_vjp(
     output.initialize(m_config, *m_geometry, m_internal_viewing_geometry,
                       atmosphere);
 
-    using StokesBlock =
-        Eigen::Matrix<double, NSTOKES, Eigen::Dynamic, Eigen::RowMajor>;
-    std::vector<Eigen::MatrixXd> native_gradients(m_config.num_threads());
-    std::vector<StokesBlock> radiance_storage(m_config.num_threads());
-    std::vector<StokesBlock> cotangent_storage(m_config.num_threads());
+    m_native_vjp_gradients.resize(m_config.num_threads());
+    m_native_vjp_radiance.resize(m_config.num_threads());
+    m_native_vjp_cotangent.resize(m_config.num_threads());
     for (int thread = 0; thread < m_config.num_threads(); ++thread) {
-        native_gradients[thread].resize(atmosphere.num_deriv(),
-                                        wavelength_batch_size);
-        radiance_storage[thread].resize(NSTOKES, wavelength_batch_size);
-        cotangent_storage[thread].resize(NSTOKES, wavelength_batch_size);
+        m_native_vjp_gradients[thread].resize(atmosphere.num_deriv(),
+                                              wavelength_batch_size);
+        m_native_vjp_radiance[thread].resize(NSTOKES, wavelength_batch_size);
+        m_native_vjp_cotangent[thread].resize(NSTOKES, wavelength_batch_size);
     }
-    const int num_wavelength_threads = m_config.num_wavelength_threads();
+}
+
+template <int NSTOKES>
+void Sasktran2<NSTOKES>::calculate_vjp_block_thread(
+    sasktran2::OutputVJP<NSTOKES>& output,
+    const sasktran2::WavelengthBlock<>& block, int wavelength_threadidx) const {
+    if (block.start < 0 || block.count < 1 ||
+        block.end() > output.num_wavel() || wavelength_threadidx < 0 ||
+        wavelength_threadidx >= m_config.num_wavelength_threads() ||
+        wavelength_threadidx >=
+            static_cast<int>(m_native_vjp_gradients.size()) ||
+        wavelength_threadidx >=
+            static_cast<int>(m_native_vjp_radiance.size()) ||
+        wavelength_threadidx >=
+            static_cast<int>(m_native_vjp_cotangent.size()) ||
+        block.count > m_native_vjp_gradients[wavelength_threadidx].cols()) {
+        throw std::invalid_argument(
+            "Invalid wavelength block or worker for native VJP");
+    }
+    for (auto& source : m_source_terms) {
+        source->calculate_vjp(block, wavelength_threadidx);
+    }
     const int num_source_threads = m_config.num_source_threads();
+    if (num_source_threads == 1) {
+        m_native_vjp_gradients[wavelength_threadidx]
+            .leftCols(block.count)
+            .setZero();
+    } else {
+        for (int thread = 0; thread < num_source_threads; ++thread) {
+            m_native_vjp_gradients[thread].leftCols(block.count).setZero();
+        }
+    }
+#pragma omp parallel for num_threads(num_source_threads) schedule(dynamic)
+    for (int ray = 0; ray < m_internal_viewing_geometry.num_rays(); ++ray) {
+#ifdef SKTRAN_OPENMP_SUPPORT
+        const int ray_threadidx = omp_get_thread_num() + wavelength_threadidx;
+#else
+        const int ray_threadidx = wavelength_threadidx;
+#endif
+        auto& radiance = m_native_vjp_radiance[ray_threadidx];
+        auto& cotangent = m_native_vjp_cotangent[ray_threadidx];
+        for (int lane = 0; lane < block.count; ++lane) {
+            cotangent.col(lane) =
+                output.native_cotangent(ray, block.wavelength(lane));
+        }
+        m_source_integrator->integrate_vjp_block(
+            radiance, m_los_source_terms, block, ray, wavelength_threadidx,
+            ray_threadidx, cotangent, m_native_vjp_gradients[ray_threadidx]);
+        for (int lane = 0; lane < block.count; ++lane) {
+            output.assign_native_value(ray, block.wavelength(lane),
+                                       radiance.col(lane));
+        }
+    }
+    auto& reduced_gradient = m_native_vjp_gradients[wavelength_threadidx];
+    if (num_source_threads > 1) {
+        for (int thread = 1; thread < num_source_threads; ++thread) {
+            reduced_gradient.leftCols(block.count) +=
+                m_native_vjp_gradients[thread].leftCols(block.count);
+        }
+    }
+    // Globally coupled sources complete one adjoint after all LOS cotangents
+    // have reached their thread-local accumulators.
+    auto reduced_gradient_block = reduced_gradient.leftCols(block.count);
+    for (const auto& source : m_source_terms) {
+        source->finalize_vjp(block, wavelength_threadidx,
+                             reduced_gradient_block);
+    }
+    output.accumulate_native_gradient(block, wavelength_threadidx,
+                                      reduced_gradient);
+}
+
+template <int NSTOKES>
+void Sasktran2<NSTOKES>::calculate_vjp(
+    const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere,
+    sasktran2::OutputVJP<NSTOKES>& output) const {
+    initialize_vjp(atmosphere, output);
+    const int wavelength_batch_size =
+        effective_wavelength_batch_size(atmosphere.num_wavel());
+    const int num_wavelength_threads = m_config.num_wavelength_threads();
     const int num_blocks =
         (atmosphere.num_wavel() + wavelength_batch_size - 1) /
         wavelength_batch_size;
@@ -702,56 +801,7 @@ void Sasktran2<NSTOKES>::calculate_vjp(
         const sasktran2::WavelengthBlock<> block{
             start,
             std::min(wavelength_batch_size, atmosphere.num_wavel() - start)};
-        for (auto& source : m_source_terms) {
-            source->calculate_vjp(block, wavelength_threadidx);
-        }
-        if (num_source_threads == 1) {
-            native_gradients[wavelength_threadidx]
-                .leftCols(block.count)
-                .setZero();
-        } else {
-            for (int thread = 0; thread < num_source_threads; ++thread) {
-                native_gradients[thread].leftCols(block.count).setZero();
-            }
-        }
-#pragma omp parallel for num_threads(num_source_threads) schedule(dynamic)
-        for (int ray = 0; ray < m_internal_viewing_geometry.num_rays(); ++ray) {
-#ifdef SKTRAN_OPENMP_SUPPORT
-            const int ray_threadidx =
-                omp_get_thread_num() + wavelength_threadidx;
-#else
-            const int ray_threadidx = wavelength_threadidx;
-#endif
-            auto& radiance = radiance_storage[ray_threadidx];
-            auto& cotangent = cotangent_storage[ray_threadidx];
-            for (int lane = 0; lane < block.count; ++lane) {
-                cotangent.col(lane) =
-                    output.native_cotangent(ray, block.wavelength(lane));
-            }
-            m_source_integrator->integrate_vjp_block(
-                radiance, m_los_source_terms, block, ray, wavelength_threadidx,
-                ray_threadidx, cotangent, native_gradients[ray_threadidx]);
-            for (int lane = 0; lane < block.count; ++lane) {
-                output.assign_native_value(ray, block.wavelength(lane),
-                                           radiance.col(lane));
-            }
-        }
-        auto& reduced_gradient = native_gradients[wavelength_threadidx];
-        if (num_source_threads > 1) {
-            for (int thread = 1; thread < num_source_threads; ++thread) {
-                reduced_gradient.leftCols(block.count) +=
-                    native_gradients[thread].leftCols(block.count);
-            }
-        }
-        // Globally coupled sources complete one adjoint after all LOS
-        // cotangents have reached their thread-local accumulators.
-        auto reduced_gradient_block = reduced_gradient.leftCols(block.count);
-        for (const auto& source : m_source_terms) {
-            source->finalize_vjp(block, wavelength_threadidx,
-                                 reduced_gradient_block);
-        }
-        output.accumulate_native_gradient(block, wavelength_threadidx,
-                                          reduced_gradient);
+        calculate_vjp_block_thread(output, block, wavelength_threadidx);
     }
 }
 

--- a/rust/sasktran2-rs/src/bindings/engine.rs
+++ b/rust/sasktran2-rs/src/bindings/engine.rs
@@ -57,6 +57,34 @@ pub struct SafeFFIOutput(pub *mut ffi::OutputC);
 unsafe impl Send for SafeFFIOutput {}
 unsafe impl Sync for SafeFFIOutput {}
 
+pub struct SafeFFIJvpOutput(pub *mut ffi::OutputJVP);
+
+unsafe impl Send for SafeFFIJvpOutput {}
+unsafe impl Sync for SafeFFIJvpOutput {}
+
+pub struct SafeFFIVjpOutput(pub *mut ffi::OutputVJP);
+
+unsafe impl Send for SafeFFIVjpOutput {}
+unsafe impl Sync for SafeFFIVjpOutput {}
+
+fn rayon_for_each_worker<F>(num_items: usize, num_threads: usize, function: F) -> Result<()>
+where
+    F: Fn(usize, i32) -> Result<()> + Send + Sync,
+{
+    let thread_pool = threading::thread_pool()?;
+    thread_pool.install(|| {
+        (0..num_items).into_par_iter().try_for_each(|item| {
+            let thread_idx = current_thread_index()
+                .ok_or_else(|| anyhow::anyhow!("Rayon worker index is unavailable"))?
+                as i32;
+            if thread_idx >= num_threads as i32 {
+                return Err(anyhow::anyhow!("Thread index out of bounds"));
+            }
+            function(item, thread_idx)
+        })
+    })
+}
+
 fn safe_calc_block_thread(
     engine: &SafeFFIEngine,
     output: &SafeFFIOutput,
@@ -83,7 +111,61 @@ fn safe_calc_block_thread(
     }
 }
 
+fn safe_calc_jvp_wavelength_thread(
+    engine: &SafeFFIEngine,
+    output: &SafeFFIJvpOutput,
+    wavelength: i32,
+    thread_idx: i32,
+) -> Result<()> {
+    let result = unsafe {
+        ffi::sk_engine_calculate_jvp_wavelength_thread(engine.0, output.0, wavelength, thread_idx)
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!(
+            "Failed to calculate JVP wavelength: {}",
+            result
+        ))
+    }
+}
+
+fn safe_calc_vjp_block_thread(
+    engine: &SafeFFIEngine,
+    output: &SafeFFIVjpOutput,
+    wavelength_start: i32,
+    wavelength_count: i32,
+    thread_idx: i32,
+) -> Result<()> {
+    let result = unsafe {
+        ffi::sk_engine_calculate_vjp_block_thread(
+            engine.0,
+            output.0,
+            wavelength_start,
+            wavelength_count,
+            thread_idx,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!(
+            "Failed to calculate VJP wavelength block: {}",
+            result
+        ))
+    }
+}
+
 impl<'a> Engine<'a> {
+    fn use_rayon_wavelength_threading(&self) -> Result<bool> {
+        Ok(
+            (self.config.threading_lib() == ThreadingLib::Rayon || !openmp_support_enabled())
+                && self.config.num_threads()? > 1
+                && self.config.threading_model()?
+                    == crate::bindings::config::ThreadingModel::Wavelength,
+        )
+    }
+
     /// Creates a new engine object
     pub fn new(
         config: &'a Config,
@@ -217,11 +299,7 @@ impl<'a> Engine<'a> {
 
         // Rayon partitions wavelengths, so only use it with wavelength
         // threading. Source threading remains inside the C++ engine.
-        let use_rayon_threading = (self.config.threading_lib() == ThreadingLib::Rayon
-            || !openmp_support_enabled())
-            && self.config.num_threads()? > 1
-            && self.config.threading_model()?
-                == crate::bindings::config::ThreadingModel::Wavelength;
+        let use_rayon_threading = self.use_rayon_wavelength_threading()?;
 
         if !use_rayon_threading {
             let result = unsafe {
@@ -346,11 +424,31 @@ impl<'a> Engine<'a> {
                 .with_surface_tangent(name, tangent)
                 .map_err(anyhow::Error::msg)?;
         }
-        let result = unsafe {
-            ffi::sk_engine_calculate_jvp(self.engine, atmosphere.atmosphere, output.output)
-        };
-        if result != 0 {
-            return Err(anyhow::anyhow!("Failed to calculate JVP: {}", result));
+        let use_rayon_threading = self.use_rayon_wavelength_threading()?
+            && self.linearization_backend(LinearizationMode::Jvp)? == LinearizationBackend::Native;
+        if !use_rayon_threading {
+            let result = unsafe {
+                ffi::sk_engine_calculate_jvp(self.engine, atmosphere.atmosphere, output.output)
+            };
+            if result != 0 {
+                return Err(anyhow::anyhow!("Failed to calculate JVP: {}", result));
+            }
+        } else {
+            let result = unsafe {
+                ffi::sk_engine_initialize_jvp(self.engine, atmosphere.atmosphere, output.output)
+            };
+            if result != 0 {
+                return Err(anyhow::anyhow!("Failed to initialize JVP: {}", result));
+            }
+            let engine = SafeFFIEngine(self.engine);
+            let output = SafeFFIJvpOutput(output.output);
+            rayon_for_each_worker(
+                atmosphere.num_wavel(),
+                self.config.num_threads()?,
+                |wavelength, thread_idx| {
+                    safe_calc_jvp_wavelength_thread(&engine, &output, wavelength as i32, thread_idx)
+                },
+            )?;
         }
         Ok(output)
     }
@@ -386,11 +484,59 @@ impl<'a> Engine<'a> {
                 .with_surface_gradient(name, *size)
                 .map_err(anyhow::Error::msg)?;
         }
-        let result = unsafe {
-            ffi::sk_engine_calculate_vjp(self.engine, atmosphere.atmosphere, output.output)
-        };
-        if result != 0 {
-            return Err(anyhow::anyhow!("Failed to calculate VJP: {}", result));
+        let use_rayon_threading = self.use_rayon_wavelength_threading()?
+            && self.linearization_backend(LinearizationMode::Vjp)? == LinearizationBackend::Native;
+        if !use_rayon_threading {
+            let result = unsafe {
+                ffi::sk_engine_calculate_vjp(self.engine, atmosphere.atmosphere, output.output)
+            };
+            if result != 0 {
+                return Err(anyhow::anyhow!("Failed to calculate VJP: {}", result));
+            }
+        } else {
+            let result = unsafe {
+                ffi::sk_engine_initialize_vjp(self.engine, atmosphere.atmosphere, output.output)
+            };
+            if result != 0 {
+                return Err(anyhow::anyhow!("Failed to initialize VJP: {}", result));
+            }
+            let num_wavel = atmosphere.num_wavel();
+            let batch_size = unsafe {
+                ffi::sk_engine_effective_wavelength_batch_size(self.engine, num_wavel as i32)
+            };
+            if batch_size < 1 {
+                return Err(anyhow::anyhow!(
+                    "Failed to determine VJP wavelength batch size: {}",
+                    batch_size
+                ));
+            }
+            let batch_size = batch_size as usize;
+            let num_batches = num_wavel.div_ceil(batch_size);
+            let engine = SafeFFIEngine(self.engine);
+            let safe_output = SafeFFIVjpOutput(output.output);
+            let worker_result = rayon_for_each_worker(
+                num_batches,
+                self.config.num_threads()?,
+                |batch_index, thread_idx| {
+                    let start = batch_index * batch_size;
+                    let count = (num_wavel - start).min(batch_size);
+                    safe_calc_vjp_block_thread(
+                        &engine,
+                        &safe_output,
+                        start as i32,
+                        count as i32,
+                        thread_idx,
+                    )
+                },
+            );
+            let finalize_result = unsafe { ffi::sk_output_vjp_finalize(output.output) };
+            worker_result?;
+            if finalize_result != 0 {
+                return Err(anyhow::anyhow!(
+                    "Failed to finalize VJP: {}",
+                    finalize_result
+                ));
+            }
         }
         Ok(output)
     }

--- a/rust/sasktran2-rs/src/threading.rs
+++ b/rust/sasktran2-rs/src/threading.rs
@@ -16,6 +16,12 @@ fn create_pool(num_threads: usize) -> Result<rayon::ThreadPool> {
 
 pub fn set_num_threads(num_threads: usize) -> Result<()> {
     let mut pool = THREADPOOL.lock().unwrap();
+    if pool
+        .as_ref()
+        .is_some_and(|pool| pool.current_num_threads() == num_threads)
+    {
+        return Ok(());
+    }
     *pool = Some(create_pool(num_threads)?.into());
     Ok(())
 }

--- a/rust/sasktran2-sys/src/bindings.rs
+++ b/rust/sasktran2-sys/src/bindings.rs
@@ -1161,10 +1161,41 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    pub fn sk_engine_initialize_jvp(
+        engine: *mut Engine,
+        atmosphere: *mut Atmosphere,
+        output: *mut OutputJVP,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn sk_engine_calculate_jvp_wavelength_thread(
+        engine: *mut Engine,
+        output: *mut OutputJVP,
+        wavelength: ::std::os::raw::c_int,
+        thread_idx: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
     pub fn sk_engine_calculate_vjp(
         engine: *mut Engine,
         atmosphere: *mut Atmosphere,
         output: *mut OutputVJP,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn sk_engine_initialize_vjp(
+        engine: *mut Engine,
+        atmosphere: *mut Atmosphere,
+        output: *mut OutputVJP,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn sk_engine_calculate_vjp_block_thread(
+        engine: *mut Engine,
+        output: *mut OutputVJP,
+        wavelength_start: ::std::os::raw::c_int,
+        wavelength_count: ::std::os::raw::c_int,
+        thread_idx: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {

--- a/tests/engine/test_1d_solver_regression.py
+++ b/tests/engine/test_1d_solver_regression.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 import sasktran2 as sk
+import xarray as xr
 
 
 def _setup_1d(
@@ -373,6 +374,48 @@ def test_rayon_wavelength_batch_parity():
             rtol=5e-12,
             atol=2e-13,
         )
+
+
+@pytest.mark.parametrize("num_stokes", [1, 3])
+def test_rayon_native_jvp_vjp_match_single_thread(num_stokes):
+    """Rayon may schedule exact-single-scatter native products by wavelength."""
+    serial_engine, serial_atmosphere = _setup_1d(
+        "single_scatter", num_stokes, True, num_wavelengths=7
+    )
+    rayon_engine, rayon_atmosphere = _setup_1d(
+        "single_scatter",
+        num_stokes,
+        True,
+        num_wavelengths=7,
+        wavelength_batch_size=4,
+        num_threads=2,
+        threading_lib=sk.ThreadingLib.Rayon,
+        threading_model=sk.ThreadingModel.Wavelength,
+    )
+
+    serial = serial_engine.linearize(serial_atmosphere)
+    threaded = rayon_engine.linearize(rayon_atmosphere)
+    assert threaded.backends == {
+        "jvp": sk.LinearizationBackend.Native,
+        "vjp": sk.LinearizationBackend.Native,
+    }
+
+    tangent = threaded.tangent_template[["extinction", "ssa", "albedo"]]
+    tangent["extinction"].data[:] = np.linspace(0.2, 0.8, 25)
+    tangent["ssa"].data[:] = np.linspace(-0.3, 0.1, 25)
+    tangent["albedo"].data[:] = np.linspace(0.1, 0.7, 7)
+    for scale in (1.0, -0.4):
+        xr.testing.assert_allclose(
+            threaded.jvp(tangent * scale), serial.jvp(tangent * scale)
+        )
+
+    cotangent = xr.ones_like(threaded.value)
+    cotangent.data[:] = np.linspace(0.3, 1.1, cotangent.size).reshape(cotangent.shape)
+    for scale in (1.0, -0.4):
+        serial_gradient = serial.vjp(cotangent * scale)
+        threaded_gradient = threaded.vjp(cotangent * scale)
+        for name in tangent:
+            xr.testing.assert_allclose(threaded_gradient[name], serial_gradient[name])
 
 
 def test_unsupported_sources_fall_back_to_scalar_wavelengths():


### PR DESCRIPTION
## Summary

- split native JVP and VJP setup from per-wavelength worker execution in the C++ engine
- reuse engine-owned native-product scratch buffers
- expose narrow C worker entry points and schedule wavelength work through Rayon
- reuse the configured Rayon pool and add generic exact-single-scatter parity and repeat coverage

## Scope

This is a generic engine scheduling change and contains no SuccessiveOrdersCpp source, configuration, cache, or selective-VJP code. It depends only on #286.

## Validation

- project build passed
- 17 one-dimensional solver regression tests passed
- 25 linearization tests passed
- full Rust clippy passed
- pre-commit passed