### PR TITLE
Release 2026.8.0

### DIFF
--- a/rust/sasktran2-py-ext/Cargo.toml
+++ b/rust/sasktran2-py-ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core_rust"
-version = "2026.6.0"
+version = "2026.8.0"
 edition = "2024"
 
 [lib]


### PR DESCRIPTION
## Summary

- bump the Rust Python extension crate from 2026.6.0 to 2026.8.0
- leave all other package versions unchanged

## Validation

- whitespace validation passed
- tests not run (metadata-only release change)