### PR TITLE
Skip unused native derivative work

### DIFF
--- a/cpp/include/sasktran2/output.h
+++ b/cpp/include/sasktran2/output.h
@@ -11,6 +11,7 @@
 #include <sasktran2/wavelength_block.h>
 
 namespace sasktran2 {
+    struct NativeVJPRequest;
 
     /** Essentially a pure virtual void class to interface with SWIG, removing
      * the NSTOKES template.
@@ -401,6 +402,10 @@ namespace sasktran2 {
 
         void assign_native_value(int losidx, int wavelidx,
                                  const Eigen::Vector<double, NSTOKES>& value);
+
+        /** Returns the optional native derivative categories consumed by the
+         * registered output parameter mappings. */
+        NativeVJPRequest native_vjp_request() const;
 
         void accumulate_native_gradient(
             int wavelidx, int threadidx,

--- a/cpp/include/sasktran2/solartransmission.h
+++ b/cpp/include/sasktran2/solartransmission.h
@@ -234,13 +234,14 @@ namespace sasktran2::solartransmission {
          *   @param threadidx The thread index
          *   @param wavelidx The wavelength index
          */
-        void calculate(int wavelidx, int threadidx);
+        void calculate(int wavelidx, int threadidx,
+                       bool calculate_derivatives = true);
 
         void initialize_wavelength_blocks(int batch_size);
 
         template <int N>
         void calculate_block(const sasktran2::WavelengthBlock<N>& batch,
-                             int threadidx);
+                             int threadidx, bool calculate_derivatives = true);
 
         /**
          * Calculates the phase function at a given point and puts it into
@@ -383,6 +384,13 @@ namespace sasktran2::solartransmission {
         }
 
         const double source_amplitude = k * ssa * solar_trans / (EIGEN_PI * 4);
+        if (!calculate_derivatives) {
+            source.value =
+                source_amplitude * phase_handler.scatter_value(
+                                       threadidx, losidx, layeridx, wavelidx,
+                                       index_weights, is_entrance);
+            return;
+        }
         const bool use_zero_safe_derivative_path =
             calculate_derivatives && (k == 0.0 || ssa == 0.0);
         if (!use_zero_safe_derivative_path) {
@@ -658,6 +666,8 @@ namespace sasktran2::solartransmission {
         int m_wavelength_batch_capacity = 1;
         std::vector<int> m_active_wavelength_block_start;
         std::vector<int> m_active_wavelength_block_count;
+        std::vector<unsigned char> m_phase_tangent_active;
+        sasktran2::NativeVJPRequest m_vjp_request;
         std::vector<std::vector<int>> m_index_map;
 
         PhaseHandler<NSTOKES> m_phase_handler;
@@ -681,7 +691,6 @@ namespace sasktran2::solartransmission {
             m_batch_source_cache;
         mutable std::vector<ExactIntegrationBlockScratch<NSTOKES>>
             m_batch_integration_cache;
-
         const Geometry& m_geometry;
         const Geometry1D* m_geometry_1d = nullptr;
         const Geometry2D* m_geometry_2d = nullptr;
@@ -771,6 +780,10 @@ namespace sasktran2::solartransmission {
             const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere)
             override;
 
+        void initialize_atmosphere_native(
+            const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere)
+            override;
+
         void set_wavelength_block_capacity(int block_capacity) override {
             if (block_capacity < 1) {
                 throw std::invalid_argument(
@@ -792,17 +805,21 @@ namespace sasktran2::solartransmission {
         }
 
       private:
-        void calculate_single(int wavelidx, int threadidx);
+        void initialize_atmosphere_impl(
+            const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere,
+            bool native_products);
+
+        void calculate_single(int wavelidx, int threadidx,
+                              bool calculate_phase_derivatives);
 
         void initialize_wavelength_blocks(int block_size);
 
         template <int N>
         void calculate_block(const sasktran2::WavelengthBlock<N>& block,
-                             int threadidx);
+                             int threadidx, bool calculate_phase_derivatives);
 
-      public:
-        void calculate(const sasktran2::WavelengthBlock<>& block,
-                       int threadidx) override {
+        void calculate_impl(const sasktran2::WavelengthBlock<>& block,
+                            int threadidx, bool calculate_phase_derivatives) {
             if constexpr (std::is_same_v<S, SolarTransmissionExact>) {
                 sasktran2::dispatch_wavelength_block(
                     block, [&](const auto& fixed_block) {
@@ -810,17 +827,56 @@ namespace sasktran2::solartransmission {
                                           decltype(fixed_block)>::static_size ==
                                       1) {
                             if (m_wavelength_batch_capacity == 1) {
-                                calculate_single(fixed_block.start, threadidx);
+                                calculate_single(fixed_block.start, threadidx,
+                                                 calculate_phase_derivatives);
                             } else {
-                                calculate_block(fixed_block, threadidx);
+                                calculate_block(fixed_block, threadidx,
+                                                calculate_phase_derivatives);
                             }
                         } else {
-                            calculate_block(fixed_block, threadidx);
+                            calculate_block(fixed_block, threadidx,
+                                            calculate_phase_derivatives);
                         }
                     });
             } else {
-                calculate_single(block.start, threadidx);
+                calculate_single(block.start, threadidx,
+                                 calculate_phase_derivatives);
             }
+        }
+
+      public:
+        void calculate(const sasktran2::WavelengthBlock<>& block,
+                       int threadidx) override {
+            calculate_impl(block, threadidx, true);
+        }
+
+        void calculate_jvp(
+            const sasktran2::WavelengthBlock<>& block, int threadidx,
+            Eigen::Ref<const Eigen::VectorXd> native_tangent) override {
+            if constexpr (std::is_same_v<S, SolarTransmissionExact>) {
+                const int count = m_atmosphere->num_scattering_deriv_groups() *
+                                  m_geometry.size();
+                const int offset = m_atmosphere->scat_deriv_start_index();
+                if (offset < 0 || count < 0 ||
+                    offset + count > native_tangent.size()) {
+                    throw std::invalid_argument(
+                        "Single-scatter JVP phase tangent range is invalid");
+                }
+                m_phase_tangent_active.at(threadidx) =
+                    native_tangent.segment(offset, count).isZero(0.0) ? 0 : 1;
+            }
+            calculate_impl(block, threadidx,
+                           m_phase_tangent_active.at(threadidx) != 0);
+        }
+
+        void calculate_vjp(const sasktran2::WavelengthBlock<>& block,
+                           int threadidx) override {
+            calculate_impl(block, threadidx, m_vjp_request.scattering);
+        }
+
+        void
+        set_vjp_request(const sasktran2::NativeVJPRequest& request) override {
+            m_vjp_request = request;
         }
 
         /** Calculates the integrated source term for a given layer.

--- a/cpp/include/sasktran2/source_interface.h
+++ b/cpp/include/sasktran2/source_interface.h
@@ -32,6 +32,13 @@ namespace sasktran2 {
         StreamingJacobian = 1,
         Native = 2
     };
+
+    /** Native derivative categories whose reverse assembly can be skipped
+     * when the output has no registered consumer for them. */
+    struct NativeVJPRequest {
+        bool scattering = true;
+        bool surface = true;
+    };
 } // namespace sasktran2
 
 /** Base interface class that provides source term functionality to the Engine
@@ -151,6 +158,10 @@ template <int NSTOKES> class SourceTermInterface {
                                int threadidx) {
         calculate(block, threadidx);
     }
+
+    /** Restricts optional reverse work to derivative categories consumed by
+     * the current output. Sources may ignore this hint. */
+    virtual void set_vjp_request(const sasktran2::NativeVJPRequest&) {}
 
     /** Finalizes source-wide reverse accumulation after all LOS contributions
      * have been reduced into the native gradient. */

--- a/cpp/lib/engine/engine.cpp
+++ b/cpp/lib/engine/engine.cpp
@@ -674,6 +674,10 @@ void Sasktran2<NSTOKES>::calculate_vjp(
     output.set_wavelength_block_capacity(wavelength_batch_size);
     output.initialize(m_config, *m_geometry, m_internal_viewing_geometry,
                       atmosphere);
+    const auto vjp_request = output.native_vjp_request();
+    for (auto& source : m_source_terms) {
+        source->set_vjp_request(vjp_request);
+    }
 
     using StokesBlock =
         Eigen::Matrix<double, NSTOKES, Eigen::Dynamic, Eigen::RowMajor>;

--- a/cpp/lib/output/outputlinearization.cpp
+++ b/cpp/lib/output/outputlinearization.cpp
@@ -1,4 +1,5 @@
 #include "sasktran2/output.h"
+#include "sasktran2/source_interface.h"
 
 namespace sasktran2 {
     namespace {
@@ -533,6 +534,21 @@ namespace sasktran2 {
         for (int stokes = 0; stokes < NSTOKES; ++stokes) {
             m_radiance(linear_index + stokes) = rotated(stokes);
         }
+    }
+
+    template <int NSTOKES>
+    NativeVJPRequest OutputVJP<NSTOKES>::native_vjp_request() const {
+        NativeVJPRequest request;
+        request.scattering = false;
+        const auto& mappings =
+            this->m_atmosphere->storage().derivative_mappings_const();
+        for (const auto& [name, unused] : m_derivative_gradients) {
+            (void)unused;
+            request.scattering = request.scattering ||
+                                 mappings.at(name).is_scattering_derivative();
+        }
+        request.surface = !m_surface_gradients.empty();
+        return request;
     }
 
     template <int NSTOKES>

--- a/cpp/lib/phasefunction/phasehandler.cpp
+++ b/cpp/lib/phasefunction/phasehandler.cpp
@@ -214,14 +214,17 @@ namespace sasktran2::solartransmission {
     }
 
     template <int NSTOKES>
-    void PhaseHandler<NSTOKES>::calculate(int wavelidx, int threadidx) {
+    void PhaseHandler<NSTOKES>::calculate(int wavelidx, int threadidx,
+                                          bool calculate_derivatives) {
 
         // If we need to calculate the phase function, we do it
         if (m_config->singlescatter_phasemode() ==
             sasktran2::Config::SingleScatterPhaseMode::from_legendre) {
             // Set all elements with this threadidx to zero
             m_phase.chip(threadidx, 2).setZero();
-            m_d_phase.chip(threadidx, 3).setZero();
+            if (calculate_derivatives) {
+                m_d_phase.chip(threadidx, 3).setZero();
+            }
 
             Eigen::array<Eigen::Index, 3> dims = m_phase.dimensions();
             Eigen::array<Eigen::Index, 3> offsets = {0, 1, 0};
@@ -262,7 +265,8 @@ namespace sasktran2::solartransmission {
                             .dot(m_wigner_d02(Eigen::seq(0, max_order - 1),
                                               scat_index));
                 }
-                for (int d = 0; d < m_atmosphere->num_scattering_deriv_groups();
+                for (int d = 0; calculate_derivatives &&
+                                d < m_atmosphere->num_scattering_deriv_groups();
                      ++d) {
 
                     int d_max_order = m_atmosphere->storage().d_max_order[d](
@@ -334,7 +338,8 @@ namespace sasktran2::solartransmission {
     template <int NSTOKES>
     template <int N>
     void PhaseHandler<NSTOKES>::calculate_block(
-        const sasktran2::WavelengthBlock<N>& batch, int threadidx) {
+        const sasktran2::WavelengthBlock<N>& batch, int threadidx,
+        bool calculate_derivatives) {
         if (m_config->singlescatter_phasemode() !=
             sasktran2::Config::SingleScatterPhaseMode::from_legendre) {
             throw std::runtime_error("Phase mode not implemented");
@@ -349,7 +354,9 @@ namespace sasktran2::solartransmission {
         auto& phase = m_phase_batch[threadidx];
         auto& d_phase = m_d_phase_batch[threadidx];
         wavelength_left_cols(phase, batch).setZero();
-        wavelength_left_cols(d_phase, batch).setZero();
+        if (calculate_derivatives) {
+            wavelength_left_cols(d_phase, batch).setZero();
+        }
 
         const int num_internal =
             static_cast<int>(m_internal_to_geometry.size());
@@ -404,6 +411,7 @@ namespace sasktran2::solartransmission {
                 }
 
                 for (int derivative = 0;
+                     calculate_derivatives &&
                      derivative < m_atmosphere->num_scattering_deriv_groups();
                      ++derivative) {
                     const int derivative_max_order =
@@ -956,7 +964,7 @@ namespace sasktran2::solartransmission {
 
 #define SASKTRAN2_INSTANTIATE_PHASE_BLOCK(NSTOKES, N)                          \
     template void PhaseHandler<NSTOKES>::calculate_block<N>(                   \
-        const sasktran2::WavelengthBlock<N>&, int);                            \
+        const sasktran2::WavelengthBlock<N>&, int, bool);                      \
     template void                                                              \
     PhaseHandler<NSTOKES>::scatter_and_accumulate_derivative_block<N>(         \
         int, int, int, const raytracing::GridWeightStencilView&, bool,         \

--- a/cpp/lib/solar/singlescattersource.cpp
+++ b/cpp/lib/solar/singlescattersource.cpp
@@ -17,26 +17,41 @@ namespace sasktran2::solartransmission {
     template <typename S, int NSTOKES>
     void SingleScatterSource<S, NSTOKES>::initialize_atmosphere(
         const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere) {
+        initialize_atmosphere_impl(atmosphere, false);
+    };
+
+    template <typename S, int NSTOKES>
+    void SingleScatterSource<S, NSTOKES>::initialize_atmosphere_native(
+        const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere) {
+        initialize_atmosphere_impl(atmosphere, true);
+    };
+
+    template <typename S, int NSTOKES>
+    void SingleScatterSource<S, NSTOKES>::initialize_atmosphere_impl(
+        const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere,
+        bool native_products) {
         // Store the atmosphere for later
         m_atmosphere = &atmosphere;
         this->m_phase_handler.initialize_atmosphere(atmosphere);
 
         if constexpr (std::is_same_v<S, SolarTransmissionExact>) {
-            if (atmosphere.num_deriv() > 0) {
+            if (!native_products && atmosphere.num_deriv() > 0) {
                 initialize_active_derivative_indices();
             } else {
                 m_active_derivative_indices.clear();
             }
 
-            initialize_wavelength_blocks(m_wavelength_batch_capacity);
+            if (m_wavelength_batch_capacity > 1 || !native_products) {
+                initialize_wavelength_blocks(m_wavelength_batch_capacity);
+            }
         }
 
         // Initialize some local memory storage
+        const int cache_derivatives =
+            native_products ? 0 : atmosphere.num_deriv();
         for (int i = 0; i < m_start_source_cache.size(); ++i) {
-            m_start_source_cache[i].resize(NSTOKES, atmosphere.num_deriv(),
-                                           false);
-            m_end_source_cache[i].resize(NSTOKES, atmosphere.num_deriv(),
-                                         false);
+            m_start_source_cache[i].resize(NSTOKES, cache_derivatives, false);
+            m_end_source_cache[i].resize(NSTOKES, cache_derivatives, false);
         }
     };
 
@@ -55,19 +70,21 @@ namespace sasktran2::solartransmission {
                                                0);
         m_active_wavelength_block_count.assign(config.num_wavelength_threads(),
                                                0);
+        m_phase_tangent_active.assign(config.num_wavelength_threads(), 0);
 
         m_start_source_cache.resize(config.num_threads());
         m_end_source_cache.resize(config.num_threads());
     }
 
     template <typename S, int NSTOKES>
-    void SingleScatterSource<S, NSTOKES>::calculate_single(int wavelidx,
-                                                           int threadidx) {
+    void SingleScatterSource<S, NSTOKES>::calculate_single(
+        int wavelidx, int threadidx, bool calculate_phase_derivatives) {
         ZoneScopedN("Single Scatter Source Calculation");
         m_active_wavelength_block_start[threadidx] = wavelidx;
         m_active_wavelength_block_count[threadidx] = 1;
         // Don't have to do anything here
-        m_phase_handler.calculate(wavelidx, threadidx);
+        m_phase_handler.calculate(wavelidx, threadidx,
+                                  calculate_phase_derivatives);
 
         // Calculate the solar transmission at each cell
         if constexpr (std::is_same_v<S, SolarTransmissionExact>) {
@@ -136,7 +153,8 @@ namespace sasktran2::solartransmission {
     template <typename S, int NSTOKES>
     template <int N>
     void SingleScatterSource<S, NSTOKES>::calculate_block(
-        const sasktran2::WavelengthBlock<N>& batch, int threadidx) {
+        const sasktran2::WavelengthBlock<N>& batch, int threadidx,
+        bool calculate_phase_derivatives) {
         if constexpr (!std::is_same_v<S, SolarTransmissionExact>) {
             throw std::logic_error(
                 "Solar transmission tables do not support wavelength "
@@ -151,7 +169,8 @@ namespace sasktran2::solartransmission {
             m_active_wavelength_block_start[threadidx] = batch.start;
             m_active_wavelength_block_count[threadidx] = batch.count;
 
-            m_phase_handler.calculate_block(batch, threadidx);
+            m_phase_handler.calculate_block(batch, threadidx,
+                                            calculate_phase_derivatives);
             auto solar_trans =
                 wavelength_left_cols(m_solar_trans_batch[threadidx], batch);
             const auto extinction = wavelength_middle_cols(
@@ -237,9 +256,16 @@ namespace sasktran2::solartransmission {
 
             Eigen::Vector<double, NSTOKES> phase;
             Eigen::Vector<double, NSTOKES> phase_jvp;
-            m_phase_handler.scatter_jvp(wavel_threadidx, losidx, layeridx,
-                                        wavelidx, weights, is_entrance,
-                                        native_tangent, phase, phase_jvp);
+            if (m_phase_tangent_active.at(wavel_threadidx) != 0) {
+                m_phase_handler.scatter_jvp(wavel_threadidx, losidx, layeridx,
+                                            wavelidx, weights, is_entrance,
+                                            native_tangent, phase, phase_jvp);
+            } else {
+                phase = m_phase_handler.scatter_value(wavel_threadidx, losidx,
+                                                      layeridx, wavelidx,
+                                                      weights, is_entrance);
+                phase_jvp.setZero();
+            }
 
             const double scale = 1.0 / (EIGEN_PI * 4);
             const double amplitude = extinction * ssa * solar_trans * scale;
@@ -309,9 +335,11 @@ namespace sasktran2::solartransmission {
                 native_gradient(derivative.index()) -=
                     derivative.value() * solar_trans * solar_trans_cotangent;
             }
-            m_phase_handler.scatter_vjp(wavel_threadidx, losidx, layeridx,
-                                        wavelidx, weights, is_entrance,
-                                        amplitude * cotangent, native_gradient);
+            if (m_vjp_request.scattering) {
+                m_phase_handler.scatter_vjp(
+                    wavel_threadidx, losidx, layeridx, wavelidx, weights,
+                    is_entrance, amplitude * cotangent, native_gradient);
+            }
             return amplitude * phase;
         }
     }
@@ -321,7 +349,6 @@ namespace sasktran2::solartransmission {
         int wavelidx, int losidx, int wavel_threadidx, int threadidx,
         Eigen::Ref<const Eigen::VectorXd> native_tangent,
         sasktran2::RadianceJVP<NSTOKES>& source) const {
-        (void)threadidx;
         if constexpr (!std::is_same_v<S, SolarTransmissionExact>) {
             throw std::logic_error(
                 "Native JVP requires exact solar transmission");
@@ -413,15 +440,18 @@ namespace sasktran2::solartransmission {
                         solar_trans_cotangent;
                 }
             }
-            for (int derivative = 0;
-                 derivative < m_atmosphere->surface().num_deriv();
-                 ++derivative) {
-                const auto brdf_derivative = m_atmosphere->surface().d_brdf(
-                    wavelidx, mu_in, mu_out, phi_diff, derivative);
-                native_gradient(m_atmosphere->surface_deriv_start_index() +
-                                derivative) +=
-                    solar_trans * mu_in *
-                    cotangent.dot(brdf_derivative(Eigen::placeholders::all, 0));
+            if (m_vjp_request.surface) {
+                for (int derivative = 0;
+                     derivative < m_atmosphere->surface().num_deriv();
+                     ++derivative) {
+                    const auto brdf_derivative = m_atmosphere->surface().d_brdf(
+                        wavelidx, mu_in, mu_out, phi_diff, derivative);
+                    native_gradient(m_atmosphere->surface_deriv_start_index() +
+                                    derivative) +=
+                        solar_trans * mu_in *
+                        cotangent.dot(
+                            brdf_derivative(Eigen::placeholders::all, 0));
+                }
             }
         }
     }
@@ -1301,7 +1331,7 @@ namespace sasktran2::solartransmission {
 #define SASKTRAN2_INSTANTIATE_SINGLE_SCATTER_BLOCK(NSTOKES, BLOCK_SIZE)        \
     template void SingleScatterSource<SolarTransmissionExact, NSTOKES>::       \
         calculate_block<BLOCK_SIZE>(                                           \
-            const sasktran2::WavelengthBlock<BLOCK_SIZE>&, int);               \
+            const sasktran2::WavelengthBlock<BLOCK_SIZE>&, int, bool);         \
     template void SingleScatterSource<SolarTransmissionExact, NSTOKES>::       \
         end_of_ray_source_block<BLOCK_SIZE>(                                   \
             const sasktran2::WavelengthBlock<BLOCK_SIZE>&, int, int, int,      \

--- a/cpp/lib/successive_orders/first_order.cpp
+++ b/cpp/lib/successive_orders/first_order.cpp
@@ -426,6 +426,7 @@ namespace sasktran2::successive_orders {
         }
         m_atmosphere = nullptr;
         if (!m_use_compact_scalar) {
+            m_source.set_vjp_request(sasktran2::NativeVJPRequest{});
             m_source.initialize_atmosphere(atmosphere);
         }
         if (!m_use_compact_scalar) {
@@ -434,6 +435,7 @@ namespace sasktran2::successive_orders {
         for (auto& gradient : m_gradient_scratch) {
             gradient.resize(atmosphere.num_deriv(), 1);
         }
+        m_zero_native_tangent.setZero(atmosphere.num_deriv());
         if (m_use_compact_scalar) {
             const int coefficient_count =
                 atmosphere.storage().total_extinction.rows() *
@@ -545,6 +547,14 @@ namespace sasktran2::successive_orders {
             }
         }
         m_atmosphere = &atmosphere;
+    }
+
+    template <int NSTOKES>
+    void FirstOrderProvider<NSTOKES>::set_vjp_request(
+        const sasktran2::NativeVJPRequest& request) {
+        if (!m_use_compact_scalar) {
+            m_source.set_vjp_request(request);
+        }
     }
 
     template <int NSTOKES>
@@ -813,7 +823,8 @@ namespace sasktran2::successive_orders {
         const ScalarEndpoint& endpoint, double source_cotangent,
         Eigen::Ref<Eigen::VectorXd> native_gradient,
         Eigen::Ref<Eigen::VectorXd> solar_gradient,
-        Eigen::Ref<Eigen::VectorXd> coefficient_gradient) const {
+        Eigen::Ref<Eigen::VectorXd> coefficient_gradient,
+        bool accumulate_scattering) const {
         if (source_cotangent == 0.0) {
             return;
         }
@@ -841,14 +852,16 @@ namespace sasktran2::successive_orders {
             native_gradient(atmosphere_index) += weight * extinction_cotangent;
             native_gradient(m_atmosphere->ssa_deriv_start_index() +
                             atmosphere_index) += weight * albedo_cotangent;
-            const int order =
-                std::min(storage.max_order(atmosphere_index, wavelength),
-                         m_num_phase_moments);
-            const int coefficient_offset =
-                atmosphere_index * m_num_phase_moments;
-            const double coefficient_cotangent = weight * phase_cotangent;
-            phase_axpy(coefficient_cotangent, basis, order,
-                       coefficient_gradient.data() + coefficient_offset);
+            if (accumulate_scattering) {
+                const int order =
+                    std::min(storage.max_order(atmosphere_index, wavelength),
+                             m_num_phase_moments);
+                const int coefficient_offset =
+                    atmosphere_index * m_num_phase_moments;
+                const double coefficient_cotangent = weight * phase_cotangent;
+                phase_axpy(coefficient_cotangent, basis, order,
+                           coefficient_gradient.data() + coefficient_offset);
+            }
         }
         solar_gradient(solar_index) += solar_cotangent;
         (void)layer;
@@ -1710,27 +1723,32 @@ namespace sasktran2::successive_orders {
         Eigen::Ref<Eigen::VectorXd> native_gradient,
         const Eigen::VectorXd* transport_state,
         const Eigen::VectorXd* layer_state_projection,
-        const Eigen::VectorXd* ground_state_projection) {
+        const Eigen::VectorXd* ground_state_projection,
+        bool accumulate_scattering, bool accumulate_surface) {
         if (transport_state != nullptr || layer_state_projection != nullptr) {
             if (m_use_lower_interpolation) {
                 accumulate_scalar_vjp_impl<true, true>(
                     wavelength, wavelength_thread, forcing_cotangent,
                     native_gradient, transport_state, layer_state_projection,
-                    ground_state_projection);
+                    ground_state_projection, accumulate_scattering,
+                    accumulate_surface);
             } else {
                 accumulate_scalar_vjp_impl<true, false>(
                     wavelength, wavelength_thread, forcing_cotangent,
                     native_gradient, transport_state, layer_state_projection,
-                    ground_state_projection);
+                    ground_state_projection, accumulate_scattering,
+                    accumulate_surface);
             }
         } else if (m_use_lower_interpolation) {
             accumulate_scalar_vjp_impl<false, true>(
                 wavelength, wavelength_thread, forcing_cotangent,
-                native_gradient, nullptr, nullptr, nullptr);
+                native_gradient, nullptr, nullptr, nullptr,
+                accumulate_scattering, accumulate_surface);
         } else {
             accumulate_scalar_vjp_impl<false, false>(
                 wavelength, wavelength_thread, forcing_cotangent,
-                native_gradient, nullptr, nullptr, nullptr);
+                native_gradient, nullptr, nullptr, nullptr,
+                accumulate_scattering, accumulate_surface);
         }
     }
 
@@ -1742,7 +1760,8 @@ namespace sasktran2::successive_orders {
         Eigen::Ref<Eigen::VectorXd> native_gradient,
         const Eigen::VectorXd* transport_state,
         const Eigen::VectorXd* layer_state_projection,
-        const Eigen::VectorXd* ground_state_projection) {
+        const Eigen::VectorXd* ground_state_projection,
+        bool accumulate_scattering, bool accumulate_surface) {
         const int first_thread = wavelength_thread;
         const int last_thread = first_thread + m_num_source_threads;
         if (last_thread > static_cast<int>(m_gradient_scratch.size())) {
@@ -1752,7 +1771,9 @@ namespace sasktran2::successive_orders {
         for (int thread = first_thread; thread < last_thread; ++thread) {
             m_gradient_scratch[thread].setZero();
             m_solar_product_scratch[thread].setZero();
-            m_phase_product_scratch[thread].setZero();
+            if (accumulate_scattering) {
+                m_phase_product_scratch[thread].setZero();
+            }
         }
         const auto& rays = m_source_geometry->incoming_rays();
         const auto& interpolation = m_source_geometry->incoming_interpolation();
@@ -1903,16 +1924,19 @@ namespace sasktran2::successive_orders {
                     prefix_cotangent = forcing_gradient * ground_source;
                     solar_gradient(m_solar_offsets[ray]) +=
                         prefix * forcing_gradient * mu_in * brdf(0, 0);
-                    for (int derivative = 0;
-                         derivative < m_atmosphere->surface().num_deriv();
-                         ++derivative) {
-                        thread_gradient(
-                            m_atmosphere->surface_deriv_start_index() +
-                            derivative) += prefix * forcing_gradient *
-                                           solar(m_solar_offsets[ray]) * mu_in *
-                                           m_atmosphere->surface().d_brdf(
-                                               wavelength, mu_in, mu_out, phi,
-                                               derivative)(0, 0);
+                    if (accumulate_surface) {
+                        for (int derivative = 0;
+                             derivative < m_atmosphere->surface().num_deriv();
+                             ++derivative) {
+                            thread_gradient(
+                                m_atmosphere->surface_deriv_start_index() +
+                                derivative) += prefix * forcing_gradient *
+                                               solar(m_solar_offsets[ray]) *
+                                               mu_in *
+                                               m_atmosphere->surface().d_brdf(
+                                                   wavelength, mu_in, mu_out,
+                                                   phi, derivative)(0, 0);
+                        }
                     }
                 }
             }
@@ -2074,11 +2098,12 @@ namespace sasktran2::successive_orders {
                             wavelength, ray, layer, start_entrance,
                             exit_solar + 1, *start_weights, start,
                             start_cotangent, thread_gradient, solar_gradient,
-                            coefficient_gradient);
+                            coefficient_gradient, accumulate_scattering);
                         accumulate_scalar_endpoint_vjp(
                             wavelength, ray, layer, end_entrance, exit_solar,
                             *end_weights, end, end_cotangent, thread_gradient,
-                            solar_gradient, coefficient_gradient);
+                            solar_gradient, coefficient_gradient,
+                            accumulate_scattering);
                     }
                 }
                 layer_prefix_cotangent += prefix_cotangent * attenuation;
@@ -2100,7 +2125,8 @@ namespace sasktran2::successive_orders {
                         wavelength, ray, 0, false, m_solar_offsets[ray],
                         exit_weights, scratch.endpoints[0],
                         scratch.endpoint_cotangent(0), thread_gradient,
-                        solar_gradient, coefficient_gradient);
+                        solar_gradient, coefficient_gradient,
+                        accumulate_scattering);
                     for (int endpoint = 1; endpoint <= num_layers; ++endpoint) {
                         const auto entrance_weights =
                             traced_ray.entrance_weights(endpoint - 1);
@@ -2110,7 +2136,7 @@ namespace sasktran2::successive_orders {
                             scratch.endpoints[endpoint],
                             scratch.endpoint_cotangent(endpoint),
                             thread_gradient, solar_gradient,
-                            coefficient_gradient);
+                            coefficient_gradient, accumulate_scattering);
                     }
                 }
             }
@@ -2118,28 +2144,33 @@ namespace sasktran2::successive_orders {
 
         for (int thread = first_thread; thread < last_thread; ++thread) {
             auto thread_gradient = m_gradient_scratch[thread].col(0);
-            const auto& coefficient_gradient = m_phase_product_scratch[thread];
-            const int locations =
-                m_atmosphere->storage().total_extinction.rows();
-            for (int group = 0;
-                 group < m_atmosphere->num_scattering_deriv_groups(); ++group) {
-                const int native_offset =
-                    m_atmosphere->scat_deriv_start_index() + group * locations;
-                for (int location = 0; location < locations; ++location) {
-                    const int order =
-                        std::min(m_atmosphere->storage().d_max_order[group](
-                                     location, wavelength),
-                                 m_num_phase_moments);
-                    double value = 0.0;
-                    const int coefficient_offset =
-                        location * m_num_phase_moments;
-                    for (int degree = 0; degree < order; ++degree) {
-                        value +=
-                            coefficient_gradient(coefficient_offset + degree) *
-                            m_atmosphere->storage().d_leg_coeff(
-                                degree, location, wavelength, group);
+            if (accumulate_scattering) {
+                const auto& coefficient_gradient =
+                    m_phase_product_scratch[thread];
+                const int locations =
+                    m_atmosphere->storage().total_extinction.rows();
+                for (int group = 0;
+                     group < m_atmosphere->num_scattering_deriv_groups();
+                     ++group) {
+                    const int native_offset =
+                        m_atmosphere->scat_deriv_start_index() +
+                        group * locations;
+                    for (int location = 0; location < locations; ++location) {
+                        const int order =
+                            std::min(m_atmosphere->storage().d_max_order[group](
+                                         location, wavelength),
+                                     m_num_phase_moments);
+                        double value = 0.0;
+                        const int coefficient_offset =
+                            location * m_num_phase_moments;
+                        for (int degree = 0; degree < order; ++degree) {
+                            value += coefficient_gradient(coefficient_offset +
+                                                          degree) *
+                                     m_atmosphere->storage().d_leg_coeff(
+                                         degree, location, wavelength, group);
+                        }
+                        thread_gradient(native_offset + location) += value;
                     }
-                    thread_gradient(native_offset + location) += value;
                 }
             }
             auto& solar_gradient = m_solar_product_scratch[thread];
@@ -2271,7 +2302,8 @@ namespace sasktran2::successive_orders {
         int wavelength, int wavelength_thread,
         const Eigen::VectorXd& transport_state,
         Eigen::Ref<const Eigen::VectorXd> forcing_cotangent,
-        Eigen::Ref<Eigen::VectorXd> native_gradient) {
+        Eigen::Ref<Eigen::VectorXd> native_gradient, bool accumulate_scattering,
+        bool accumulate_surface) {
         validate_ready(wavelength, wavelength_thread);
         if (!m_use_compact_scalar || forcing_cotangent.size() != size() ||
             native_gradient.size() != m_atmosphere->num_deriv() ||
@@ -2282,7 +2314,8 @@ namespace sasktran2::successive_orders {
         }
         accumulate_scalar_vjp(wavelength, wavelength_thread, forcing_cotangent,
                               native_gradient, &transport_state, nullptr,
-                              nullptr);
+                              nullptr, accumulate_scattering,
+                              accumulate_surface);
     }
 
     template <int NSTOKES>
@@ -2291,7 +2324,8 @@ namespace sasktran2::successive_orders {
         const Eigen::VectorXd& layer_state_projection,
         const Eigen::VectorXd& ground_state_projection,
         Eigen::Ref<const Eigen::VectorXd> forcing_cotangent,
-        Eigen::Ref<Eigen::VectorXd> native_gradient) {
+        Eigen::Ref<Eigen::VectorXd> native_gradient, bool accumulate_scattering,
+        bool accumulate_surface) {
         validate_ready(wavelength, wavelength_thread);
         if (!m_use_compact_scalar || forcing_cotangent.size() != size() ||
             native_gradient.size() != m_atmosphere->num_deriv() ||
@@ -2304,7 +2338,8 @@ namespace sasktran2::successive_orders {
         }
         accumulate_scalar_vjp(wavelength, wavelength_thread, forcing_cotangent,
                               native_gradient, nullptr, &layer_state_projection,
-                              &ground_state_projection);
+                              &ground_state_projection, accumulate_scattering,
+                              accumulate_surface);
     }
 
     template <int NSTOKES>
@@ -2321,7 +2356,16 @@ namespace sasktran2::successive_orders {
             return;
         }
         const sasktran2::WavelengthBlock<> block{wavelength, 1};
-        m_source.calculate(block, wavelength_thread);
+        // This forcing is consumed only as a value. Calling the native JVP
+        // preparation with a zero direction suppresses the exact source's
+        // phase-derivative materialization, which otherwise scales with every
+        // atmospheric derivative even though it is discarded below.
+        if (m_atmosphere->num_deriv() == 0) {
+            m_source.calculate(block, wavelength_thread);
+        } else {
+            m_source.calculate_jvp(block, wavelength_thread,
+                                   m_zero_native_tangent);
+        }
 
 #pragma omp parallel for if (m_num_source_threads > 1)                         \
     num_threads(m_num_source_threads) schedule(dynamic)
@@ -2374,7 +2418,8 @@ namespace sasktran2::successive_orders {
     void FirstOrderProvider<NSTOKES>::accumulate_vjp(
         int wavelength, int wavelength_thread,
         Eigen::Ref<const Eigen::VectorXd> forcing_cotangent,
-        Eigen::Ref<Eigen::VectorXd> native_gradient) {
+        Eigen::Ref<Eigen::VectorXd> native_gradient, bool accumulate_scattering,
+        bool accumulate_surface) {
         validate_ready(wavelength, wavelength_thread);
         if (forcing_cotangent.size() != size() ||
             native_gradient.size() != m_atmosphere->num_deriv()) {
@@ -2387,7 +2432,8 @@ namespace sasktran2::successive_orders {
         if (m_use_compact_scalar) {
             accumulate_scalar_vjp(wavelength, wavelength_thread,
                                   forcing_cotangent, native_gradient, nullptr,
-                                  nullptr, nullptr);
+                                  nullptr, nullptr, accumulate_scattering,
+                                  accumulate_surface);
             return;
         }
         m_source.calculate_vjp(sasktran2::WavelengthBlock<>{wavelength, 1},

--- a/cpp/lib/successive_orders/first_order.h
+++ b/cpp/lib/successive_orders/first_order.h
@@ -31,6 +31,7 @@ namespace sasktran2::successive_orders {
         void initialize_geometry(const SourceGeometry1D& source_geometry);
         void initialize_atmosphere(
             const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere);
+        void set_vjp_request(const sasktran2::NativeVJPRequest& request);
 
         int size() const { return m_num_rays * NSTOKES; }
 
@@ -67,20 +68,24 @@ namespace sasktran2::successive_orders {
         /** Accumulates the VJP of the first-order radiance. */
         void accumulate_vjp(int wavelength, int wavelength_thread,
                             Eigen::Ref<const Eigen::VectorXd> forcing_cotangent,
-                            Eigen::Ref<Eigen::VectorXd> native_gradient);
+                            Eigen::Ref<Eigen::VectorXd> native_gradient,
+                            bool accumulate_scattering = true,
+                            bool accumulate_surface = true);
 
         void accumulate_vjp_with_transport(
             int wavelength, int wavelength_thread,
             const Eigen::VectorXd& transport_state,
             Eigen::Ref<const Eigen::VectorXd> forcing_cotangent,
-            Eigen::Ref<Eigen::VectorXd> native_gradient);
+            Eigen::Ref<Eigen::VectorXd> native_gradient,
+            bool accumulate_scattering = true, bool accumulate_surface = true);
 
         void accumulate_vjp_with_projected_transport(
             int wavelength, int wavelength_thread,
             const Eigen::VectorXd& layer_state_projection,
             const Eigen::VectorXd& ground_state_projection,
             Eigen::Ref<const Eigen::VectorXd> forcing_cotangent,
-            Eigen::Ref<Eigen::VectorXd> native_gradient);
+            Eigen::Ref<Eigen::VectorXd> native_gradient,
+            bool accumulate_scattering = true, bool accumulate_surface = true);
 
         std::size_t workspace_bytes() const;
 
@@ -185,7 +190,8 @@ namespace sasktran2::successive_orders {
             Eigen::Ref<Eigen::VectorXd> native_gradient,
             const Eigen::VectorXd* transport_state,
             const Eigen::VectorXd* layer_state_projection,
-            const Eigen::VectorXd* ground_state_projection);
+            const Eigen::VectorXd* ground_state_projection,
+            bool accumulate_scattering, bool accumulate_surface);
         template <bool WITH_TRANSPORT, bool LOWER_INTERPOLATION>
         void accumulate_scalar_vjp_impl(
             int wavelength, int wavelength_thread,
@@ -193,7 +199,8 @@ namespace sasktran2::successive_orders {
             Eigen::Ref<Eigen::VectorXd> native_gradient,
             const Eigen::VectorXd* transport_state,
             const Eigen::VectorXd* layer_state_projection,
-            const Eigen::VectorXd* ground_state_projection);
+            const Eigen::VectorXd* ground_state_projection,
+            bool accumulate_scattering, bool accumulate_surface);
 
         ScalarEndpoint scalar_endpoint(
             int wavelength, int ray, int layer, bool entrance, int solar_index,
@@ -212,7 +219,8 @@ namespace sasktran2::successive_orders {
             const ScalarEndpoint& endpoint, double source_cotangent,
             Eigen::Ref<Eigen::VectorXd> native_gradient,
             Eigen::Ref<Eigen::VectorXd> solar_gradient,
-            Eigen::Ref<Eigen::VectorXd> coefficient_gradient) const;
+            Eigen::Ref<Eigen::VectorXd> coefficient_gradient,
+            bool accumulate_scattering) const;
 
         const sasktran2::Geometry1D& m_geometry;
         ExactSource m_source;
@@ -244,6 +252,7 @@ namespace sasktran2::successive_orders {
         mutable std::vector<sasktran2::WavelengthBlockDual<NSTOKES>>
             m_primal_scratch;
         mutable std::vector<Eigen::MatrixXd> m_gradient_scratch;
+        Eigen::VectorXd m_zero_native_tangent;
         mutable std::vector<
             Eigen::Matrix<double, NSTOKES, Eigen::Dynamic, Eigen::RowMajor>>
             m_vjp_radiance_scratch;

--- a/cpp/lib/successive_orders/scattering_assembler.cpp
+++ b/cpp/lib/successive_orders/scattering_assembler.cpp
@@ -437,7 +437,8 @@ namespace sasktran2::successive_orders {
         const sasktran2::atmosphere::Atmosphere<1>& atmosphere, int wavelength,
         Eigen::Ref<const Eigen::MatrixXd> atmospheric_coefficient_gradient,
         Eigen::Ref<const Eigen::VectorXd> ground_value_gradient,
-        Eigen::Ref<Eigen::VectorXd> native_gradient) const {
+        Eigen::Ref<Eigen::VectorXd> native_gradient, bool accumulate_scattering,
+        bool accumulate_surface) const {
         validate_atmosphere(atmosphere, wavelength);
         validate_native_product(atmosphere, native_gradient.size());
         if (atmospheric_coefficient_gradient.rows() !=
@@ -452,36 +453,43 @@ namespace sasktran2::successive_orders {
             return;
         }
 
-        const auto& storage = atmosphere.storage();
-        const int locations = storage.total_extinction.rows();
-        for (int point_index = 0;
-             point_index < m_geometry->num_interior_points(); ++point_index) {
-            for (const auto& weight :
-                 m_geometry->source_point(point_index).atmosphere_weights()) {
-                for (int group = 0;
-                     group < atmosphere.num_scattering_deriv_groups();
-                     ++group) {
-                    double value = 0.0;
-                    const double delta_m_scale = delta_m_derivative_scale(
-                        storage, weight.index, wavelength, group);
-                    for (int degree = 0;
-                         degree < m_angular_basis->num_coefficients();
-                         ++degree) {
-                        const double coefficient_derivative =
-                            storage.d_leg_coeff(degree, weight.index,
-                                                wavelength, group) -
-                            (2.0 * degree + 1.0) * delta_m_scale;
-                        value += atmospheric_coefficient_gradient(point_index,
-                                                                  degree) *
-                                 weight.weight * coefficient_derivative;
+        if (accumulate_scattering) {
+            const auto& storage = atmosphere.storage();
+            const int locations = storage.total_extinction.rows();
+            for (int point_index = 0;
+                 point_index < m_geometry->num_interior_points();
+                 ++point_index) {
+                for (const auto& weight : m_geometry->source_point(point_index)
+                                              .atmosphere_weights()) {
+                    for (int group = 0;
+                         group < atmosphere.num_scattering_deriv_groups();
+                         ++group) {
+                        double value = 0.0;
+                        const double delta_m_scale = delta_m_derivative_scale(
+                            storage, weight.index, wavelength, group);
+                        for (int degree = 0;
+                             degree < m_angular_basis->num_coefficients();
+                             ++degree) {
+                            const double coefficient_derivative =
+                                storage.d_leg_coeff(degree, weight.index,
+                                                    wavelength, group) -
+                                (2.0 * degree + 1.0) * delta_m_scale;
+                            value += atmospheric_coefficient_gradient(
+                                         point_index, degree) *
+                                     weight.weight * coefficient_derivative;
+                        }
+                        native_gradient(atmosphere.scat_deriv_start_index() +
+                                        group * locations + weight.index) +=
+                            value;
                     }
-                    native_gradient(atmosphere.scat_deriv_start_index() +
-                                    group * locations + weight.index) += value;
                 }
             }
         }
+
         for (int ground_index = 0;
-             ground_index < m_geometry->num_ground_points(); ++ground_index) {
+             accumulate_surface &&
+             ground_index < m_geometry->num_ground_points();
+             ++ground_index) {
             const auto& angular = m_ground_geometry[ground_index];
             const int rows = static_cast<int>(angular.mu_out.size());
             const int columns = static_cast<int>(angular.mu_in.size());
@@ -811,7 +819,8 @@ namespace sasktran2::successive_orders {
         const sasktran2::atmosphere::Atmosphere<3>& atmosphere, int wavelength,
         Eigen::Ref<const Eigen::MatrixXd> atmospheric_coefficient_gradient,
         Eigen::Ref<const Eigen::VectorXd> ground_value_gradient,
-        Eigen::Ref<Eigen::VectorXd> native_gradient) const {
+        Eigen::Ref<Eigen::VectorXd> native_gradient, bool accumulate_scattering,
+        bool accumulate_surface) const {
         validate_atmosphere(atmosphere, wavelength);
         validate_native_product(atmosphere, native_gradient.size());
         if (atmospheric_coefficient_gradient.rows() !=
@@ -826,40 +835,49 @@ namespace sasktran2::successive_orders {
             return;
         }
 
-        const auto& storage = atmosphere.storage();
-        const int locations = storage.total_extinction.rows();
-        for (int point_index = 0;
-             point_index < m_geometry->num_interior_points(); ++point_index) {
-            for (const auto& weight :
-                 m_geometry->source_point(point_index).atmosphere_weights()) {
-                for (int group = 0;
-                     group < atmosphere.num_scattering_deriv_groups();
-                     ++group) {
-                    double value = 0.0;
-                    const double delta_m_scale = delta_m_derivative_scale(
-                        storage, weight.index, wavelength, group);
-                    for (int coefficient = 0;
-                         coefficient < atmospheric_coefficient_gradient.cols();
-                         ++coefficient) {
-                        const int degree = coefficient / 4;
-                        const double delta_m_correction =
-                            delta_m_corrects_vector_component(coefficient)
-                                ? (2.0 * degree + 1.0) * delta_m_scale
-                                : 0.0;
-                        value += atmospheric_coefficient_gradient(point_index,
-                                                                  coefficient) *
-                                 weight.weight *
-                                 (storage.d_leg_coeff(coefficient, weight.index,
-                                                      wavelength, group) -
-                                  delta_m_correction);
+        if (accumulate_scattering) {
+            const auto& storage = atmosphere.storage();
+            const int locations = storage.total_extinction.rows();
+            for (int point_index = 0;
+                 point_index < m_geometry->num_interior_points();
+                 ++point_index) {
+                for (const auto& weight : m_geometry->source_point(point_index)
+                                              .atmosphere_weights()) {
+                    for (int group = 0;
+                         group < atmosphere.num_scattering_deriv_groups();
+                         ++group) {
+                        double value = 0.0;
+                        const double delta_m_scale = delta_m_derivative_scale(
+                            storage, weight.index, wavelength, group);
+                        for (int coefficient = 0;
+                             coefficient <
+                             atmospheric_coefficient_gradient.cols();
+                             ++coefficient) {
+                            const int degree = coefficient / 4;
+                            const double delta_m_correction =
+                                delta_m_corrects_vector_component(coefficient)
+                                    ? (2.0 * degree + 1.0) * delta_m_scale
+                                    : 0.0;
+                            value +=
+                                atmospheric_coefficient_gradient(point_index,
+                                                                 coefficient) *
+                                weight.weight *
+                                (storage.d_leg_coeff(coefficient, weight.index,
+                                                     wavelength, group) -
+                                 delta_m_correction);
+                        }
+                        native_gradient(atmosphere.scat_deriv_start_index() +
+                                        group * locations + weight.index) +=
+                            value;
                     }
-                    native_gradient(atmosphere.scat_deriv_start_index() +
-                                    group * locations + weight.index) += value;
                 }
             }
         }
+
         for (int ground_index = 0;
-             ground_index < m_geometry->num_ground_points(); ++ground_index) {
+             accumulate_surface &&
+             ground_index < m_geometry->num_ground_points();
+             ++ground_index) {
             const auto& angular = m_ground_geometry[ground_index];
             const int rows = static_cast<int>(angular.mu_out.size());
             const int columns = static_cast<int>(angular.mu_in.size());

--- a/cpp/lib/successive_orders/scattering_assembler.h
+++ b/cpp/lib/successive_orders/scattering_assembler.h
@@ -52,7 +52,9 @@ namespace sasktran2::successive_orders {
             int wavelength,
             Eigen::Ref<const Eigen::MatrixXd> atmospheric_coefficient_gradient,
             Eigen::Ref<const Eigen::VectorXd> ground_value_gradient,
-            Eigen::Ref<Eigen::VectorXd> native_gradient) const;
+            Eigen::Ref<Eigen::VectorXd> native_gradient,
+            bool accumulate_scattering = true,
+            bool accumulate_surface = true) const;
 
         std::size_t storage_bytes() const;
 
@@ -127,7 +129,9 @@ namespace sasktran2::successive_orders {
             int wavelength,
             Eigen::Ref<const Eigen::MatrixXd> atmospheric_coefficient_gradient,
             Eigen::Ref<const Eigen::VectorXd> ground_value_gradient,
-            Eigen::Ref<Eigen::VectorXd> native_gradient) const;
+            Eigen::Ref<Eigen::VectorXd> native_gradient,
+            bool accumulate_scattering = true,
+            bool accumulate_surface = true) const;
 
         std::size_t storage_bytes() const;
 

--- a/cpp/lib/successive_orders/source.cpp
+++ b/cpp/lib/successive_orders/source.cpp
@@ -48,6 +48,8 @@ namespace sasktran2::successive_orders {
             Eigen::Ref<const Eigen::VectorXd> native_tangent) override;
         void calculate_vjp(const sasktran2::WavelengthBlock<>& block,
                            int threadidx) override;
+        void
+        set_vjp_request(const sasktran2::NativeVJPRequest& request) override;
         void finalize_vjp(
             const sasktran2::WavelengthBlock<>& block, int threadidx,
             Eigen::Ref<Eigen::MatrixXd> native_gradient) const override;
@@ -168,10 +170,12 @@ namespace sasktran2::successive_orders {
         accumulate_vjp(const Assembler& assembler,
                        const sasktran2::atmosphere::Atmosphere<1>& atmosphere,
                        int wavelength, const ProblemParameterData<1>& gradient,
-                       Eigen::Ref<Eigen::VectorXd> native_gradient) {
+                       Eigen::Ref<Eigen::VectorXd> native_gradient,
+                       const sasktran2::NativeVJPRequest& request) {
             assembler.accumulate_vjp(atmosphere, wavelength,
                                      gradient.atmospheric_coefficients,
-                                     gradient.ground_values, native_gradient);
+                                     gradient.ground_values, native_gradient,
+                                     request.scattering, request.surface);
         }
     };
 
@@ -193,10 +197,12 @@ namespace sasktran2::successive_orders {
         accumulate_vjp(const Assembler& assembler,
                        const sasktran2::atmosphere::Atmosphere<3>& atmosphere,
                        int wavelength, const ProblemParameterData<3>& gradient,
-                       Eigen::Ref<Eigen::VectorXd> native_gradient) {
+                       Eigen::Ref<Eigen::VectorXd> native_gradient,
+                       const sasktran2::NativeVJPRequest& request) {
             assembler.accumulate_vjp(atmosphere, wavelength,
                                      gradient.atmospheric_coefficients,
-                                     gradient.ground_values, native_gradient);
+                                     gradient.ground_values, native_gradient,
+                                     request.scattering, request.surface);
         }
     };
 
@@ -291,6 +297,11 @@ namespace sasktran2::successive_orders {
             m_solver_settings.validate();
             m_geometry_settings.validate();
             m_first_order.initialize_config(config);
+        }
+
+        void set_vjp_request(const sasktran2::NativeVJPRequest& request) {
+            m_vjp_request = request;
+            m_first_order.set_vjp_request(request);
         }
 
         void initialize_geometry(
@@ -472,7 +483,8 @@ namespace sasktran2::successive_orders {
             auto gradient = native_gradient.col(0);
             warn_if_implicit_derivative_is_unchecked(m_solver_settings,
                                                      block.start, "VJP");
-            reverse(block.start, threadidx, work, work.los_cotangent, gradient);
+            reverse(block.start, threadidx, work, work.los_cotangent, gradient,
+                    m_vjp_request);
         }
 
         void start_of_ray_source(
@@ -696,6 +708,7 @@ namespace sasktran2::successive_orders {
         void reverse(int wavelength, int threadidx, WavelengthState& work,
                      Eigen::Ref<const Eigen::VectorXd> los_cotangent,
                      Eigen::Ref<Eigen::VectorXd> native_gradient,
+                     const sasktran2::NativeVJPRequest& request,
                      bool emit_convergence_warning = true) {
             work.los_transport.template apply_vjp_stokes<NSTOKES>(
                 work.state, los_cotangent, work.state_cotangent,
@@ -717,22 +730,24 @@ namespace sasktran2::successive_orders {
                     native_gradient, work.transport_vjp_workspace);
             }
             Adapter::accumulate_vjp(*m_scattering_assembler, *m_atmosphere,
-                                    wavelength, work.gradient, native_gradient);
+                                    wavelength, work.gradient, native_gradient,
+                                    request);
             if (m_first_order.uses_compact_scalar_kernel()) {
                 if (work.transport_state_projected) {
                     m_first_order.accumulate_vjp_with_projected_transport(
                         wavelength, threadidx, work.layer_state_projection,
                         work.ground_state_projection, work.gradient.forcing,
-                        native_gradient);
+                        native_gradient, request.scattering, request.surface);
                 } else {
                     m_first_order.accumulate_vjp_with_transport(
                         wavelength, threadidx, work.state,
-                        work.gradient.forcing, native_gradient);
+                        work.gradient.forcing, native_gradient,
+                        request.scattering, request.surface);
                 }
             } else {
-                m_first_order.accumulate_vjp(wavelength, threadidx,
-                                             work.gradient.forcing,
-                                             native_gradient);
+                m_first_order.accumulate_vjp(
+                    wavelength, threadidx, work.gradient.forcing,
+                    native_gradient, request.scattering, request.surface);
             }
         }
 
@@ -743,6 +758,7 @@ namespace sasktran2::successive_orders {
             work.jacobian.resize(outputs, derivatives);
             work.los_cotangent.setZero();
             Eigen::VectorXd native_gradient(derivatives);
+            const sasktran2::NativeVJPRequest full_request;
             if (m_first_order.uses_compact_scalar_kernel() &&
                 !work.transport_state_projected) {
                 m_first_order.project_transport_state(
@@ -754,7 +770,7 @@ namespace sasktran2::successive_orders {
                 work.los_cotangent(output) = 1.0;
                 native_gradient.setZero();
                 reverse(wavelength, threadidx, work, work.los_cotangent,
-                        native_gradient, output == 0);
+                        native_gradient, full_request, output == 0);
                 work.jacobian.row(output) = native_gradient.transpose();
                 work.los_cotangent(output) = 0.0;
             }
@@ -769,6 +785,7 @@ namespace sasktran2::successive_orders {
         }
 
         const sasktran2::Config* m_config = nullptr;
+        sasktran2::NativeVJPRequest m_vjp_request;
         const Atmosphere* m_atmosphere = nullptr;
         std::uint64_t m_atmosphere_instance_id = 0;
         std::uint64_t m_atmosphere_revision = 0;
@@ -845,6 +862,12 @@ namespace sasktran2::successive_orders {
     void SuccessiveOrdersSource<NSTOKES>::calculate_vjp(
         const sasktran2::WavelengthBlock<>& block, int threadidx) {
         m_impl->calculate_vjp(block, threadidx);
+    }
+
+    template <int NSTOKES>
+    void SuccessiveOrdersSource<NSTOKES>::set_vjp_request(
+        const sasktran2::NativeVJPRequest& request) {
+        m_impl->set_vjp_request(request);
     }
 
     template <int NSTOKES>

--- a/tests/engine/test_linearization.py
+++ b/tests/engine/test_linearization.py
@@ -509,6 +509,16 @@ def test_engine_native_products_match_materialized_jacobian():
     xr.testing.assert_allclose(lin.jvp(tangent), expected_jvp)
 
     cotangent = xr.ones_like(lin.value) * 1.7
+    selected_gradient = lin.vjp(cotangent, parameters=("extinction", "ssa"))
+    xr.testing.assert_allclose(
+        selected_gradient["extinction"],
+        (lin.jacobian["extinction"] * cotangent).sum(lin.value.dims),
+    )
+    xr.testing.assert_allclose(
+        selected_gradient["ssa"],
+        (lin.jacobian["ssa"] * cotangent).sum(lin.value.dims),
+    )
+
     gradient = lin.vjp(cotangent)
     xr.testing.assert_allclose(
         gradient["extinction"],


### PR DESCRIPTION
## Summary

- derive a two-bit native VJP request for scattering and surface parameters from registered output mappings
- let sources consume that request while preserving full-work defaults
- avoid exact-single-scatter phase and surface derivative work when the output cannot consume it
- apply the same selective gates inside the private SuccessiveOrdersCpp reverse path
- use native-product atmosphere initialization for exact single scattering

## Scope

This PR is based on the source-only PR #285. It contains no configuration, documentation, caching, C API, Rust, or Rayon scheduling changes. The engine change is only four lines that propagate the output request to sources.

## Validation

- project build passed
- 45 focused Python linearization and SuccessiveOrdersCpp tests passed
- C++ successive-orders suite: 44 cases and 975 assertions passed
- C++ linearization suite: 10 cases and 322 assertions passed
- pre-commit passed