### PR TITLE
Add 2D successive-orders source support

### DIFF
--- a/asv_bench/benchmarks/successive_orders_2d.py
+++ b/asv_bench/benchmarks/successive_orders_2d.py
@@ -18,19 +18,15 @@ NUM_LOS_VERTICAL = 60
 NUM_ANGULAR = 110
 NUM_THREADS = 1
 
-ATMOSPHERE_HORIZONTAL_ANGLES_RAD = np.linspace(
-    -0.4, 0.4, NUM_ATMOSPHERE_HORIZONTAL
+ATMOSPHERE_HORIZONTAL_ANGLES_RAD = np.linspace(-0.4, 0.4, NUM_ATMOSPHERE_HORIZONTAL)
+ATMOSPHERE_ALTITUDES_M = np.linspace(0.0, TOP_ALTITUDE_M, NUM_ATMOSPHERE_VERTICAL)
+SOURCE_ALTITUDES_M = (np.arange(NUM_SOURCE_VERTICAL, dtype=np.float64) + 0.5) * (
+    TOP_ALTITUDE_M / NUM_SOURCE_VERTICAL
 )
-ATMOSPHERE_ALTITUDES_M = np.linspace(
-    0.0, TOP_ALTITUDE_M, NUM_ATMOSPHERE_VERTICAL
-)
-SOURCE_ALTITUDES_M = (
-    np.arange(NUM_SOURCE_VERTICAL, dtype=np.float64) + 0.5
-) * (TOP_ALTITUDE_M / NUM_SOURCE_VERTICAL)
 LOS_HORIZONTAL_ANGLES_RAD = np.linspace(-0.2, 0.2, NUM_LOS_HORIZONTAL)
-LOS_TANGENT_ALTITUDES_M = (
-    np.arange(NUM_LOS_VERTICAL, dtype=np.float64) + 0.5
-) * (TOP_ALTITUDE_M / NUM_LOS_VERTICAL)
+LOS_TANGENT_ALTITUDES_M = (np.arange(NUM_LOS_VERTICAL, dtype=np.float64) + 0.5) * (
+    TOP_ALTITUDE_M / NUM_LOS_VERTICAL
+)
 
 
 class SuccessiveOrders2DRepeatedVJP:
@@ -115,9 +111,9 @@ class SuccessiveOrders2DRepeatedVJP:
         self._engine = sk.Engine(config, geometry, viewing)
         self._linearization = self._engine.linearize(atmosphere)
         self._cotangent = xr.ones_like(self._linearization.value)
-        self._cotangent.data[:] = np.linspace(
-            0.5, 1.5, self._cotangent.size
-        ).reshape(self._cotangent.shape)
+        self._cotangent.data[:] = np.linspace(0.5, 1.5, self._cotangent.size).reshape(
+            self._cotangent.shape
+        )
         self._update_index = 0
 
     def _change_atmosphere(self):
@@ -132,9 +128,7 @@ class SuccessiveOrders2DRepeatedVJP:
         self._atmosphere.mark_changed()
 
     def time_vjp_repeated_same_atmosphere(self):
-        self._linearization.vjp(
-            self._cotangent, parameters=("extinction", "ssa")
-        )
+        self._linearization.vjp(self._cotangent, parameters=("extinction", "ssa"))
 
     def time_linearize_changed_atmosphere(self):
         self._change_atmosphere()
@@ -143,9 +137,7 @@ class SuccessiveOrders2DRepeatedVJP:
     def time_linearize_and_vjp_changed_atmosphere(self):
         self._change_atmosphere()
         self._linearization = self._engine.linearize(self._atmosphere)
-        self._linearization.vjp(
-            self._cotangent, parameters=("extinction", "ssa")
-        )
+        self._linearization.vjp(self._cotangent, parameters=("extinction", "ssa"))
 
     def peakmem_retained_linearization(self):
         pass
@@ -153,6 +145,4 @@ class SuccessiveOrders2DRepeatedVJP:
     def peakmem_vjp_changed_atmosphere(self):
         self._change_atmosphere()
         self._linearization = self._engine.linearize(self._atmosphere)
-        self._linearization.vjp(
-            self._cotangent, parameters=("extinction", "ssa")
-        )
+        self._linearization.vjp(self._cotangent, parameters=("extinction", "ssa"))

--- a/asv_bench/benchmarks/successive_orders_2d.py
+++ b/asv_bench/benchmarks/successive_orders_2d.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import numpy as np
+import sasktran2 as sk
+import xarray as xr
+
+from . import _skip_slow
+
+EARTH_RADIUS_M = 6_372_000.0
+TOP_ALTITUDE_M = 80_000.0
+
+NUM_ATMOSPHERE_HORIZONTAL = 40
+NUM_ATMOSPHERE_VERTICAL = 80
+NUM_SOURCE_HORIZONTAL = 5
+NUM_SOURCE_VERTICAL = 25
+NUM_LOS_HORIZONTAL = 40
+NUM_LOS_VERTICAL = 60
+NUM_ANGULAR = 110
+NUM_THREADS = 1
+
+ATMOSPHERE_HORIZONTAL_ANGLES_RAD = np.linspace(
+    -0.4, 0.4, NUM_ATMOSPHERE_HORIZONTAL
+)
+ATMOSPHERE_ALTITUDES_M = np.linspace(
+    0.0, TOP_ALTITUDE_M, NUM_ATMOSPHERE_VERTICAL
+)
+SOURCE_ALTITUDES_M = (
+    np.arange(NUM_SOURCE_VERTICAL, dtype=np.float64) + 0.5
+) * (TOP_ALTITUDE_M / NUM_SOURCE_VERTICAL)
+LOS_HORIZONTAL_ANGLES_RAD = np.linspace(-0.2, 0.2, NUM_LOS_HORIZONTAL)
+LOS_TANGENT_ALTITUDES_M = (
+    np.arange(NUM_LOS_VERTICAL, dtype=np.float64) + 0.5
+) * (TOP_ALTITUDE_M / NUM_LOS_VERTICAL)
+
+
+class SuccessiveOrders2DRepeatedVJP:
+    """Large 2D source-grid workload with repeated atmosphere updates."""
+
+    timeout = 1200
+    number = 1
+    repeat = 3
+    warmup_time = 0
+
+    def setup(self):
+        _skip_slow()
+
+        config = sk.Config()
+        config.num_threads = NUM_THREADS
+        config.log_level = sk.LogLevel.Error
+        config.num_stokes = 1
+        config.num_streams = 4
+        config.num_singlescatter_moments = 4
+        config.single_scatter_source = sk.SingleScatterSource.NoSource
+        config.multiple_scatter_source = sk.MultipleScatterSource.SuccessiveOrders
+        config.occultation_source = sk.OccultationSource.NoSource
+        config.emission_source = sk.EmissionSource.NoSource
+        config.num_sza = NUM_SOURCE_HORIZONTAL
+        config.successive_orders_altitude_grid_m = SOURCE_ALTITUDES_M
+        config.num_successive_orders_incoming = NUM_ANGULAR
+        config.num_successive_orders_outgoing = NUM_ANGULAR
+        config.delta_m_scaling = False
+
+        geometry = sk.Geometry2D(
+            cos_sza=0.6,
+            solar_azimuth=0.0,
+            earth_radius_m=EARTH_RADIUS_M,
+            altitude_grid_m=ATMOSPHERE_ALTITUDES_M,
+            horizontal_angle_grid_radians=ATMOSPHERE_HORIZONTAL_ANGLES_RAD,
+        )
+        viewing = sk.ViewingGeometry()
+        for horizontal_angle in LOS_HORIZONTAL_ANGLES_RAD:
+            for tangent_altitude_m in LOS_TANGENT_ALTITUDES_M:
+                viewing.add_ray(
+                    sk.TangentAltitude(
+                        tangent_altitude_m=tangent_altitude_m,
+                        observer_altitude_m=200_000.0,
+                        horizontal_angle_radians=horizontal_angle,
+                        viewing_azimuth_radians=0.0,
+                    )
+                )
+
+        atmosphere = sk.Atmosphere(
+            geometry,
+            config,
+            wavelengths_nm=np.array([600.0]),
+            calculate_derivatives=True,
+            pressure_derivative=False,
+            temperature_derivative=False,
+            specific_humidity_derivative=False,
+            legendre_derivative=False,
+        )
+        horizontal, altitude = np.meshgrid(
+            ATMOSPHERE_HORIZONTAL_ANGLES_RAD,
+            ATMOSPHERE_ALTITUDES_M,
+            indexing="ij",
+        )
+        self._base_extinction = (
+            1.5e-5
+            * np.exp(-altitude / 18_000.0)
+            * (1.0 + 0.2 * np.sin(2.0 * np.pi * horizontal / 0.8))
+        ).reshape(-1, 1)
+        self._base_ssa = (
+            0.92
+            - 0.12 * altitude / TOP_ALTITUDE_M
+            + 0.02 * np.cos(2.0 * np.pi * horizontal / 0.8)
+        ).reshape(-1, 1)
+        atmosphere.storage.total_extinction[:] = self._base_extinction
+        atmosphere.storage.ssa[:] = self._base_ssa
+        atmosphere.leg_coeff.a1[0] = 1.0
+        atmosphere.leg_coeff.a1[2] = 0.3
+        atmosphere.surface.albedo[:] = 0.1
+        atmosphere.mark_changed()
+
+        self._atmosphere = atmosphere
+        self._engine = sk.Engine(config, geometry, viewing)
+        self._linearization = self._engine.linearize(atmosphere)
+        self._cotangent = xr.ones_like(self._linearization.value)
+        self._cotangent.data[:] = np.linspace(
+            0.5, 1.5, self._cotangent.size
+        ).reshape(self._cotangent.shape)
+        self._update_index = 0
+
+    def _change_atmosphere(self):
+        self._update_index += 1
+        sign = 1.0 if self._update_index % 2 else -1.0
+        self._atmosphere.storage.total_extinction[:] = self._base_extinction * (
+            1.0 + sign * 0.01
+        )
+        self._atmosphere.storage.ssa[:] = np.clip(
+            self._base_ssa + sign * 0.002, 0.0, 1.0
+        )
+        self._atmosphere.mark_changed()
+
+    def time_vjp_repeated_same_atmosphere(self):
+        self._linearization.vjp(
+            self._cotangent, parameters=("extinction", "ssa")
+        )
+
+    def time_linearize_changed_atmosphere(self):
+        self._change_atmosphere()
+        self._linearization = self._engine.linearize(self._atmosphere)
+
+    def time_linearize_and_vjp_changed_atmosphere(self):
+        self._change_atmosphere()
+        self._linearization = self._engine.linearize(self._atmosphere)
+        self._linearization.vjp(
+            self._cotangent, parameters=("extinction", "ssa")
+        )
+
+    def peakmem_retained_linearization(self):
+        pass
+
+    def peakmem_vjp_changed_atmosphere(self):
+        self._change_atmosphere()
+        self._linearization = self._engine.linearize(self._atmosphere)
+        self._linearization.vjp(
+            self._cotangent, parameters=("extinction", "ssa")
+        )

--- a/cpp/c_api/geometry.cpp
+++ b/cpp/c_api/geometry.cpp
@@ -138,7 +138,17 @@ int sk_geometry2d_get_horizontal_angles(const Geometry2D* geometry,
 }
 
 int sk_geometry2d_get_refractive_index_ptr(const Geometry2D* geometry,
-                                           double** refractive_index) {
+                                           const double** refractive_index) {
+    if (geometry == nullptr || refractive_index == nullptr) {
+        return -1;
+    }
+    const auto& values = geometry->impl->refractive_index();
+    *refractive_index = values.data();
+    return 0;
+}
+
+int sk_geometry2d_get_refractive_index_mut_ptr(Geometry2D* geometry,
+                                               double** refractive_index) {
     if (geometry == nullptr || refractive_index == nullptr) {
         return -1;
     }

--- a/cpp/c_api/geometry.cpp
+++ b/cpp/c_api/geometry.cpp
@@ -137,6 +137,16 @@ int sk_geometry2d_get_horizontal_angles(const Geometry2D* geometry,
     return 0;
 }
 
+int sk_geometry2d_get_refractive_index_ptr(const Geometry2D* geometry,
+                                           double** refractive_index) {
+    if (geometry == nullptr || refractive_index == nullptr) {
+        return -1;
+    }
+    auto& values = geometry->impl->refractive_index();
+    *refractive_index = values.data();
+    return 0;
+}
+
 int sk_geometry2d_get_location_index(const Geometry2D* geometry,
                                      int altitude_index, int horizontal_index,
                                      int* location_index) {

--- a/cpp/include/c_api/geometry.h
+++ b/cpp/include/c_api/geometry.h
@@ -39,7 +39,10 @@ int sk_geometry2d_get_horizontal_angles(const Geometry2D* geometry,
                                         double* horizontal_angles);
 
 int sk_geometry2d_get_refractive_index_ptr(const Geometry2D* geometry,
-                                           double** refractive_index);
+                                           const double** refractive_index);
+
+int sk_geometry2d_get_refractive_index_mut_ptr(Geometry2D* geometry,
+                                               double** refractive_index);
 
 int sk_geometry2d_get_location_index(const Geometry2D* geometry,
                                      int altitude_index, int horizontal_index,

--- a/cpp/include/c_api/geometry.h
+++ b/cpp/include/c_api/geometry.h
@@ -38,6 +38,9 @@ int sk_geometry2d_get_altitudes(const Geometry2D* geometry, double* altitudes);
 int sk_geometry2d_get_horizontal_angles(const Geometry2D* geometry,
                                         double* horizontal_angles);
 
+int sk_geometry2d_get_refractive_index_ptr(const Geometry2D* geometry,
+                                           double** refractive_index);
+
 int sk_geometry2d_get_location_index(const Geometry2D* geometry,
                                      int altitude_index, int horizontal_index,
                                      int* location_index);

--- a/cpp/include/sasktran2/config.h
+++ b/cpp/include/sasktran2/config.h
@@ -27,8 +27,8 @@ namespace sasktran2 {
          * 'exact' causes solar rays to be traced for each integration point
          * along the line of sight
          *
-         * 'solartable' Creates a solar transmission table at a set of grid
-         * points.  NOT YET IMPLEMENTED.
+         * 'solartable' creates a solar transmission table at a set of grid
+         * points and interpolates it to the line-of-sight integration points.
          *
          * 'discrete_ordinates' Lets the discrete ordinates solution include the
          * single scatter term.  Only has an effect in Plane Parallel or

--- a/cpp/include/sasktran2/engine.h
+++ b/cpp/include/sasktran2/engine.h
@@ -126,7 +126,7 @@ template <int NSTOKES> class Sasktran2 : public Sasktran2Interface {
         initialize();
     }
 
-    /** Constructs the transmission-only structured 2D model. */
+    /** Constructs the structured 2D model. */
     Sasktran2(const sasktran2::Config& config,
               const sasktran2::Geometry2D* geometry,
               const sasktran2::viewinggeometry::ViewingGeometryContainer&

--- a/cpp/include/sasktran2/geometry.h
+++ b/cpp/include/sasktran2/geometry.h
@@ -371,6 +371,7 @@ namespace sasktran2 {
       private:
         const grids::AltitudeGrid m_alt_grid;
         const Eigen::VectorXd m_horizontal_angles;
+        Eigen::VectorXd m_refractive_index;
 
       public:
         Geometry2D(double cos_sza, double saa, double earth_radius,
@@ -389,6 +390,14 @@ namespace sasktran2 {
         const Eigen::VectorXd& horizontal_angle_grid() const {
             return m_horizontal_angles;
         }
+
+        /** Altitude-only refractive-index profile used by solar rays. The 2D
+         * extinction field remains horizontally varying, while refraction is
+         * currently required to be spherically symmetric. */
+        const Eigen::VectorXd& refractive_index() const {
+            return m_refractive_index;
+        }
+        Eigen::VectorXd& refractive_index() { return m_refractive_index; }
 
         int num_atmosphere_dimensions() const override { return 2; }
         int size() const override;

--- a/cpp/include/sasktran2/math/unitsphere.h
+++ b/cpp/include/sasktran2/math/unitsphere.h
@@ -34,8 +34,6 @@ namespace sasktran2::math {
         double m_quadrature_normalization;
 
         std::vector<int> m_contributing_map;
-        std::vector<int> m_reverse_contributing_map;
-        std::vector<bool> m_is_full_sphere_looking_up;
 
       public:
         UnitSphereGround(std::unique_ptr<const UnitSphere>&& sphere,

--- a/cpp/include/sasktran2/math/unitsphere.h
+++ b/cpp/include/sasktran2/math/unitsphere.h
@@ -34,6 +34,8 @@ namespace sasktran2::math {
         double m_quadrature_normalization;
 
         std::vector<int> m_contributing_map;
+        std::vector<int> m_reverse_contributing_map;
+        std::vector<bool> m_is_full_sphere_looking_up;
 
       public:
         UnitSphereGround(std::unique_ptr<const UnitSphere>&& sphere,

--- a/cpp/include/sasktran2/raytracing.h
+++ b/cpp/include/sasktran2/raytracing.h
@@ -999,6 +999,11 @@ namespace sasktran2::raytracing {
             const sasktran2::viewinggeometry::ViewingRay& ray,
             TracedRay& tracedray) const;
 
+        void trace_ray_optical_depth(
+            const sasktran2::viewinggeometry::ViewingRay& ray,
+            const Eigen::VectorXd& refractive_index,
+            TracedRay& tracedray) const;
+
         void trace_ray(const sasktran2::viewinggeometry::ViewingRay& ray,
                        const Eigen::VectorXd& refractive_index,
                        TracedRay& tracedray) const;

--- a/cpp/include/sasktran2/raytracing.h
+++ b/cpp/include/sasktran2/raytracing.h
@@ -991,8 +991,9 @@ namespace sasktran2::raytracing {
 
     /** Standalone Rust structured-2D ray tracer.
      *
-     * The refractive-index overload accepts one altitude-only profile for this
-     * ray. Profiles are not stored on Geometry2D and may differ between calls.
+     * The refractive-index overload accepts an explicit altitude-only profile
+     * for this ray. It is deliberately separate from Geometry2D's stored solar
+     * refractive-index profile so callers can choose which rays are bent.
      */
     class RustRayTracer2D {
       public:

--- a/cpp/include/sasktran2/raytracing.h
+++ b/cpp/include/sasktran2/raytracing.h
@@ -197,6 +197,19 @@ namespace sasktran2::raytracing {
             return grid_weight_indices.size();
         }
 
+        /** Transfers the integrated optical-depth stencil out of this ray.
+         * All endpoint stencil views are invalidated. This is intended for
+         * construction-time conversion to a smaller runtime representation. */
+        void release_optical_depth_storage(std::vector<int>& indices,
+                                           std::vector<double>& weights) {
+            indices = std::move(grid_weight_indices);
+            weights = std::move(integrated_od_weights);
+            entrance_grid_weights.clear();
+            entrance_grid_weights.shrink_to_fit();
+            exit_grid_weights.clear();
+            exit_grid_weights.shrink_to_fit();
+        }
+
         /** Appends one layer's common node list and three aligned weight lists.
          *
          * The caller defines the node order and must use the same order in all

--- a/cpp/include/sasktran2/raytracing.h
+++ b/cpp/include/sasktran2/raytracing.h
@@ -989,6 +989,16 @@ namespace sasktran2::raytracing {
         void trace_ray(const sasktran2::viewinggeometry::ViewingRay& ray,
                        TracedRay& tracedray) const;
 
+        /** Trace only the integrated atmosphere-grid optical-depth stencil.
+         *
+         * Endpoint geometry and solar-angle metadata are omitted. This is used
+         * while constructing exact solar-transmission matrices, whose consumer
+         * reads only `TracedRay::optical_depth_weights()`.
+         */
+        void trace_ray_optical_depth(
+            const sasktran2::viewinggeometry::ViewingRay& ray,
+            TracedRay& tracedray) const;
+
         void trace_ray(const sasktran2::viewinggeometry::ViewingRay& ray,
                        const Eigen::VectorXd& refractive_index,
                        TracedRay& tracedray) const;
@@ -996,7 +1006,8 @@ namespace sasktran2::raytracing {
       private:
         void trace_ray_impl(const sasktran2::viewinggeometry::ViewingRay& ray,
                             const Eigen::VectorXd* refractive_index,
-                            TracedRay& tracedray) const;
+                            TracedRay& tracedray,
+                            bool optical_depth_only) const;
 
         const sasktran2::Geometry2D& m_geometry;
         std::unique_ptr<RustRayTracer2DImpl> m_impl;

--- a/cpp/include/sasktran2/raytracing_rust_bridge.h
+++ b/cpp/include/sasktran2/raytracing_rust_bridge.h
@@ -16,5 +16,6 @@ namespace sasktran2::rust::raytracer {
     void prepare_trace_result_2d(CppTraceResult2D& result,
                                  const RustTraceSummary& summary);
     void set_trace_layer_2d(CppTraceResult2D& result, std::size_t index,
-                            const RustTraceLayer& layer);
+                            const RustTraceLayer& layer,
+                            bool optical_depth_only);
 } // namespace sasktran2::rust::raytracer

--- a/cpp/include/sasktran2/solartransmission.h
+++ b/cpp/include/sasktran2/solartransmission.h
@@ -319,8 +319,7 @@ namespace sasktran2::solartransmission {
         std::size_t storage_bytes() const;
     };
 
-    /** Geometry-only solar optical-depth table used by the compact scalar
-     * successive-orders source.
+    /** Geometry-only solar optical-depth table shared by source terms.
      *
      * Implementations may use a conventional geometry matrix or a
      * characteristic sweep. The latter stores only incremental path stencils,
@@ -1059,6 +1058,7 @@ namespace sasktran2::solartransmission {
         std::shared_ptr<S> m_solar_transmission;
 #ifdef SKTRAN_RUST_SUPPORT
         std::shared_ptr<SolarTransmissionTable2D> m_shared_solar_table_2d;
+        const sasktran2::raytracing::RustRayTracer2D* m_raytracer_2d = nullptr;
 #endif
         const sasktran2::atmosphere::Atmosphere<NSTOKES>* m_atmosphere;
 
@@ -1207,14 +1207,10 @@ namespace sasktran2::solartransmission {
             : m_solar_transmission(
                   make_2d_transmission(geometry, raytracer, shared_table)),
               m_shared_solar_table_2d(std::move(shared_table)),
-              m_geometry(geometry), m_geometry_2d(&geometry),
-              m_phase_handler(geometry) {
+              m_raytracer_2d(&raytracer), m_geometry(geometry),
+              m_geometry_2d(&geometry), m_phase_handler(geometry) {
             if constexpr (compact_2d_table) {
                 m_shared_solar_table_2d = m_solar_transmission;
-            } else if (m_shared_solar_table_2d == nullptr) {
-                m_shared_solar_table_2d =
-                    std::make_shared<SolarTransmissionTable2D>(geometry,
-                                                               raytracer);
             }
             initialize_fixed_dispatch();
         };

--- a/cpp/include/sasktran2/solartransmission.h
+++ b/cpp/include/sasktran2/solartransmission.h
@@ -691,6 +691,9 @@ namespace sasktran2::solartransmission {
         std::vector<sasktran2::raytracing::LayerGeometry> m_los_end_layers;
 
         void initialize_active_derivative_indices();
+        void initialize_atmosphere_impl(
+            const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere,
+            bool materialized_derivative_storage);
 
         void initialize_fixed_dispatch() {
             if constexpr (std::is_same_v<S, SolarTransmissionExact>) {
@@ -768,6 +771,9 @@ namespace sasktran2::solartransmission {
          *
          */
         void initialize_atmosphere(
+            const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere)
+            override;
+        void initialize_atmosphere_native(
             const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere)
             override;
 

--- a/cpp/include/sasktran2/solartransmission.h
+++ b/cpp/include/sasktran2/solartransmission.h
@@ -280,6 +280,79 @@ namespace sasktran2::solartransmission {
         }
     };
 
+    /** Compact row-major interpolation from solar-table nodes to ray
+     * endpoints.
+     *
+     * The rows are assembled in order and normally contain at most eight
+     * entries for a three-dimensional table. Keeping the construction in CSR
+     * form avoids the large temporary triplet list required by Eigen's sparse
+     * matrix builder for the hundreds of thousands of endpoints used by the
+     * successive-orders source.
+     */
+    class SolarTableInterpolation {
+      private:
+        std::vector<std::uint32_t> m_outer;
+        std::vector<std::uint32_t> m_inner;
+        std::vector<double> m_values;
+        Eigen::Index m_rows = 0;
+        Eigen::Index m_cols = 0;
+        Eigen::Index m_next_row = 0;
+
+      public:
+        void clear();
+        void initialize(Eigen::Index rows, Eigen::Index cols,
+                        Eigen::Index capacity);
+        void append_row(
+            const std::vector<std::pair<int, double>>& interpolation_weights);
+        void finalize();
+
+        Eigen::Index rows() const { return m_rows; }
+        Eigen::Index cols() const { return m_cols; }
+        Eigen::Index non_zeros() const {
+            return static_cast<Eigen::Index>(m_values.size());
+        }
+
+        void apply(Eigen::Ref<const Eigen::VectorXd> table_values,
+                   Eigen::Ref<Eigen::VectorXd> endpoint_values) const;
+        void apply_transpose(Eigen::Ref<const Eigen::VectorXd> endpoint_values,
+                             Eigen::Ref<Eigen::VectorXd> table_values) const;
+        std::size_t storage_bytes() const;
+    };
+
+    /** Geometry-only solar optical-depth table used by the compact scalar
+     * successive-orders source.
+     *
+     * Implementations may use a conventional geometry matrix or a
+     * characteristic sweep. The latter stores only incremental path stencils,
+     * which is substantially smaller than materializing cumulative
+     * atmosphere-to-sun rows at every source-ray endpoint.
+     */
+    class SolarTransmissionTableEvaluator {
+      public:
+        virtual ~SolarTransmissionTableEvaluator() = default;
+
+        virtual void initialize_config(const sasktran2::Config& config) = 0;
+        virtual void
+        initialize_geometry(const std::vector<sasktran2::raytracing::TracedRay>&
+                                integration_rays) = 0;
+        virtual void generate_interpolation(
+            const std::vector<sasktran2::raytracing::TracedRay>& rays,
+            SolarTableInterpolation& interpolator,
+            std::vector<bool>& ground_hit_flag,
+            std::vector<Eigen::Vector3d>* solar_propagation_directions =
+                nullptr) const = 0;
+
+        virtual Eigen::Index table_size() const = 0;
+        virtual Eigen::Index atmosphere_size() const = 0;
+        virtual void apply(Eigen::Ref<const Eigen::VectorXd> extinction,
+                           Eigen::Ref<Eigen::VectorXd> table_od) const = 0;
+        virtual void
+        accumulate_transpose(Eigen::Ref<const Eigen::VectorXd> table_cotangent,
+                             Eigen::Ref<Eigen::VectorXd> extinction_cotangent,
+                             double scale) const = 0;
+        virtual std::size_t storage_bytes() const = 0;
+    };
+
     class SolarTransmissionBase {
       protected:
         const Geometry& m_geometry;
@@ -335,10 +408,17 @@ namespace sasktran2::solartransmission {
             const std::vector<sasktran2::raytracing::TracedRay>& rays,
             SolarGeometryMatrix& od_matrix,
             std::vector<bool>& ground_hit_flag) const;
+
+        void generate_refracted_geometry_matrix(
+            const std::vector<sasktran2::raytracing::TracedRay>& rays,
+            const std::vector<Eigen::Vector3d>& solar_propagation_directions,
+            SolarGeometryMatrix& od_matrix,
+            std::vector<bool>& ground_hit_flag) const;
 #endif
     };
 
-    class SolarTransmissionTable : public SolarTransmissionExact {
+    class SolarTransmissionTable : public SolarTransmissionExact,
+                                   public SolarTransmissionTableEvaluator {
       private:
         std::unique_ptr<sasktran2::grids::SourceLocationInterpolator>
             m_location_interpolator;
@@ -366,10 +446,78 @@ namespace sasktran2::solartransmission {
             Eigen::SparseMatrix<double, Eigen::RowMajor>& interpolator,
             std::vector<bool>& ground_hit_flag) const;
 
+        void generate_interpolation(
+            const std::vector<sasktran2::raytracing::TracedRay>& rays,
+            SolarTableInterpolation& interpolator,
+            std::vector<bool>& ground_hit_flag,
+            std::vector<Eigen::Vector3d>* solar_propagation_directions =
+                nullptr) const override;
+        Eigen::Index table_size() const override {
+            return m_geometry_matrix.rows();
+        }
+        Eigen::Index atmosphere_size() const override {
+            return m_geometry_matrix.cols();
+        }
+        void apply(Eigen::Ref<const Eigen::VectorXd> extinction,
+                   Eigen::Ref<Eigen::VectorXd> table_od) const override;
+        void
+        accumulate_transpose(Eigen::Ref<const Eigen::VectorXd> table_cotangent,
+                             Eigen::Ref<Eigen::VectorXd> extinction_cotangent,
+                             double scale) const override;
+        std::size_t storage_bytes() const override;
+
         const Eigen::MatrixXd& geometry_matrix() const {
             return m_geometry_matrix;
         }
     };
+
+#ifdef SKTRAN_RUST_SUPPORT
+    /** Three-dimensional solar optical-depth table for a structured 2D
+     * atmosphere.
+     *
+     * Table locations are parameterized by altitude, solar zenith angle, and
+     * azimuth around the solar axis. Parallel rays are launched at the
+     * top-of-atmosphere chord and traced inward. Each ray stores only the
+     * incremental 2D cell-basis stencils; optical depth is accumulated by a
+     * forward sweep and its VJP by the corresponding reverse sweep.
+     */
+    class SolarTransmissionTable2D final
+        : public SolarTransmissionTableEvaluator {
+      private:
+        class Impl;
+        std::unique_ptr<Impl> m_impl;
+
+      public:
+        SolarTransmissionTable2D(
+            const Geometry2D& geometry,
+            const sasktran2::raytracing::RustRayTracer2D& raytracer);
+        ~SolarTransmissionTable2D() override;
+
+        void initialize_config(const sasktran2::Config& config) override;
+        void
+        initialize_geometry(const std::vector<sasktran2::raytracing::TracedRay>&
+                                integration_rays) override;
+        void generate_interpolation(
+            const std::vector<sasktran2::raytracing::TracedRay>& rays,
+            SolarTableInterpolation& interpolator,
+            std::vector<bool>& ground_hit_flag,
+            std::vector<Eigen::Vector3d>* solar_propagation_directions =
+                nullptr) const override;
+        void generate_solar_geometry(
+            const std::vector<sasktran2::raytracing::TracedRay>& rays,
+            std::vector<bool>& ground_hit_flag,
+            std::vector<Eigen::Vector3d>& solar_propagation_directions) const;
+        Eigen::Index table_size() const override;
+        Eigen::Index atmosphere_size() const override;
+        void apply(Eigen::Ref<const Eigen::VectorXd> extinction,
+                   Eigen::Ref<Eigen::VectorXd> table_od) const override;
+        void
+        accumulate_transpose(Eigen::Ref<const Eigen::VectorXd> table_cotangent,
+                             Eigen::Ref<Eigen::VectorXd> extinction_cotangent,
+                             double scale) const override;
+        std::size_t storage_bytes() const override;
+    };
+#endif
 
     /**
      * The PhaseHandler is responsible for constructing the phase function for
@@ -468,7 +616,9 @@ namespace sasktran2::solartransmission {
          */
         void initialize_geometry(
             const std::vector<sasktran2::raytracing::TracedRay>& los_rays,
-            const std::vector<std::vector<int>>& index_map);
+            const std::vector<std::vector<int>>& index_map,
+            const std::vector<Eigen::Vector3d>* solar_propagation_directions =
+                nullptr);
 
         /**
          *   Calculates the phase function from the legendre coefficients at the
@@ -561,7 +711,8 @@ namespace sasktran2::solartransmission {
 
         void initialize_geometry_impl(
             const std::vector<sasktran2::raytracing::TracedRay>& los_rays,
-            const std::vector<std::vector<int>>& index_map);
+            const std::vector<std::vector<int>>& index_map,
+            const std::vector<Eigen::Vector3d>* solar_propagation_directions);
 
         const int* geometry_internal_indices(int losidx, int layeridx,
                                              bool is_entrance) const {
@@ -894,7 +1045,21 @@ namespace sasktran2::solartransmission {
     template <typename S, int NSTOKES>
     class SingleScatterSource : public SourceTermInterface<NSTOKES> {
       private:
-        S m_solar_transmission;
+        static constexpr bool exact_transmission =
+            std::is_same_v<S, SolarTransmissionExact>;
+#ifdef SKTRAN_RUST_SUPPORT
+        static constexpr bool compact_2d_table =
+            std::is_same_v<S, SolarTransmissionTable2D>;
+#else
+        static constexpr bool compact_2d_table = false;
+#endif
+        static constexpr bool native_transmission_linearization =
+            exact_transmission || compact_2d_table;
+
+        std::shared_ptr<S> m_solar_transmission;
+#ifdef SKTRAN_RUST_SUPPORT
+        std::shared_ptr<SolarTransmissionTable2D> m_shared_solar_table_2d;
+#endif
         const sasktran2::atmosphere::Atmosphere<NSTOKES>* m_atmosphere;
 
         Eigen::MatrixXd m_geometry_matrix;
@@ -905,6 +1070,13 @@ namespace sasktran2::solartransmission {
         using RowMajorMatrix = Eigen::Matrix<double, Eigen::Dynamic,
                                              Eigen::Dynamic, Eigen::RowMajor>;
         std::vector<RowMajorMatrix> m_solar_trans_batch;
+        SolarTableInterpolation m_solar_interpolation;
+        std::vector<Eigen::Vector3d> m_solar_propagation_directions;
+        std::vector<Eigen::VectorXd> m_solar_table_product;
+        std::vector<Eigen::VectorXd> m_solar_trans_jvp;
+        mutable std::vector<Eigen::VectorXd> m_solar_endpoint_cotangent;
+        mutable Eigen::VectorXd m_solar_endpoint_cotangent_sum;
+        mutable Eigen::VectorXd m_solar_table_cotangent;
         int m_wavelength_batch_capacity = 1;
         std::vector<int> m_active_wavelength_block_start;
         std::vector<int> m_active_wavelength_block_count;
@@ -974,32 +1146,76 @@ namespace sasktran2::solartransmission {
 
         Eigen::Vector<double, NSTOKES> endpoint_source_vjp(
             int wavelidx, int losidx, int layeridx, int wavel_threadidx,
-            int solar_index,
+            int threadidx, int solar_index,
             const sasktran2::raytracing::GridWeightStencilView& weights,
             bool is_entrance, const Eigen::Vector<double, NSTOKES>& cotangent,
             Eigen::Ref<Eigen::VectorXd> native_gradient) const;
 
         double solar_transmission_value(int wavelidx, int threadidx,
                                         int solar_index) const;
+        double solar_transmission_tangent(
+            int wavelidx, int threadidx, int solar_index,
+            Eigen::Ref<const Eigen::VectorXd> native_tangent) const;
+        bool ground_scattering_geometry(int losidx, double& mu_in,
+                                        double& mu_out, double& phi_diff) const;
+
+#ifdef SKTRAN_RUST_SUPPORT
+        static std::shared_ptr<S> make_2d_transmission(
+            const Geometry2D& geometry,
+            const sasktran2::raytracing::RustRayTracer2D& raytracer,
+            const std::shared_ptr<SolarTransmissionTable2D>& shared_table) {
+            if constexpr (compact_2d_table) {
+                return shared_table != nullptr
+                           ? shared_table
+                           : std::make_shared<SolarTransmissionTable2D>(
+                                 geometry, raytracer);
+            } else {
+                if constexpr (exact_transmission) {
+                    return std::make_shared<S>(geometry, raytracer);
+                } else {
+                    return {};
+                }
+            }
+        }
+#endif
 
       public:
+        template <
+            typename T = S,
+            std::enable_if_t<std::is_same_v<T, SolarTransmissionExact> ||
+                                 std::is_same_v<T, SolarTransmissionTable>,
+                             int> = 0>
         SingleScatterSource(
             const Geometry1D& geometry,
             const sasktran2::raytracing::RayTracerBase& raytracer)
-            : m_solar_transmission(geometry, raytracer), m_geometry(geometry),
-              m_geometry_1d(&geometry), m_phase_handler(geometry) {
+            : m_solar_transmission(std::make_shared<S>(geometry, raytracer)),
+              m_geometry(geometry), m_geometry_1d(&geometry),
+              m_phase_handler(geometry) {
             initialize_fixed_dispatch();
         };
 
 #ifdef SKTRAN_RUST_SUPPORT
-        template <typename T = S,
-                  std::enable_if_t<std::is_same_v<T, SolarTransmissionExact>,
-                                   int> = 0>
+        template <
+            typename T = S,
+            std::enable_if_t<std::is_same_v<T, SolarTransmissionExact> ||
+                                 std::is_same_v<T, SolarTransmissionTable2D>,
+                             int> = 0>
         SingleScatterSource(
             const Geometry2D& geometry,
-            const sasktran2::raytracing::RustRayTracer2D& raytracer)
-            : m_solar_transmission(geometry, raytracer), m_geometry(geometry),
-              m_geometry_2d(&geometry), m_phase_handler(geometry) {
+            const sasktran2::raytracing::RustRayTracer2D& raytracer,
+            std::shared_ptr<SolarTransmissionTable2D> shared_table = nullptr)
+            : m_solar_transmission(
+                  make_2d_transmission(geometry, raytracer, shared_table)),
+              m_shared_solar_table_2d(std::move(shared_table)),
+              m_geometry(geometry), m_geometry_2d(&geometry),
+              m_phase_handler(geometry) {
+            if constexpr (compact_2d_table) {
+                m_shared_solar_table_2d = m_solar_transmission;
+            } else if (m_shared_solar_table_2d == nullptr) {
+                m_shared_solar_table_2d =
+                    std::make_shared<SolarTransmissionTable2D>(geometry,
+                                                               raytracer);
+            }
             initialize_fixed_dispatch();
         };
 #endif
@@ -1059,7 +1275,7 @@ namespace sasktran2::solartransmission {
       public:
         void calculate(const sasktran2::WavelengthBlock<>& block,
                        int threadidx) override {
-            if constexpr (std::is_same_v<S, SolarTransmissionExact>) {
+            if constexpr (exact_transmission) {
                 sasktran2::dispatch_wavelength_block(
                     block, [&](const auto& fixed_block) {
                         if constexpr (std::decay_t<
@@ -1078,6 +1294,15 @@ namespace sasktran2::solartransmission {
                 calculate_single(block.start, threadidx);
             }
         }
+
+        void calculate_jvp(
+            const sasktran2::WavelengthBlock<>& block, int threadidx,
+            Eigen::Ref<const Eigen::VectorXd> native_tangent) override;
+        void calculate_vjp(const sasktran2::WavelengthBlock<>& block,
+                           int threadidx) override;
+        void finalize_vjp(
+            const sasktran2::WavelengthBlock<>& block, int threadidx,
+            Eigen::Ref<Eigen::MatrixXd> native_gradient) const override;
 
         /** Calculates the integrated source term for a given layer.
          *
@@ -1201,13 +1426,18 @@ namespace sasktran2::solartransmission {
         }
 
         bool supports_sparse_derivative_tracking() const override {
-            return std::is_same_v<S, SolarTransmissionExact>;
+            return exact_transmission;
         }
 
         bool supports_linearization(
             sasktran2::LinearizationMode mode) const override {
-            return mode == sasktran2::LinearizationMode::Jacobian ||
-                   std::is_same_v<S, SolarTransmissionExact>;
+            if constexpr (exact_transmission) {
+                return true;
+            }
+            if constexpr (compact_2d_table) {
+                return mode != sasktran2::LinearizationMode::Jacobian;
+            }
+            return mode == sasktran2::LinearizationMode::Jacobian;
         }
 
         void end_of_ray_source_jvp(

--- a/cpp/include/sasktran2/solartransmission.h
+++ b/cpp/include/sasktran2/solartransmission.h
@@ -8,6 +8,8 @@
 #include <sasktran2/config.h>
 #include <sasktran2/dual.h>
 #include <array>
+#include <cstdint>
+#include <limits>
 
 namespace sasktran2::solartransmission {
     /** Generates one row of what is known as the geometry matrix.  The optical
@@ -32,6 +34,251 @@ namespace sasktran2::solartransmission {
             }
         }
     }
+
+    /** Row-major solar geometry storage with a compact exact-2D mode.
+     *
+     * Exact 2D calculations commonly have hundreds of thousands of rows but
+     * only a few thousand atmosphere columns. Eigen uses the same index type
+     * for both dimensions, so its inner indices remain 32 bit. The compact
+     * mode keeps row offsets as size_t while storing column indices as uint16.
+     * Grids wider than the compact index range transparently use Eigen's
+     * standard sparse representation.
+     */
+    class SolarGeometryMatrix {
+      public:
+        using StandardMatrix = Eigen::SparseMatrix<double, Eigen::RowMajor>;
+
+        class InnerIterator {
+          private:
+            const double* m_values = nullptr;
+            const std::uint16_t* m_compact_indices = nullptr;
+            const int* m_standard_indices = nullptr;
+            std::size_t m_position = 0;
+            std::size_t m_end = 0;
+
+          public:
+            InnerIterator(const SolarGeometryMatrix& matrix, Eigen::Index row) {
+                if (matrix.m_compact) {
+                    m_position = matrix.m_compact_outer[row];
+                    m_end = matrix.m_compact_outer[row + 1];
+                    m_values = matrix.m_compact_values.data();
+                    m_compact_indices = matrix.m_compact_inner.data();
+                } else {
+                    const auto* outer = matrix.m_standard.outerIndexPtr();
+                    m_position = static_cast<std::size_t>(outer[row]);
+                    const auto* inner_nonzeros =
+                        matrix.m_standard.innerNonZeroPtr();
+                    m_end = inner_nonzeros == nullptr
+                                ? static_cast<std::size_t>(outer[row + 1])
+                                : m_position + static_cast<std::size_t>(
+                                                   inner_nonzeros[row]);
+                    m_values = matrix.m_standard.valuePtr();
+                    m_standard_indices = matrix.m_standard.innerIndexPtr();
+                }
+            }
+
+            explicit operator bool() const { return m_position < m_end; }
+            InnerIterator& operator++() {
+                ++m_position;
+                return *this;
+            }
+            Eigen::Index index() const {
+                return m_compact_indices == nullptr
+                           ? m_standard_indices[m_position]
+                           : m_compact_indices[m_position];
+            }
+            double value() const { return m_values[m_position]; }
+        };
+
+      private:
+        StandardMatrix m_standard;
+        std::vector<double> m_compact_values;
+        std::vector<std::uint16_t> m_compact_inner;
+        std::vector<std::size_t> m_compact_outer;
+        Eigen::Index m_compact_rows = 0;
+        Eigen::Index m_compact_cols = 0;
+        bool m_compact = false;
+
+        void reserve_capacity(Eigen::Index capacity) {
+            if (m_compact) {
+                m_compact_values.reserve(static_cast<std::size_t>(capacity));
+                m_compact_inner.reserve(static_cast<std::size_t>(capacity));
+            } else {
+                auto& storage = m_standard.data();
+                storage.reserve(capacity - storage.size());
+            }
+        }
+
+      public:
+        StandardMatrix& use_standard() {
+            m_compact = false;
+            std::vector<double>().swap(m_compact_values);
+            std::vector<std::uint16_t>().swap(m_compact_inner);
+            std::vector<std::size_t>().swap(m_compact_outer);
+            m_compact_rows = 0;
+            m_compact_cols = 0;
+            return m_standard;
+        }
+
+        const StandardMatrix& standard() const { return m_standard; }
+
+        void initialize_exact(Eigen::Index rows, Eigen::Index cols,
+                              Eigen::Index initial_capacity) {
+            m_compact = cols <= static_cast<Eigen::Index>(
+                                    std::numeric_limits<std::uint16_t>::max()) +
+                                    1;
+            if (!m_compact) {
+                auto& standard = use_standard();
+                standard.resize(rows, cols);
+                standard.reserve(initial_capacity);
+                return;
+            }
+
+            m_standard = StandardMatrix{};
+            m_compact_rows = rows;
+            m_compact_cols = cols;
+            m_compact_values.clear();
+            m_compact_inner.clear();
+            m_compact_outer.assign(static_cast<std::size_t>(rows) + 1, 0);
+            reserve_capacity(initial_capacity);
+        }
+
+        void ensure_capacity(Eigen::Index additional) {
+            const Eigen::Index required = non_zeros() + additional;
+            const Eigen::Index allocated = allocated_size();
+            if (required <= allocated) {
+                return;
+            }
+            const Eigen::Index grown = allocated + allocated / 2;
+            reserve_capacity(std::max(required, grown));
+        }
+
+        void start_row(Eigen::Index row) {
+            if (m_compact) {
+                m_compact_outer[row] = m_compact_values.size();
+            } else {
+                m_standard.startVec(row);
+            }
+        }
+
+        void insert_back(Eigen::Index row, Eigen::Index column, double value) {
+            if (m_compact) {
+                m_compact_inner.push_back(static_cast<std::uint16_t>(column));
+                m_compact_values.push_back(value);
+            } else {
+                m_standard.insertBackByOuterInner(row, column) = value;
+            }
+        }
+
+        void finalize() {
+            if (m_compact) {
+                m_compact_outer[m_compact_rows] = m_compact_values.size();
+            } else {
+                m_standard.finalize();
+                m_standard.data().squeeze();
+            }
+        }
+
+        Eigen::Index rows() const {
+            return m_compact ? m_compact_rows : m_standard.rows();
+        }
+        Eigen::Index cols() const {
+            return m_compact ? m_compact_cols : m_standard.cols();
+        }
+        Eigen::Index non_zeros() const {
+            return m_compact
+                       ? static_cast<Eigen::Index>(m_compact_values.size())
+                       : m_standard.nonZeros();
+        }
+        Eigen::Index allocated_size() const {
+            return m_compact
+                       ? static_cast<Eigen::Index>(m_compact_values.capacity())
+                       : m_standard.data().allocatedSize();
+        }
+        Eigen::Index row_nonzeros(Eigen::Index row) const {
+            if (m_compact) {
+                return static_cast<Eigen::Index>(m_compact_outer[row + 1] -
+                                                 m_compact_outer[row]);
+            }
+            return m_standard.innerVector(row).nonZeros();
+        }
+        bool is_compact() const { return m_compact; }
+
+        template <typename Vector>
+        double row_dot(Eigen::Index row, const Vector& vector) const {
+            double result = 0.0;
+            if (m_compact) {
+                const auto begin = m_compact_outer[row];
+                const auto end = m_compact_outer[row + 1];
+                for (std::size_t position = begin; position < end; ++position) {
+                    result += m_compact_values[position] *
+                              vector(m_compact_inner[position]);
+                }
+                return result;
+            }
+
+            for (StandardMatrix::InnerIterator entry(m_standard, row); entry;
+                 ++entry) {
+                result += entry.value() * vector(entry.index());
+            }
+            return result;
+        }
+
+        template <typename Vector>
+        void accumulate_row(Eigen::Index row, double scale,
+                            Vector& vector) const {
+            if (m_compact) {
+                const auto begin = m_compact_outer[row];
+                const auto end = m_compact_outer[row + 1];
+                for (std::size_t position = begin; position < end; ++position) {
+                    vector(m_compact_inner[position]) +=
+                        scale * m_compact_values[position];
+                }
+                return;
+            }
+
+            for (StandardMatrix::InnerIterator entry(m_standard, row); entry;
+                 ++entry) {
+                vector(entry.index()) += scale * entry.value();
+            }
+        }
+
+        template <typename Rhs, typename Destination>
+        void multiply(const Rhs& rhs, Destination& destination) const {
+            if (!m_compact) {
+                destination.noalias() = m_standard * rhs;
+                return;
+            }
+
+            if (rhs.cols() == 1) {
+                for (Eigen::Index row = 0; row < m_compact_rows; ++row) {
+                    double result = 0.0;
+                    const auto begin = m_compact_outer[row];
+                    const auto end = m_compact_outer[row + 1];
+                    for (std::size_t position = begin; position < end;
+                         ++position) {
+                        result += m_compact_values[position] *
+                                  rhs(m_compact_inner[position], 0);
+                    }
+                    destination(row, 0) = result;
+                }
+                return;
+            }
+
+            destination.setZero();
+            for (Eigen::Index row = 0; row < m_compact_rows; ++row) {
+                const auto begin = m_compact_outer[row];
+                const auto end = m_compact_outer[row + 1];
+                for (std::size_t position = begin; position < end; ++position) {
+                    const auto column = m_compact_inner[position];
+                    const double value = m_compact_values[position];
+                    for (Eigen::Index lane = 0; lane < rhs.cols(); ++lane) {
+                        destination(row, lane) += value * rhs(column, lane);
+                    }
+                }
+            }
+        }
+    };
 
     class SolarTransmissionBase {
       protected:
@@ -86,7 +333,7 @@ namespace sasktran2::solartransmission {
 
         void generate_geometry_matrix(
             const std::vector<sasktran2::raytracing::TracedRay>& rays,
-            Eigen::SparseMatrix<double, Eigen::RowMajor>& od_matrix,
+            SolarGeometryMatrix& od_matrix,
             std::vector<bool>& ground_hit_flag) const;
 #endif
     };
@@ -147,7 +394,7 @@ namespace sasktran2::solartransmission {
      * m_internal_to_cos_scatter.  This combination lets us calculate the phase
      * function.  But to actually use it, we need to map the entrance and exit
      * points of the ray to the internal indices.  This is done through the
-     * m_geometry_entrance_to_internal and m_geometry_exit_to_internal
+     * packed entrance/exit ranges and m_geometry_to_internal
      *
      * @tparam NSTOKES
      */
@@ -185,14 +432,10 @@ namespace sasktran2::solartransmission {
         std::vector<int> m_active_wavelength_block_start;
         std::vector<int> m_active_wavelength_block_count;
 
-        std::vector<std::vector<std::vector<int>>>
-            m_geometry_entrance_to_internal; /** Mapping from layer entrances to
-                                                internal,
-                                                [los][layer][interp_index] */
-        std::vector<std::vector<std::vector<int>>>
-            m_geometry_exit_to_internal;         /** Mapping from layer exits to
-                                                    internal, [los][layer][interp_index]
-                                                  */
+        std::vector<std::uint32_t> m_geometry_layer_offsets;
+        std::vector<std::uint32_t> m_geometry_entrance_offsets;
+        std::vector<std::uint32_t> m_geometry_exit_offsets;
+        std::vector<int> m_geometry_to_internal;
         std::vector<int> m_internal_to_geometry; /** Maps the internal index
                                                       to the geometry index */
         std::vector<int>
@@ -320,6 +563,16 @@ namespace sasktran2::solartransmission {
             const std::vector<sasktran2::raytracing::TracedRay>& los_rays,
             const std::vector<std::vector<int>>& index_map);
 
+        const int* geometry_internal_indices(int losidx, int layeridx,
+                                             bool is_entrance) const {
+            const auto flat_layer = m_geometry_layer_offsets[losidx] +
+                                    static_cast<std::uint32_t>(layeridx);
+            const auto offset = is_entrance
+                                    ? m_geometry_entrance_offsets[flat_layer]
+                                    : m_geometry_exit_offsets[flat_layer];
+            return m_geometry_to_internal.data() + offset;
+        }
+
         void
         scatter_impl(int wavelidx, int losidx, int layeridx,
                      const raytracing::GridWeightStencilView& index_weights,
@@ -329,17 +582,16 @@ namespace sasktran2::solartransmission {
     };
 
     template <int NSTOKES>
-    inline void scattering_source(
-        const PhaseHandler<NSTOKES>& phase_handler, int threadidx, int losidx,
-        int layeridx, int wavelidx,
-        const raytracing::GridWeightStencilView& index_weights,
-        bool is_entrance, double solar_trans,
-        const atmosphere::Atmosphere<NSTOKES>& atmosphere,
-        Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator
-            solar_trans_iter,
-        bool calculate_derivatives,
-        sasktran2::Dual<double, sasktran2::dualstorage::dense, NSTOKES>&
-            source) {
+    inline void
+    scattering_source(const PhaseHandler<NSTOKES>& phase_handler, int threadidx,
+                      int losidx, int layeridx, int wavelidx,
+                      const raytracing::GridWeightStencilView& index_weights,
+                      bool is_entrance, double solar_trans,
+                      const atmosphere::Atmosphere<NSTOKES>& atmosphere,
+                      SolarGeometryMatrix::InnerIterator solar_trans_iter,
+                      bool calculate_derivatives,
+                      sasktran2::Dual<double, sasktran2::dualstorage::dense,
+                                      NSTOKES>& source) {
         const auto& storage = atmosphere.storage();
         source.value.setZero();
 
@@ -458,8 +710,7 @@ namespace sasktran2::solartransmission {
         const raytracing::GridWeightStencilView& index_weights,
         bool is_entrance, double solar_trans,
         const atmosphere::Atmosphere<NSTOKES>& atmosphere,
-        Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator
-            solar_trans_iter,
+        SolarGeometryMatrix::InnerIterator solar_trans_iter,
         double derivative_scale, Target& target) {
         const auto& storage = atmosphere.storage();
         double ssa = 0.0;
@@ -562,8 +813,7 @@ namespace sasktran2::solartransmission {
         const Eigen::Ref<const Eigen::Matrix<double, 1, N, Eigen::RowMajor>>&
             solar_trans,
         const atmosphere::Atmosphere<NSTOKES>& atmosphere,
-        Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator
-            solar_trans_iter,
+        SolarGeometryMatrix::InnerIterator solar_trans_iter,
         const Eigen::Ref<const Eigen::Matrix<double, 1, N, Eigen::RowMajor>>&
             derivative_scale,
         sasktran2::WavelengthBlockDual<NSTOKES>& target,
@@ -648,7 +898,7 @@ namespace sasktran2::solartransmission {
         const sasktran2::atmosphere::Atmosphere<NSTOKES>* m_atmosphere;
 
         Eigen::MatrixXd m_geometry_matrix;
-        Eigen::SparseMatrix<double, Eigen::RowMajor> m_geometry_sparse;
+        SolarGeometryMatrix m_geometry_sparse;
         std::vector<bool> m_ground_hit_flag;
 
         std::vector<Eigen::VectorXd> m_solar_trans;

--- a/cpp/lib/CMakeLists.txt
+++ b/cpp/lib/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(
   raytracing/rust_raytracer.cpp
   solar/solartransmissionexact.cpp
   solar/solartransmissiontable.cpp
+  solar/solartransmissiontable2d.cpp
   solar/singlescattersource.cpp
   solar/occultation.cpp
   emission/emission_source.cpp

--- a/cpp/lib/engine/engine.cpp
+++ b/cpp/lib/engine/engine.cpp
@@ -26,8 +26,10 @@ template <int NSTOKES> void Sasktran2<NSTOKES>::initialize() {
                  sasktran2::Config::SingleScatterSource::none &&
              m_config.single_scatter_source() !=
                  sasktran2::Config::SingleScatterSource::exact) ||
-            m_config.multiple_scatter_source() !=
-                sasktran2::Config::MultipleScatterSource::none ||
+            (m_config.multiple_scatter_source() !=
+                 sasktran2::Config::MultipleScatterSource::none &&
+             m_config.multiple_scatter_source() !=
+                 sasktran2::Config::MultipleScatterSource::successive_orders) ||
             (m_config.emission_source() !=
                  sasktran2::Config::EmissionSource::none &&
              m_config.emission_source() !=
@@ -36,8 +38,8 @@ template <int NSTOKES> void Sasktran2<NSTOKES>::initialize() {
                  sasktran2::Config::EmissionSource::volume_emission_rate)) {
             throw std::invalid_argument(
                 "Geometry2D currently supports exact single scattering, "
-                "occultation, standard emission, and volume emission rate "
-                "sources, with multiple scattering disabled");
+                "successive-orders multiple scattering, occultation, "
+                "standard emission, and volume emission rate sources");
         }
         if (!m_viewing_geometry.flux_observers().empty()) {
             throw std::invalid_argument(
@@ -47,6 +49,13 @@ template <int NSTOKES> void Sasktran2<NSTOKES>::initialize() {
             throw std::invalid_argument(
                 "Geometry2D engine integration does not yet accept per-ray "
                 "refractive-index profiles");
+        }
+        if (m_config.multiple_scatter_source() ==
+                sasktran2::Config::MultipleScatterSource::successive_orders &&
+            m_config.multiple_scatter_refraction()) {
+            throw std::invalid_argument(
+                "Geometry2D successive orders does not support diffuse-ray "
+                "refraction");
         }
     }
 
@@ -141,6 +150,18 @@ template <int NSTOKES> void Sasktran2<NSTOKES>::construct_source_terms() {
                     NSTOKES, sasktran2::Config::EmissionSource::
                                  volume_emission_rate>>());
             m_los_source_terms.push_back(m_source_terms.back().get());
+        }
+        if (m_config.multiple_scatter_source() ==
+            sasktran2::Config::MultipleScatterSource::successive_orders) {
+#ifdef SKTRAN_RUST_SUPPORT
+            m_source_terms.emplace_back(
+                sasktran2::successive_orders::make_successive_orders_source<
+                    NSTOKES>(*m_raytracer_2d, *m_geometry_2d));
+            m_los_source_terms.push_back(m_source_terms.back().get());
+#else
+            throw std::invalid_argument(
+                "Geometry2D successive orders requires Rust support");
+#endif
         }
         for (auto& source : m_source_terms) {
             source->initialize_config(m_config);

--- a/cpp/lib/engine/engine.cpp
+++ b/cpp/lib/engine/engine.cpp
@@ -143,7 +143,9 @@ template <int NSTOKES> void Sasktran2<NSTOKES>::construct_source_terms() {
                     sasktran2::solartransmission::SingleScatterSource<
                         sasktran2::solartransmission::SolarTransmissionExact,
                         NSTOKES>>(*m_geometry_2d, *m_raytracer_2d,
-                                  shared_solar_table));
+                                  m_config.solar_refraction()
+                                      ? shared_solar_table
+                                      : nullptr));
             m_los_source_terms.push_back(m_source_terms.back().get());
 #else
             throw std::invalid_argument(

--- a/cpp/lib/engine/engine.cpp
+++ b/cpp/lib/engine/engine.cpp
@@ -25,7 +25,9 @@ template <int NSTOKES> void Sasktran2<NSTOKES>::initialize() {
         if ((m_config.single_scatter_source() !=
                  sasktran2::Config::SingleScatterSource::none &&
              m_config.single_scatter_source() !=
-                 sasktran2::Config::SingleScatterSource::exact) ||
+                 sasktran2::Config::SingleScatterSource::exact &&
+             m_config.single_scatter_source() !=
+                 sasktran2::Config::SingleScatterSource::solartable) ||
             (m_config.multiple_scatter_source() !=
                  sasktran2::Config::MultipleScatterSource::none &&
              m_config.multiple_scatter_source() !=
@@ -37,7 +39,8 @@ template <int NSTOKES> void Sasktran2<NSTOKES>::initialize() {
              m_config.emission_source() !=
                  sasktran2::Config::EmissionSource::volume_emission_rate)) {
             throw std::invalid_argument(
-                "Geometry2D currently supports exact single scattering, "
+                "Geometry2D currently supports exact and table single "
+                "scattering, "
                 "successive-orders multiple scattering, occultation, "
                 "standard emission, and volume emission rate sources");
         }
@@ -115,6 +118,23 @@ template <int NSTOKES> void Sasktran2<NSTOKES>::construct_integrator() {
 template <int NSTOKES> void Sasktran2<NSTOKES>::construct_source_terms() {
 
     if (m_geometry_2d != nullptr) {
+#ifdef SKTRAN_RUST_SUPPORT
+        std::shared_ptr<sasktran2::solartransmission::SolarTransmissionTable2D>
+            shared_solar_table;
+        const bool needs_solar_table =
+            m_config.single_scatter_source() ==
+                sasktran2::Config::SingleScatterSource::solartable ||
+            (m_config.single_scatter_source() ==
+                 sasktran2::Config::SingleScatterSource::exact &&
+             m_config.solar_refraction()) ||
+            m_config.multiple_scatter_source() ==
+                sasktran2::Config::MultipleScatterSource::successive_orders;
+        if (needs_solar_table) {
+            shared_solar_table = std::make_shared<
+                sasktran2::solartransmission::SolarTransmissionTable2D>(
+                *m_geometry_2d, *m_raytracer_2d);
+        }
+#endif
         if (m_config.single_scatter_source() ==
             sasktran2::Config::SingleScatterSource::exact) {
 #ifdef SKTRAN_RUST_SUPPORT
@@ -122,11 +142,27 @@ template <int NSTOKES> void Sasktran2<NSTOKES>::construct_source_terms() {
                 std::make_unique<
                     sasktran2::solartransmission::SingleScatterSource<
                         sasktran2::solartransmission::SolarTransmissionExact,
-                        NSTOKES>>(*m_geometry_2d, *m_raytracer_2d));
+                        NSTOKES>>(*m_geometry_2d, *m_raytracer_2d,
+                                  shared_solar_table));
             m_los_source_terms.push_back(m_source_terms.back().get());
 #else
             throw std::invalid_argument(
                 "Geometry2D exact single scattering requires Rust support");
+#endif
+        }
+        if (m_config.single_scatter_source() ==
+            sasktran2::Config::SingleScatterSource::solartable) {
+#ifdef SKTRAN_RUST_SUPPORT
+            m_source_terms.emplace_back(
+                std::make_unique<
+                    sasktran2::solartransmission::SingleScatterSource<
+                        sasktran2::solartransmission::SolarTransmissionTable2D,
+                        NSTOKES>>(*m_geometry_2d, *m_raytracer_2d,
+                                  shared_solar_table));
+            m_los_source_terms.push_back(m_source_terms.back().get());
+#else
+            throw std::invalid_argument(
+                "Geometry2D table single scattering requires Rust support");
 #endif
         }
         if (m_config.occultation_source() ==
@@ -156,7 +192,8 @@ template <int NSTOKES> void Sasktran2<NSTOKES>::construct_source_terms() {
 #ifdef SKTRAN_RUST_SUPPORT
             m_source_terms.emplace_back(
                 sasktran2::successive_orders::make_successive_orders_source<
-                    NSTOKES>(*m_raytracer_2d, *m_geometry_2d));
+                    NSTOKES>(*m_raytracer_2d, *m_geometry_2d,
+                             shared_solar_table));
             m_los_source_terms.push_back(m_source_terms.back().get());
 #else
             throw std::invalid_argument(

--- a/cpp/lib/geometry/geometry2d.cpp
+++ b/cpp/lib/geometry/geometry2d.cpp
@@ -166,6 +166,7 @@ namespace sasktran2 {
           m_alt_grid(std::move(altitude_grid), grids::gridspacing::automatic,
                      grids::outofbounds::extend, altitude_interpolation),
           m_horizontal_angles(std::move(horizontal_angle_grid)) {
+        m_refractive_index = Eigen::VectorXd::Ones(m_alt_grid.grid().size());
         validate();
     }
 
@@ -383,6 +384,19 @@ namespace sasktran2 {
         if (coordinates().earth_radius() + altitudes[0] <= 0.0) {
             spdlog::critical(
                 "Invalid 2D altitude grid: radii must be positive");
+            validation::throw_configuration_error();
+        }
+        if (m_refractive_index.size() != altitudes.size()) {
+            spdlog::critical(
+                "Invalid 2D refractive-index size: {} values for {} altitudes",
+                m_refractive_index.size(), altitudes.size());
+            validation::throw_configuration_error();
+        }
+        if (!m_refractive_index.allFinite() ||
+            (m_refractive_index.array() <= 0.0).any()) {
+            spdlog::critical(
+                "Invalid 2D refractive index: values must be finite and "
+                "positive");
             validation::throw_configuration_error();
         }
 

--- a/cpp/lib/phasefunction/phasehandler.cpp
+++ b/cpp/lib/phasefunction/phasehandler.cpp
@@ -33,14 +33,17 @@ namespace sasktran2::solartransmission {
     template <int NSTOKES>
     void PhaseHandler<NSTOKES>::initialize_geometry(
         const std::vector<sasktran2::raytracing::TracedRay>& los_rays,
-        const std::vector<std::vector<int>>& index_map) {
-        initialize_geometry_impl(los_rays, index_map);
+        const std::vector<std::vector<int>>& index_map,
+        const std::vector<Eigen::Vector3d>* solar_propagation_directions) {
+        initialize_geometry_impl(los_rays, index_map,
+                                 solar_propagation_directions);
     }
 
     template <int NSTOKES>
     void PhaseHandler<NSTOKES>::initialize_geometry_impl(
         const std::vector<sasktran2::raytracing::TracedRay>& los_rays,
-        const std::vector<std::vector<int>>& index_map) {
+        const std::vector<std::vector<int>>& index_map,
+        const std::vector<Eigen::Vector3d>* solar_propagation_directions) {
 
         ZoneScopedN("Phase Handler Initialize Geometry");
 
@@ -51,6 +54,19 @@ namespace sasktran2::solartransmission {
         std::size_t total_layers = 0;
         std::size_t num_endpoint_references = 0;
         std::size_t num_phase_entries = 0;
+        const bool endpoint_solar_geometry =
+            solar_propagation_directions != nullptr;
+        if (endpoint_solar_geometry) {
+            std::size_t endpoint_count = 0;
+            for (const auto& ray : los_rays) {
+                endpoint_count += ray.layers.size() + 1;
+            }
+            if (solar_propagation_directions->size() != endpoint_count) {
+                throw std::invalid_argument(
+                    "Single-scatter solar directions do not match the ray "
+                    "endpoint geometry");
+            }
+        }
         int counting_scatter_index = 0;
         std::vector<int> last_scatter_by_geometry(m_geometry.size(), -1);
         const auto count_endpoint =
@@ -84,23 +100,34 @@ namespace sasktran2::solartransmission {
             if (ray.layers.empty()) {
                 continue;
             }
-            for (std::size_t layer_index = 0; layer_index < ray.layers.size();
-                 ++layer_index) {
-                count_endpoint(ray.entrance_weights(layer_index));
-                const auto exit_weights = ray.exit_weights(layer_index);
-                const bool can_share_exit =
-                    layer_index > 0 &&
-                    same_nonzero_indices(exit_weights,
-                                         ray.entrance_weights(layer_index - 1));
-                if (!can_share_exit) {
-                    count_endpoint(exit_weights);
-                }
-                if (!ray.is_straight) {
+            if (endpoint_solar_geometry) {
+                for (std::size_t layer_index = 0;
+                     layer_index < ray.layers.size(); ++layer_index) {
+                    count_endpoint(ray.entrance_weights(layer_index));
+                    ++counting_scatter_index;
+                    count_endpoint(ray.exit_weights(layer_index));
                     ++counting_scatter_index;
                 }
-            }
-            if (ray.is_straight) {
-                ++counting_scatter_index;
+            } else {
+                for (std::size_t layer_index = 0;
+                     layer_index < ray.layers.size(); ++layer_index) {
+                    count_endpoint(ray.entrance_weights(layer_index));
+                    const auto exit_weights = ray.exit_weights(layer_index);
+                    const bool can_share_exit =
+                        layer_index > 0 &&
+                        same_nonzero_indices(
+                            exit_weights,
+                            ray.entrance_weights(layer_index - 1));
+                    if (!can_share_exit) {
+                        count_endpoint(exit_weights);
+                    }
+                    if (!ray.is_straight) {
+                        ++counting_scatter_index;
+                    }
+                }
+                if (ray.is_straight) {
+                    ++counting_scatter_index;
+                }
             }
             if (num_endpoint_references >
                 std::numeric_limits<std::uint32_t>::max()) {
@@ -149,6 +176,29 @@ namespace sasktran2::solartransmission {
             };
         double theta, C1, C2, S1, S2;
         int negation;
+        const auto append_scatter_angle = [&](const Eigen::Vector3d&
+                                                  solar_propagation,
+                                              const sasktran2::raytracing::
+                                                  TracedLayer& scatter_layer,
+                                              const sasktran2::raytracing::
+                                                  TracedRay& ray) {
+            const auto result =
+                m_geometry.coordinates().stokes_standard_to_observer_z(
+                    scatter_layer.average_look_away,
+                    ray.observer_and_look.observer.position);
+            math::stokes_scattering_factors(solar_propagation.normalized(),
+                                            -scatter_layer.average_look_away,
+                                            theta, C1, C2, S1, S2, negation);
+            if constexpr (NSTOKES == 3) {
+                const double adjusted_C2 =
+                    C2 * result.first - S2 * result.second;
+                const double adjusted_S2 =
+                    C2 * result.second + S2 * result.first;
+                m_scatter_angles.push_back({theta, adjusted_C2, adjusted_S2});
+            } else {
+                m_scatter_angles.push_back({theta});
+            }
+        };
         // First we need to iterate through and figure out how many internal
         // indices we will end up with and how many scatter angles we will need
 
@@ -157,6 +207,34 @@ namespace sasktran2::solartransmission {
 
             // Empty rays don't need to be considered
             if (ray.layers.size() == 0) {
+                continue;
+            }
+
+            if (endpoint_solar_geometry) {
+                for (int j = 0; j < ray.layers.size(); ++j) {
+                    const auto flat_layer = m_geometry_layer_offsets[i] +
+                                            static_cast<std::uint32_t>(j);
+                    const int exit_solar_index = index_map[i][j];
+                    const int entrance_solar_index = exit_solar_index + 1;
+
+                    append_scatter_angle(
+                        (*solar_propagation_directions)[entrance_solar_index],
+                        ray.layers[j], ray);
+                    m_geometry_entrance_offsets[flat_layer] =
+                        static_cast<std::uint32_t>(
+                            m_geometry_to_internal.size());
+                    append_endpoint(ray.entrance_weights(j));
+                    ++num_scatter;
+
+                    append_scatter_angle(
+                        (*solar_propagation_directions)[exit_solar_index],
+                        ray.layers[j], ray);
+                    m_geometry_exit_offsets[flat_layer] =
+                        static_cast<std::uint32_t>(
+                            m_geometry_to_internal.size());
+                    append_endpoint(ray.exit_weights(j));
+                    ++num_scatter;
+                }
                 continue;
             }
 

--- a/cpp/lib/phasefunction/phasehandler.cpp
+++ b/cpp/lib/phasefunction/phasehandler.cpp
@@ -2,22 +2,31 @@
 #include <sasktran2/solartransmission.h>
 #include <spdlog/spdlog.h>
 
+#include <limits>
+
 namespace sasktran2::solartransmission {
     namespace {
-        std::vector<std::pair<int, double>>
-        endpoint_weights(const sasktran2::raytracing::TracedRay& ray,
-                         std::size_t layer_index, bool entrance) {
-            const auto stencil = entrance ? ray.entrance_weights(layer_index)
-                                          : ray.exit_weights(layer_index);
-            std::vector<std::pair<int, double>> result;
-            result.reserve(stencil.size());
-            for (std::size_t index = 0; index < stencil.size(); ++index) {
-                const auto weight = stencil[index];
-                if (weight.second != 0.0) {
-                    result.push_back(weight);
+        bool same_nonzero_indices(
+            const sasktran2::raytracing::GridWeightStencilView& lhs,
+            const sasktran2::raytracing::GridWeightStencilView& rhs) {
+            std::size_t lhs_index = 0;
+            std::size_t rhs_index = 0;
+            while (true) {
+                while (lhs_index < lhs.size() && lhs[lhs_index].second == 0.0) {
+                    ++lhs_index;
                 }
+                while (rhs_index < rhs.size() && rhs[rhs_index].second == 0.0) {
+                    ++rhs_index;
+                }
+                if (lhs_index == lhs.size() || rhs_index == rhs.size()) {
+                    return lhs_index == lhs.size() && rhs_index == rhs.size();
+                }
+                if (lhs[lhs_index].first != rhs[rhs_index].first) {
+                    return false;
+                }
+                ++lhs_index;
+                ++rhs_index;
             }
-            return result;
         }
     } // namespace
 
@@ -38,19 +47,111 @@ namespace sasktran2::solartransmission {
         m_scatter_angles.clear();
         m_internal_to_geometry.clear();
         m_internal_to_cos_scatter.clear();
-        m_geometry_entrance_to_internal.clear();
-        m_geometry_exit_to_internal.clear();
+        m_geometry_layer_offsets.assign(los_rays.size() + 1, 0);
+        std::size_t total_layers = 0;
+        std::size_t num_endpoint_references = 0;
+        std::size_t num_phase_entries = 0;
+        int counting_scatter_index = 0;
+        std::vector<int> last_scatter_by_geometry(m_geometry.size(), -1);
+        const auto count_endpoint =
+            [&](const raytracing::GridWeightStencilView& weights) {
+                for (std::size_t index = 0; index < weights.size(); ++index) {
+                    const auto weight = weights[index];
+                    if (weight.second == 0.0) {
+                        continue;
+                    }
+                    ++num_endpoint_references;
+                    if (last_scatter_by_geometry[weight.first] !=
+                        counting_scatter_index) {
+                        last_scatter_by_geometry[weight.first] =
+                            counting_scatter_index;
+                        ++num_phase_entries;
+                    }
+                }
+            };
+        for (std::size_t ray_index = 0; ray_index < los_rays.size();
+             ++ray_index) {
+            const auto& ray = los_rays[ray_index];
+            m_geometry_layer_offsets[ray_index] =
+                static_cast<std::uint32_t>(total_layers);
+            total_layers += ray.layers.size();
+            if (total_layers > std::numeric_limits<std::uint32_t>::max()) {
+                throw std::length_error(
+                    "Single-scatter phase geometry exceeds the packed layer "
+                    "index range");
+            }
+
+            if (ray.layers.empty()) {
+                continue;
+            }
+            for (std::size_t layer_index = 0; layer_index < ray.layers.size();
+                 ++layer_index) {
+                count_endpoint(ray.entrance_weights(layer_index));
+                const auto exit_weights = ray.exit_weights(layer_index);
+                const bool can_share_exit =
+                    layer_index > 0 &&
+                    same_nonzero_indices(exit_weights,
+                                         ray.entrance_weights(layer_index - 1));
+                if (!can_share_exit) {
+                    count_endpoint(exit_weights);
+                }
+                if (!ray.is_straight) {
+                    ++counting_scatter_index;
+                }
+            }
+            if (ray.is_straight) {
+                ++counting_scatter_index;
+            }
+            if (num_endpoint_references >
+                std::numeric_limits<std::uint32_t>::max()) {
+                throw std::length_error(
+                    "Single-scatter phase geometry exceeds the packed "
+                    "endpoint index range");
+            }
+            if (num_phase_entries >
+                static_cast<std::size_t>(std::numeric_limits<int>::max())) {
+                throw std::length_error(
+                    "Single-scatter phase geometry exceeds the internal "
+                    "index range");
+            }
+        }
+        m_geometry_layer_offsets.back() =
+            static_cast<std::uint32_t>(total_layers);
+        m_geometry_entrance_offsets.assign(total_layers, 0);
+        m_geometry_exit_offsets.assign(total_layers, 0);
+        m_geometry_to_internal.clear();
+        m_geometry_to_internal.reserve(num_endpoint_references);
+        m_internal_to_geometry.reserve(num_phase_entries);
+        m_internal_to_cos_scatter.reserve(num_phase_entries);
 
         int num_internal = 0;
         int num_scatter = 0;
+        std::fill(last_scatter_by_geometry.begin(),
+                  last_scatter_by_geometry.end(), -1);
+        std::vector<int> internal_by_geometry(m_geometry.size(), -1);
+        const auto append_endpoint =
+            [&](const raytracing::GridWeightStencilView& weights) {
+                for (std::size_t index = 0; index < weights.size(); ++index) {
+                    const auto weight = weights[index];
+                    if (weight.second == 0.0) {
+                        continue;
+                    }
+                    if (last_scatter_by_geometry[weight.first] != num_scatter) {
+                        last_scatter_by_geometry[weight.first] = num_scatter;
+                        internal_by_geometry[weight.first] = num_internal;
+                        m_internal_to_geometry.push_back(weight.first);
+                        m_internal_to_cos_scatter.push_back(num_scatter);
+                        ++num_internal;
+                    }
+                    m_geometry_to_internal.push_back(
+                        internal_by_geometry[weight.first]);
+                }
+            };
         double theta, C1, C2, S1, S2;
         int negation;
         // First we need to iterate through and figure out how many internal
         // indices we will end up with and how many scatter angles we will need
 
-        // Keep track of the entrance and exits separately
-        m_geometry_entrance_to_internal.resize(los_rays.size());
-        m_geometry_exit_to_internal.resize(los_rays.size());
         for (int i = 0; i < los_rays.size(); ++i) {
             const auto& ray = los_rays[i];
 
@@ -82,12 +183,9 @@ namespace sasktran2::solartransmission {
                 }
             }
 
-            // We have to map every exit/internal layer point to an internal
-            // scattering angle
-            m_geometry_entrance_to_internal[i].resize(ray.layers.size());
-            m_geometry_exit_to_internal[i].resize(ray.layers.size());
-
             for (int j = 0; j < ray.layers.size(); ++j) {
+                const auto flat_layer =
+                    m_geometry_layer_offsets[i] + static_cast<std::uint32_t>(j);
 
                 // If the ray isn't straight every layer has a scattering angle
                 if (!ray.is_straight) {
@@ -114,46 +212,27 @@ namespace sasktran2::solartransmission {
                     }
                 }
 
-                const auto entrance_weights = endpoint_weights(ray, j, true);
-                const auto exit_weights = endpoint_weights(ray, j, false);
-                m_geometry_entrance_to_internal[i][j].resize(
-                    entrance_weights.size());
-                m_geometry_exit_to_internal[i][j].resize(exit_weights.size());
+                const auto entrance_weights = ray.entrance_weights(j);
+                const auto exit_weights = ray.exit_weights(j);
+                auto& entrance_offset = m_geometry_entrance_offsets[flat_layer];
+                entrance_offset =
+                    static_cast<std::uint32_t>(m_geometry_to_internal.size());
 
-                for (int k = 0; k < entrance_weights.size(); ++k) {
-                    m_geometry_entrance_to_internal[i][j][k] = num_internal;
-                    ++num_internal;
+                append_endpoint(entrance_weights);
 
-                    m_internal_to_geometry.push_back(entrance_weights[k].first);
-                    m_internal_to_cos_scatter.push_back(num_scatter);
-                }
+                const bool can_share_exit =
+                    j > 0 && same_nonzero_indices(exit_weights,
+                                                  ray.entrance_weights(j - 1));
 
-                bool can_share_exit = false;
-                if (j > 0) {
-                    const auto previous_entrance_weights =
-                        endpoint_weights(ray, j - 1, true);
-                    can_share_exit =
-                        exit_weights.size() == previous_entrance_weights.size();
-                    for (int k = 0; can_share_exit && k < exit_weights.size();
-                         ++k) {
-                        can_share_exit = exit_weights[k].first ==
-                                         previous_entrance_weights[k].first;
-                    }
-                }
-
+                auto& exit_offset = m_geometry_exit_offsets[flat_layer];
                 if (!can_share_exit) {
                     // End layer at TOA, need to use layer exit
-                    for (int k = 0; k < exit_weights.size(); ++k) {
-                        m_geometry_exit_to_internal[i][j][k] = num_internal;
-                        ++num_internal;
-
-                        m_internal_to_geometry.push_back(exit_weights[k].first);
-                        m_internal_to_cos_scatter.push_back(num_scatter);
-                    }
+                    exit_offset = static_cast<std::uint32_t>(
+                        m_geometry_to_internal.size());
+                    append_endpoint(exit_weights);
                 } else {
                     // Assign to previous layers entrance
-                    m_geometry_exit_to_internal[i][j] =
-                        m_geometry_entrance_to_internal[i][j - 1];
+                    exit_offset = m_geometry_entrance_offsets[flat_layer - 1];
                 }
 
                 if (!ray.is_straight) {
@@ -164,6 +243,13 @@ namespace sasktran2::solartransmission {
                 ++num_scatter;
             }
         }
+
+        spdlog::debug(
+            "Single-scatter phase geometry: {} layers, {} endpoint references "
+            "(capacity {}), {} phase entries, {} scatter angles",
+            total_layers, m_geometry_to_internal.size(),
+            m_geometry_to_internal.capacity(), m_internal_to_geometry.size(),
+            m_scatter_angles.size());
 
         if constexpr (NSTOKES == 3) {
             m_phase.resize(2, (int)m_internal_to_geometry.size(),
@@ -507,9 +593,8 @@ namespace sasktran2::solartransmission {
         const raytracing::GridWeightStencilView& index_weights,
         bool is_entrance, double source_amplitude, double derivative_scale,
         Target& target) const {
-        const auto& internal_indices =
-            is_entrance ? m_geometry_entrance_to_internal[losidx][layeridx]
-                        : m_geometry_exit_to_internal[losidx][layeridx];
+        const int* internal_indices =
+            geometry_internal_indices(losidx, layeridx, is_entrance);
 
         if constexpr (NSTOKES == 1) {
             double phase_result = 0.0;
@@ -656,9 +741,8 @@ namespace sasktran2::solartransmission {
         bool is_entrance) const {
         Eigen::Vector<double, NSTOKES> phase =
             Eigen::Vector<double, NSTOKES>::Zero();
-        const auto& internal_indices =
-            is_entrance ? m_geometry_entrance_to_internal[losidx][layeridx]
-                        : m_geometry_exit_to_internal[losidx][layeridx];
+        const int* internal_indices =
+            geometry_internal_indices(losidx, layeridx, is_entrance);
 
         const int batch_lane =
             m_wavelength_batch_capacity > 1
@@ -719,9 +803,8 @@ namespace sasktran2::solartransmission {
         phase = scatter_value(threadidx, losidx, layeridx, wavelidx,
                               index_weights, is_entrance);
         phase_jvp.setZero();
-        const auto& internal_indices =
-            is_entrance ? m_geometry_entrance_to_internal[losidx][layeridx]
-                        : m_geometry_exit_to_internal[losidx][layeridx];
+        const int* internal_indices =
+            geometry_internal_indices(losidx, layeridx, is_entrance);
 
         const int batch_lane =
             m_wavelength_batch_capacity > 1
@@ -785,9 +868,8 @@ namespace sasktran2::solartransmission {
         const raytracing::GridWeightStencilView& index_weights,
         bool is_entrance, const Eigen::Vector<double, NSTOKES>& phase_cotangent,
         Eigen::Ref<Eigen::VectorXd> native_gradient) const {
-        const auto& internal_indices =
-            is_entrance ? m_geometry_entrance_to_internal[losidx][layeridx]
-                        : m_geometry_exit_to_internal[losidx][layeridx];
+        const int* internal_indices =
+            geometry_internal_indices(losidx, layeridx, is_entrance);
         const int batch_lane =
             m_wavelength_batch_capacity > 1
                 ? wavelidx - m_active_wavelength_block_start.at(threadidx)
@@ -873,9 +955,8 @@ namespace sasktran2::solartransmission {
                            num_internal +
                        internal_index;
             };
-        const auto& internal_indices =
-            is_entrance ? m_geometry_entrance_to_internal[losidx][layeridx]
-                        : m_geometry_exit_to_internal[losidx][layeridx];
+        const int* internal_indices =
+            geometry_internal_indices(losidx, layeridx, is_entrance);
 
         const auto accumulate_phase = [&](int internal_index, double weight) {
             wavelength_head(phase_result.row(0), batch).array() +=

--- a/cpp/lib/raytracing/rust_raytracer.cpp
+++ b/cpp/lib/raytracing/rust_raytracer.cpp
@@ -328,6 +328,12 @@ namespace sasktran2::raytracing {
         trace_ray_impl(ray, nullptr, result, true);
     }
 
+    void RustRayTracer2D::trace_ray_optical_depth(
+        const sasktran2::viewinggeometry::ViewingRay& ray,
+        const Eigen::VectorXd& refractive_index, TracedRay& result) const {
+        trace_ray_impl(ray, &refractive_index, result, true);
+    }
+
     void RustRayTracer2D::trace_ray(
         const sasktran2::viewinggeometry::ViewingRay& ray,
         const Eigen::VectorXd& refractive_index, TracedRay& result) const {

--- a/cpp/lib/raytracing/rust_raytracer.cpp
+++ b/cpp/lib/raytracing/rust_raytracer.cpp
@@ -121,8 +121,35 @@ namespace sasktran2::rust::raytracer {
             m_result.reserve_grid_weights(summary.num_layers * 4);
         }
 
-        void set_layer(std::size_t index, const RustTraceLayer& rust_layer) {
+        void set_layer(std::size_t index, const RustTraceLayer& rust_layer,
+                       bool optical_depth_only) {
             auto& layer = m_result.layers[index];
+            const int altitude_cell = rust_layer.cell_altitude_index;
+            const int horizontal_cell = rust_layer.cell_horizontal_index;
+            // One structured 2D layer is confined to one cell. All endpoint
+            // and integrated-OD weights use the same four cell corners in
+            // altitude-fastest order:
+            //   (h0,a0), (h0,a1), (h1,a0), (h1,a1).
+            // Geometry2D::location_index uses the same flattening convention.
+            const std::array<int, 4> indices = {
+                m_geometry.location_index(altitude_cell, horizontal_cell),
+                m_geometry.location_index(altitude_cell + 1, horizontal_cell),
+                m_geometry.location_index(altitude_cell, horizontal_cell + 1),
+                m_geometry.location_index(altitude_cell + 1,
+                                          horizontal_cell + 1)};
+            const std::array<double, 4> od_weights = {
+                rust_layer.integrated_od_weight_0,
+                rust_layer.integrated_od_weight_1,
+                rust_layer.integrated_od_weight_2,
+                rust_layer.integrated_od_weight_3};
+            if (optical_depth_only) {
+                constexpr std::array<double, 4> unused_endpoint_weights = {
+                    0.0, 0.0, 0.0, 0.0};
+                m_result.set_layer_weights(index, indices,
+                                           unused_endpoint_weights,
+                                           unused_endpoint_weights, od_weights);
+                return;
+            }
 
             layer.type = static_cast<sasktran2::raytracing::LayerType>(
                 rust_layer.layer_type);
@@ -157,25 +184,12 @@ namespace sasktran2::rust::raytracer {
             layer.cos_sza_exit = rust_layer.cos_sza_exit;
             layer.saz_entrance = rust_layer.saz_entrance;
             layer.saz_exit = rust_layer.saz_exit;
-            const int altitude_cell = rust_layer.cell_altitude_index;
-            const int horizontal_cell = rust_layer.cell_horizontal_index;
             const auto entrance_coordinates =
                 m_geometry.cell_interpolation_coordinates(
                     layer.entrance, altitude_cell, horizontal_cell);
             const auto exit_coordinates =
                 m_geometry.cell_interpolation_coordinates(
                     layer.exit, altitude_cell, horizontal_cell);
-            // One structured 2D layer is confined to one cell. All endpoint
-            // and integrated-OD weights use the same four cell corners in
-            // altitude-fastest order:
-            //   (h0,a0), (h0,a1), (h1,a0), (h1,a1).
-            // Geometry2D::location_index uses the same flattening convention.
-            const std::array<int, 4> indices = {
-                m_geometry.location_index(altitude_cell, horizontal_cell),
-                m_geometry.location_index(altitude_cell + 1, horizontal_cell),
-                m_geometry.location_index(altitude_cell, horizontal_cell + 1),
-                m_geometry.location_index(altitude_cell + 1,
-                                          horizontal_cell + 1)};
             const auto interpolation_weights = [](const auto& coordinates) {
                 // coordinates = (altitude upper fraction,
                 //                horizontal upper fraction).
@@ -190,11 +204,6 @@ namespace sasktran2::rust::raytracer {
             const auto entrance_weights =
                 interpolation_weights(entrance_coordinates);
             const auto exit_weights = interpolation_weights(exit_coordinates);
-            const std::array<double, 4> od_weights = {
-                rust_layer.integrated_od_weight_0,
-                rust_layer.integrated_od_weight_1,
-                rust_layer.integrated_od_weight_2,
-                rust_layer.integrated_od_weight_3};
             m_result.set_layer_weights(index, indices, entrance_weights,
                                        exit_weights, od_weights);
             layer.entrance.lower_alt_index = altitude_cell;
@@ -223,8 +232,9 @@ namespace sasktran2::rust::raytracer {
     }
 
     void set_trace_layer_2d(CppTraceResult2D& result, std::size_t index,
-                            const RustTraceLayer& layer) {
-        result.set_layer(index, layer);
+                            const RustTraceLayer& layer,
+                            bool optical_depth_only) {
+        result.set_layer(index, layer, optical_depth_only);
     }
 
     void set_trace_layers(CppTraceResult& result,
@@ -309,18 +319,25 @@ namespace sasktran2::raytracing {
     void RustRayTracer2D::trace_ray(
         const sasktran2::viewinggeometry::ViewingRay& ray,
         TracedRay& result) const {
-        trace_ray_impl(ray, nullptr, result);
+        trace_ray_impl(ray, nullptr, result, false);
+    }
+
+    void RustRayTracer2D::trace_ray_optical_depth(
+        const sasktran2::viewinggeometry::ViewingRay& ray,
+        TracedRay& result) const {
+        trace_ray_impl(ray, nullptr, result, true);
     }
 
     void RustRayTracer2D::trace_ray(
         const sasktran2::viewinggeometry::ViewingRay& ray,
         const Eigen::VectorXd& refractive_index, TracedRay& result) const {
-        trace_ray_impl(ray, &refractive_index, result);
+        trace_ray_impl(ray, &refractive_index, result, false);
     }
 
     void RustRayTracer2D::trace_ray_impl(
         const sasktran2::viewinggeometry::ViewingRay& ray,
-        const Eigen::VectorXd* refractive_index, TracedRay& result) const {
+        const Eigen::VectorXd* refractive_index, TracedRay& result,
+        bool optical_depth_only) const {
         if (refractive_index != nullptr &&
             refractive_index->size() != m_geometry.num_altitudes()) {
             throw std::invalid_argument(
@@ -339,7 +356,7 @@ namespace sasktran2::raytracing {
             *m_impl->rust_tracer, ray.observer.position.x(),
             ray.observer.position.y(), ray.observer.position.z(),
             ray.look_away.x(), ray.look_away.y(), ray.look_away.z(), profile,
-            cpp_result);
+            optical_depth_only, cpp_result);
     }
 
 } // namespace sasktran2::raytracing

--- a/cpp/lib/solar/singlescattersource.cpp
+++ b/cpp/lib/solar/singlescattersource.cpp
@@ -17,12 +17,25 @@ namespace sasktran2::solartransmission {
     template <typename S, int NSTOKES>
     void SingleScatterSource<S, NSTOKES>::initialize_atmosphere(
         const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere) {
+        initialize_atmosphere_impl(atmosphere, true);
+    }
+
+    template <typename S, int NSTOKES>
+    void SingleScatterSource<S, NSTOKES>::initialize_atmosphere_native(
+        const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere) {
+        initialize_atmosphere_impl(atmosphere, false);
+    }
+
+    template <typename S, int NSTOKES>
+    void SingleScatterSource<S, NSTOKES>::initialize_atmosphere_impl(
+        const sasktran2::atmosphere::Atmosphere<NSTOKES>& atmosphere,
+        bool materialized_derivative_storage) {
         // Store the atmosphere for later
         m_atmosphere = &atmosphere;
         this->m_phase_handler.initialize_atmosphere(atmosphere);
 
         if constexpr (std::is_same_v<S, SolarTransmissionExact>) {
-            if (atmosphere.num_deriv() > 0) {
+            if (materialized_derivative_storage && atmosphere.num_deriv() > 0) {
                 initialize_active_derivative_indices();
             } else {
                 m_active_derivative_indices.clear();

--- a/cpp/lib/solar/singlescattersource.cpp
+++ b/cpp/lib/solar/singlescattersource.cpp
@@ -34,7 +34,15 @@ namespace sasktran2::solartransmission {
         m_atmosphere = &atmosphere;
         this->m_phase_handler.initialize_atmosphere(atmosphere);
 
-        if constexpr (std::is_same_v<S, SolarTransmissionExact>) {
+        if constexpr (compact_2d_table) {
+            if (materialized_derivative_storage && atmosphere.num_deriv() > 0) {
+                throw std::invalid_argument(
+                    "Geometry2D table single scattering supports native JVP "
+                    "and VJP linearization, not a materialized Jacobian");
+            }
+        }
+
+        if constexpr (exact_transmission) {
             if (materialized_derivative_storage && atmosphere.num_deriv() > 0) {
                 initialize_active_derivative_indices();
             } else {
@@ -58,12 +66,24 @@ namespace sasktran2::solartransmission {
         const sasktran2::Config& config) {
         m_config = &config;
 
-        this->m_solar_transmission.initialize_config(config);
+        this->m_solar_transmission->initialize_config(config);
+#ifdef SKTRAN_RUST_SUPPORT
+        if constexpr (exact_transmission) {
+            if (m_shared_solar_table_2d != nullptr) {
+                m_shared_solar_table_2d->initialize_config(config);
+            }
+        }
+#endif
         this->m_phase_handler.initialize_config(config);
 
         // Set up storage for each thread
         // m_solar_trans.resize(config.num_threads());
         m_solar_trans.resize(config.num_wavelength_threads());
+        if constexpr (compact_2d_table) {
+            m_solar_table_product.resize(config.num_wavelength_threads());
+            m_solar_trans_jvp.resize(config.num_wavelength_threads());
+            m_solar_endpoint_cotangent.resize(config.num_threads());
+        }
         m_active_wavelength_block_start.assign(config.num_wavelength_threads(),
                                                0);
         m_active_wavelength_block_count.assign(config.num_wavelength_threads(),
@@ -83,7 +103,7 @@ namespace sasktran2::solartransmission {
         m_phase_handler.calculate(wavelidx, threadidx);
 
         // Calculate the solar transmission at each cell
-        if constexpr (std::is_same_v<S, SolarTransmissionExact>) {
+        if constexpr (exact_transmission) {
             // Faster to use the dense matrix if most of the elements are
             // nonzero
             if (m_geometry_matrix.size() > 0 &&
@@ -107,9 +127,20 @@ namespace sasktran2::solartransmission {
         if constexpr (std::is_same_v<S, SolarTransmissionTable>) {
             m_solar_trans[threadidx].noalias() =
                 m_geometry_sparse.standard() *
-                (m_solar_transmission.geometry_matrix() *
+                (m_solar_transmission->geometry_matrix() *
                  m_atmosphere->storage().total_extinction(
                      Eigen::placeholders::all, wavelidx));
+        }
+
+        if constexpr (compact_2d_table) {
+            auto& table_od = m_solar_table_product[threadidx];
+            table_od.resize(m_solar_transmission->table_size());
+            m_solar_transmission->apply(
+                m_atmosphere->storage().total_extinction(
+                    Eigen::placeholders::all, wavelidx),
+                table_od);
+            m_solar_trans[threadidx].resize(m_solar_interpolation.rows());
+            m_solar_interpolation.apply(table_od, m_solar_trans[threadidx]);
         }
 
         m_solar_trans[threadidx] =
@@ -125,7 +156,7 @@ namespace sasktran2::solartransmission {
     template <typename S, int NSTOKES>
     void SingleScatterSource<S, NSTOKES>::initialize_wavelength_blocks(
         int block_size) {
-        if constexpr (!std::is_same_v<S, SolarTransmissionExact>) {
+        if constexpr (!exact_transmission) {
             throw std::logic_error(
                 "Solar transmission tables do not support wavelength "
                 "batching");
@@ -153,7 +184,7 @@ namespace sasktran2::solartransmission {
     template <int N>
     void SingleScatterSource<S, NSTOKES>::calculate_block(
         const sasktran2::WavelengthBlock<N>& batch, int threadidx) {
-        if constexpr (!std::is_same_v<S, SolarTransmissionExact>) {
+        if constexpr (!exact_transmission) {
             throw std::logic_error(
                 "Solar transmission tables do not support wavelength "
                 "batching");
@@ -210,13 +241,118 @@ namespace sasktran2::solartransmission {
     }
 
     template <typename S, int NSTOKES>
+    double SingleScatterSource<S, NSTOKES>::solar_transmission_tangent(
+        int wavelidx, int threadidx, int solar_index,
+        Eigen::Ref<const Eigen::VectorXd> native_tangent) const {
+        if constexpr (compact_2d_table) {
+            return m_solar_trans_jvp.at(threadidx)(solar_index);
+        } else {
+            const double solar_trans =
+                solar_transmission_value(wavelidx, threadidx, solar_index);
+            return -solar_trans *
+                   m_geometry_sparse.row_dot(solar_index, native_tangent);
+        }
+    }
+
+    template <typename S, int NSTOKES>
+    bool SingleScatterSource<S, NSTOKES>::ground_scattering_geometry(
+        int losidx, double& mu_in, double& mu_out, double& phi_diff) const {
+        const auto& first_layer = m_los_end_layers.at(losidx);
+        Eigen::Vector3d direction_to_sun = m_geometry.coordinates().sun_unit();
+        if (!m_solar_propagation_directions.empty()) {
+            direction_to_sun =
+                -m_solar_propagation_directions[m_index_map[losidx][0]];
+        }
+        sasktran2::raytracing::calculate_csz_saz(
+            direction_to_sun.normalized(), first_layer.exit,
+            first_layer.average_look_away, mu_in, phi_diff,
+            m_geometry.coordinates().geometry_type());
+        mu_out =
+            -first_layer.exit.cos_zenith_angle(first_layer.average_look_away);
+        return mu_in > 0.0;
+    }
+
+    template <typename S, int NSTOKES>
+    void SingleScatterSource<S, NSTOKES>::calculate_jvp(
+        const sasktran2::WavelengthBlock<>& block, int threadidx,
+        Eigen::Ref<const Eigen::VectorXd> native_tangent) {
+        calculate(block, threadidx);
+        if constexpr (compact_2d_table) {
+            if (block.count != 1 ||
+                native_tangent.size() != m_atmosphere->num_deriv()) {
+                throw std::invalid_argument(
+                    "Invalid Geometry2D table single-scatter JVP block");
+            }
+            auto& table_tangent = m_solar_table_product[threadidx];
+            table_tangent.resize(m_solar_transmission->table_size());
+            m_solar_transmission->apply(
+                native_tangent.head(m_solar_transmission->atmosphere_size()),
+                table_tangent);
+            auto& endpoint_tangent = m_solar_trans_jvp[threadidx];
+            endpoint_tangent.resize(m_solar_interpolation.rows());
+            m_solar_interpolation.apply(table_tangent, endpoint_tangent);
+            endpoint_tangent.array() *= -m_solar_trans[threadidx].array();
+        }
+    }
+
+    template <typename S, int NSTOKES>
+    void SingleScatterSource<S, NSTOKES>::calculate_vjp(
+        const sasktran2::WavelengthBlock<>& block, int threadidx) {
+        calculate(block, threadidx);
+        if constexpr (compact_2d_table) {
+            if (block.count != 1) {
+                throw std::invalid_argument(
+                    "Geometry2D table single-scatter VJP requires scalar "
+                    "wavelength blocks");
+            }
+            const int first_thread = threadidx;
+            const int last_thread =
+                first_thread + m_config->num_source_threads();
+            if (last_thread >
+                static_cast<int>(m_solar_endpoint_cotangent.size())) {
+                throw std::logic_error(
+                    "Single-scatter VJP thread layout is invalid");
+            }
+            for (int thread = first_thread; thread < last_thread; ++thread) {
+                m_solar_endpoint_cotangent[thread].setZero();
+            }
+        }
+    }
+
+    template <typename S, int NSTOKES>
+    void SingleScatterSource<S, NSTOKES>::finalize_vjp(
+        const sasktran2::WavelengthBlock<>& block, int threadidx,
+        Eigen::Ref<Eigen::MatrixXd> native_gradient) const {
+        if constexpr (compact_2d_table) {
+            if (block.count != 1 || native_gradient.cols() != 1) {
+                throw std::invalid_argument(
+                    "Invalid Geometry2D table single-scatter VJP result");
+            }
+            m_solar_endpoint_cotangent_sum.setZero(
+                m_solar_interpolation.rows());
+            const int last_thread = threadidx + m_config->num_source_threads();
+            for (int thread = threadidx; thread < last_thread; ++thread) {
+                m_solar_endpoint_cotangent_sum +=
+                    m_solar_endpoint_cotangent[thread];
+            }
+            m_solar_table_cotangent.resize(m_solar_transmission->table_size());
+            m_solar_interpolation.apply_transpose(
+                m_solar_endpoint_cotangent_sum, m_solar_table_cotangent);
+            auto extinction_gradient = native_gradient.col(0).head(
+                m_solar_transmission->atmosphere_size());
+            m_solar_transmission->accumulate_transpose(
+                m_solar_table_cotangent, extinction_gradient, 1.0);
+        }
+    }
+
+    template <typename S, int NSTOKES>
     void SingleScatterSource<S, NSTOKES>::endpoint_source_jvp(
         int wavelidx, int losidx, int layeridx, int wavel_threadidx,
         int solar_index,
         const sasktran2::raytracing::GridWeightStencilView& weights,
         bool is_entrance, Eigen::Ref<const Eigen::VectorXd> native_tangent,
         sasktran2::RadianceJVP<NSTOKES>& result) const {
-        if constexpr (!std::is_same_v<S, SolarTransmissionExact>) {
+        if constexpr (!native_transmission_linearization) {
             throw std::logic_error(
                 "Native JVP requires exact solar transmission");
         } else {
@@ -242,9 +378,8 @@ namespace sasktran2::solartransmission {
 
             const double solar_trans = solar_transmission_value(
                 wavelidx, wavel_threadidx, solar_index);
-            const double solar_od_jvp =
-                m_geometry_sparse.row_dot(solar_index, native_tangent);
-            const double solar_trans_jvp = -solar_trans * solar_od_jvp;
+            const double solar_trans_jvp = solar_transmission_tangent(
+                wavelidx, wavel_threadidx, solar_index, native_tangent);
 
             Eigen::Vector<double, NSTOKES> phase;
             Eigen::Vector<double, NSTOKES> phase_jvp;
@@ -267,11 +402,11 @@ namespace sasktran2::solartransmission {
     Eigen::Vector<double, NSTOKES>
     SingleScatterSource<S, NSTOKES>::endpoint_source_vjp(
         int wavelidx, int losidx, int layeridx, int wavel_threadidx,
-        int solar_index,
+        int threadidx, int solar_index,
         const sasktran2::raytracing::GridWeightStencilView& weights,
         bool is_entrance, const Eigen::Vector<double, NSTOKES>& cotangent,
         Eigen::Ref<Eigen::VectorXd> native_gradient) const {
-        if constexpr (!std::is_same_v<S, SolarTransmissionExact>) {
+        if constexpr (!native_transmission_linearization) {
             throw std::logic_error(
                 "Native VJP requires exact solar transmission");
         } else {
@@ -314,9 +449,15 @@ namespace sasktran2::solartransmission {
                 native_gradient(m_atmosphere->ssa_deriv_start_index() +
                                 weight.first) += weight.second * ssa_cotangent;
             }
-            m_geometry_sparse.accumulate_row(
-                solar_index, -solar_trans * solar_trans_cotangent,
-                native_gradient);
+            const double solar_od_cotangent =
+                -solar_trans * solar_trans_cotangent;
+            if constexpr (compact_2d_table) {
+                m_solar_endpoint_cotangent[threadidx](solar_index) +=
+                    solar_od_cotangent;
+            } else {
+                m_geometry_sparse.accumulate_row(
+                    solar_index, solar_od_cotangent, native_gradient);
+            }
             m_phase_handler.scatter_vjp(wavel_threadidx, losidx, layeridx,
                                         wavelidx, weights, is_entrance,
                                         amplitude * cotangent, native_gradient);
@@ -329,33 +470,28 @@ namespace sasktran2::solartransmission {
         int wavelidx, int losidx, int wavel_threadidx, int threadidx,
         Eigen::Ref<const Eigen::VectorXd> native_tangent,
         sasktran2::RadianceJVP<NSTOKES>& source) const {
-        (void)threadidx;
-        if constexpr (!std::is_same_v<S, SolarTransmissionExact>) {
+        if constexpr (!native_transmission_linearization) {
             throw std::logic_error(
                 "Native JVP requires exact solar transmission");
         } else {
             if (!m_los_ground_is_hit.at(losidx)) {
                 return;
             }
-            const auto& first_layer = m_los_end_layers.at(losidx);
-            const double mu_in = first_layer.exit.cos_zenith_angle(
-                m_geometry.coordinates().sun_unit());
-            if (mu_in <= 0.0) {
+            double mu_in;
+            double mu_out;
+            double phi_diff;
+            if (!ground_scattering_geometry(losidx, mu_in, mu_out, phi_diff)) {
                 return;
             }
-            const double mu_out = -first_layer.exit.cos_zenith_angle(
-                first_layer.average_look_away);
-            const double phi_diff = first_layer.saz_exit;
             const int solar_index = m_index_map[losidx][0];
             const double solar_trans = solar_transmission_value(
                 wavelidx, wavel_threadidx, solar_index);
-            double solar_od_jvp = 0.0;
+            double solar_trans_jvp = 0.0;
             if (m_config->wf_precision() !=
                 sasktran2::Config::WeightingFunctionPrecision::limited) {
-                solar_od_jvp =
-                    m_geometry_sparse.row_dot(solar_index, native_tangent);
+                solar_trans_jvp = solar_transmission_tangent(
+                    wavelidx, wavel_threadidx, solar_index, native_tangent);
             }
-            const double solar_trans_jvp = -solar_trans * solar_od_jvp;
             const auto brdf =
                 m_atmosphere->surface().brdf(wavelidx, mu_in, mu_out, phi_diff);
             Eigen::Matrix<double, NSTOKES, NSTOKES> brdf_jvp =
@@ -383,23 +519,19 @@ namespace sasktran2::solartransmission {
         const Eigen::Vector<double, NSTOKES>&,
         Eigen::Vector<double, NSTOKES>& cotangent,
         Eigen::Ref<Eigen::VectorXd> native_gradient) const {
-        (void)threadidx;
-        if constexpr (!std::is_same_v<S, SolarTransmissionExact>) {
+        if constexpr (!native_transmission_linearization) {
             throw std::logic_error(
                 "Native VJP requires exact solar transmission");
         } else {
             if (!m_los_ground_is_hit.at(losidx)) {
                 return;
             }
-            const auto& first_layer = m_los_end_layers.at(losidx);
-            const double mu_in = first_layer.exit.cos_zenith_angle(
-                m_geometry.coordinates().sun_unit());
-            if (mu_in <= 0.0) {
+            double mu_in;
+            double mu_out;
+            double phi_diff;
+            if (!ground_scattering_geometry(losidx, mu_in, mu_out, phi_diff)) {
                 return;
             }
-            const double mu_out = -first_layer.exit.cos_zenith_angle(
-                first_layer.average_look_away);
-            const double phi_diff = first_layer.saz_exit;
             const int solar_index = m_index_map[losidx][0];
             const double solar_trans = solar_transmission_value(
                 wavelidx, wavel_threadidx, solar_index);
@@ -409,9 +541,15 @@ namespace sasktran2::solartransmission {
                 mu_in * cotangent.dot(brdf(Eigen::placeholders::all, 0));
             if (m_config->wf_precision() !=
                 sasktran2::Config::WeightingFunctionPrecision::limited) {
-                m_geometry_sparse.accumulate_row(
-                    solar_index, -solar_trans * solar_trans_cotangent,
-                    native_gradient);
+                const double solar_od_cotangent =
+                    -solar_trans * solar_trans_cotangent;
+                if constexpr (compact_2d_table) {
+                    m_solar_endpoint_cotangent[threadidx](solar_index) +=
+                        solar_od_cotangent;
+                } else {
+                    m_geometry_sparse.accumulate_row(
+                        solar_index, solar_od_cotangent, native_gradient);
+                }
             }
             for (int derivative = 0;
                  derivative < m_atmosphere->surface().num_deriv();
@@ -431,23 +569,13 @@ namespace sasktran2::solartransmission {
         int wavelidx, int losidx, int wavel_threadidx, int threadidx,
         sasktran2::WavelengthBlockLaneDualView<NSTOKES, 1>& source) const {
         if (m_los_ground_is_hit.at(losidx)) {
-            const auto& first_layer = m_los_end_layers.at(losidx);
             // Single scatter ground source is solar_trans * cos(th) * brdf
-
-            // Cosine of direction to the sun at the surface
-            // TODO: This does not account for refraction?
-            double mu_in = first_layer.exit.cos_zenith_angle(
-                m_geometry.coordinates().sun_unit());
-            if (mu_in <= 0.0) {
+            double mu_in;
+            double mu_out;
+            double phi_diff;
+            if (!ground_scattering_geometry(losidx, mu_in, mu_out, phi_diff)) {
                 return;
             }
-
-            // Cosine of direction to LOS at the surface
-            double mu_out = -1.0 * first_layer.exit.cos_zenith_angle(
-                                       first_layer.average_look_away);
-
-            // We already have the azimuthal difference
-            double phi_diff = first_layer.saz_exit;
 
             Eigen::Matrix<double, NSTOKES, NSTOKES> brdf =
                 m_atmosphere->surface().brdf(wavelidx, mu_in, mu_out, phi_diff);
@@ -470,7 +598,7 @@ namespace sasktran2::solartransmission {
             source.value.array() += source_value.array();
             if (source.deriv.size() > 0) {
                 // Add on the solar transmission derivative factors
-                if constexpr (std::is_same_v<S, SolarTransmissionExact>) {
+                if constexpr (exact_transmission) {
                     if (m_config->wf_precision() !=
                         sasktran2::Config::WeightingFunctionPrecision::
                             limited) {
@@ -508,7 +636,7 @@ namespace sasktran2::solartransmission {
         const sasktran2::WavelengthBlock<N>& batch, int losidx,
         int wavel_threadidx, int threadidx,
         sasktran2::WavelengthBlockDual<NSTOKES>& source) const {
-        if constexpr (!std::is_same_v<S, SolarTransmissionExact>) {
+        if constexpr (!exact_transmission) {
             throw std::logic_error(
                 "Solar transmission tables do not support wavelength "
                 "batching");
@@ -517,15 +645,12 @@ namespace sasktran2::solartransmission {
                 return;
             }
 
-            const auto& first_layer = m_los_end_layers.at(losidx);
-            const double mu_in = first_layer.exit.cos_zenith_angle(
-                m_geometry.coordinates().sun_unit());
-            if (mu_in <= 0.0) {
+            double mu_in;
+            double mu_out;
+            double phi_diff;
+            if (!ground_scattering_geometry(losidx, mu_in, mu_out, phi_diff)) {
                 return;
             }
-            const double mu_out = -first_layer.exit.cos_zenith_angle(
-                first_layer.average_look_away);
-            const double phi_diff = first_layer.saz_exit;
             const int exit_index = m_index_map[losidx][0];
             const auto solar_trans = wavelength_head(
                 m_solar_trans_batch[wavel_threadidx].row(exit_index), batch);
@@ -571,7 +696,7 @@ namespace sasktran2::solartransmission {
     template <typename S, int NSTOKES>
     void SingleScatterSource<S, NSTOKES>::append_end_of_ray_active_derivatives(
         int losidx, std::vector<int>& derivative_indices) const {
-        if constexpr (!std::is_same_v<S, SolarTransmissionExact>) {
+        if constexpr (!exact_transmission) {
             return;
         }
 
@@ -599,7 +724,7 @@ namespace sasktran2::solartransmission {
     template <typename S, int NSTOKES>
     void SingleScatterSource<S, NSTOKES>::append_interior_active_derivatives(
         int losidx, int layeridx, std::vector<int>& derivative_indices) const {
-        if constexpr (!std::is_same_v<S, SolarTransmissionExact>) {
+        if constexpr (!exact_transmission) {
             return;
         }
 
@@ -634,15 +759,16 @@ namespace sasktran2::solartransmission {
             internal_viewing) {
         ZoneScopedN("Initialize Single Scatter Source Geometry");
         m_traced_rays = &internal_viewing.traced_rays;
-        this->m_solar_transmission.initialize_geometry(
+        this->m_solar_transmission->initialize_geometry(
             internal_viewing.traced_rays);
 
-        if constexpr (std::is_same_v<S, SolarTransmissionExact>) {
+        m_solar_propagation_directions.clear();
+        if constexpr (exact_transmission) {
             {
                 ZoneScopedN("Single Scatter Source Exact Geometry Matrix");
                 if (m_geometry_2d == nullptr) {
                     // The 1D solar geometry is usually dense.
-                    this->m_solar_transmission.generate_geometry_matrix(
+                    this->m_solar_transmission->generate_geometry_matrix(
                         internal_viewing.traced_rays, m_geometry_matrix,
                         m_ground_hit_flag);
                     m_geometry_sparse.use_standard() =
@@ -651,9 +777,22 @@ namespace sasktran2::solartransmission {
 #ifdef SKTRAN_RUST_SUPPORT
                     // Higher-dimensional solar paths remain sparse.
                     m_geometry_matrix.resize(0, 0);
-                    m_solar_transmission.generate_geometry_matrix(
-                        internal_viewing.traced_rays, m_geometry_sparse,
-                        m_ground_hit_flag);
+                    if (m_config->solar_refraction()) {
+                        m_shared_solar_table_2d->initialize_geometry(
+                            internal_viewing.traced_rays);
+                        m_shared_solar_table_2d->generate_solar_geometry(
+                            internal_viewing.traced_rays, m_ground_hit_flag,
+                            m_solar_propagation_directions);
+                        m_solar_transmission
+                            ->generate_refracted_geometry_matrix(
+                                internal_viewing.traced_rays,
+                                m_solar_propagation_directions,
+                                m_geometry_sparse, m_ground_hit_flag);
+                    } else {
+                        m_solar_transmission->generate_geometry_matrix(
+                            internal_viewing.traced_rays, m_geometry_sparse,
+                            m_ground_hit_flag);
+                    }
 #else
                     throw std::invalid_argument(
                         "Geometry2D exact solar transmission requires Rust "
@@ -663,9 +802,24 @@ namespace sasktran2::solartransmission {
             }
         }
         if constexpr (std::is_same_v<S, SolarTransmissionTable>) {
-            this->m_solar_transmission.generate_interpolation_matrix(
+            this->m_solar_transmission->generate_interpolation_matrix(
                 internal_viewing.traced_rays, m_geometry_sparse.use_standard(),
                 m_ground_hit_flag);
+        }
+        if constexpr (compact_2d_table) {
+            m_solar_transmission->generate_interpolation(
+                internal_viewing.traced_rays, m_solar_interpolation,
+                m_ground_hit_flag,
+                m_config->solar_refraction() ? &m_solar_propagation_directions
+                                             : nullptr);
+            auto& empty_geometry = m_geometry_sparse.use_standard();
+            empty_geometry.resize(m_solar_interpolation.rows(),
+                                  m_geometry.size());
+            empty_geometry.setZero();
+            empty_geometry.makeCompressed();
+            for (auto& cotangent : m_solar_endpoint_cotangent) {
+                cotangent.setZero(m_solar_interpolation.rows());
+            }
         }
 
         // We need some mapping between the layers inside each ray to our
@@ -686,7 +840,10 @@ namespace sasktran2::solartransmission {
         {
             ZoneScopedN("Single Scatter Source Phase Geometry");
             this->m_phase_handler.initialize_geometry(
-                internal_viewing.traced_rays, m_index_map);
+                internal_viewing.traced_rays, m_index_map,
+                m_solar_propagation_directions.empty()
+                    ? nullptr
+                    : &m_solar_propagation_directions);
         }
 
         m_los_ground_is_hit.resize(internal_viewing.traced_rays.size());
@@ -814,7 +971,7 @@ namespace sasktran2::solartransmission {
             m_geometry_1d->altitude_grid().interpolation_method() ==
                 grids::interpolation::lower;
         const bool use_fused_exact_derivatives =
-            calculate_derivatives && std::is_same_v<S, SolarTransmissionExact>;
+            calculate_derivatives && exact_transmission;
 
         if (use_fused_exact_derivatives) {
             const double od = shell_od.od(0);
@@ -1033,7 +1190,7 @@ namespace sasktran2::solartransmission {
         Eigen::Ref<const Eigen::VectorXd> native_tangent,
         sasktran2::RadianceJVP<NSTOKES>& source) const {
         (void)threadidx;
-        if constexpr (!std::is_same_v<S, SolarTransmissionExact>) {
+        if constexpr (!native_transmission_linearization) {
             throw std::logic_error(
                 "Native JVP requires exact solar transmission");
         } else {
@@ -1116,8 +1273,7 @@ namespace sasktran2::solartransmission {
         const Eigen::Vector<double, NSTOKES>&,
         Eigen::Vector<double, NSTOKES>& cotangent,
         Eigen::Ref<Eigen::VectorXd> native_gradient) const {
-        (void)threadidx;
-        if constexpr (!std::is_same_v<S, SolarTransmissionExact>) {
+        if constexpr (!native_transmission_linearization) {
             throw std::logic_error(
                 "Native VJP requires exact solar transmission");
         } else {
@@ -1155,12 +1311,12 @@ namespace sasktran2::solartransmission {
                 factor_derivative = 1 / od - factor * (1 + 1 / od);
             }
             const auto start_value = endpoint_source_vjp(
-                wavelidx, losidx, layeridx, wavel_threadidx, entrance_index,
-                *start_weights, start_is_entrance,
+                wavelidx, losidx, layeridx, wavel_threadidx, threadidx,
+                entrance_index, *start_weights, start_is_entrance,
                 factor * layer.od_quad_start * cotangent, native_gradient);
             const auto end_value = endpoint_source_vjp(
-                wavelidx, losidx, layeridx, wavel_threadidx, exit_index,
-                *end_weights, end_is_entrance,
+                wavelidx, losidx, layeridx, wavel_threadidx, threadidx,
+                exit_index, *end_weights, end_is_entrance,
                 factor * layer.od_quad_end * cotangent, native_gradient);
             const double od_cotangent =
                 factor_derivative *
@@ -1186,7 +1342,7 @@ namespace sasktran2::solartransmission {
         sasktran2::WavelengthBlockDual<NSTOKES>& source,
         typename SourceTermInterface<NSTOKES>::IntegrationDirection direction)
         const {
-        if constexpr (!std::is_same_v<S, SolarTransmissionExact>) {
+        if constexpr (!exact_transmission) {
             throw std::logic_error(
                 "Solar transmission tables do not support wavelength "
                 "batching");
@@ -1325,4 +1481,8 @@ namespace sasktran2::solartransmission {
 
     template class SingleScatterSource<SolarTransmissionTable, 1>;
     template class SingleScatterSource<SolarTransmissionTable, 3>;
+#ifdef SKTRAN_RUST_SUPPORT
+    template class SingleScatterSource<SolarTransmissionTable2D, 1>;
+    template class SingleScatterSource<SolarTransmissionTable2D, 3>;
+#endif
 } // namespace sasktran2::solartransmission

--- a/cpp/lib/solar/singlescattersource.cpp
+++ b/cpp/lib/solar/singlescattersource.cpp
@@ -87,7 +87,7 @@ namespace sasktran2::solartransmission {
             // Faster to use the dense matrix if most of the elements are
             // nonzero
             if (m_geometry_matrix.size() > 0 &&
-                double(m_geometry_sparse.nonZeros()) /
+                double(m_geometry_sparse.non_zeros()) /
                         double(m_geometry_matrix.size()) >
                     DENSE_GEOMETRY_THRESHOLD) {
                 m_solar_trans[threadidx].noalias() =
@@ -95,18 +95,21 @@ namespace sasktran2::solartransmission {
                     m_atmosphere->storage().total_extinction(
                         Eigen::placeholders::all, wavelidx);
             } else {
-                m_solar_trans[threadidx].noalias() =
-                    m_geometry_sparse *
+                m_solar_trans[threadidx].resize(m_geometry_sparse.rows());
+                const auto extinction =
                     m_atmosphere->storage().total_extinction(
                         Eigen::placeholders::all, wavelidx);
+                m_geometry_sparse.multiply(extinction,
+                                           m_solar_trans[threadidx]);
             }
         }
 
         if constexpr (std::is_same_v<S, SolarTransmissionTable>) {
             m_solar_trans[threadidx].noalias() =
-                m_geometry_sparse * (m_solar_transmission.geometry_matrix() *
-                                     m_atmosphere->storage().total_extinction(
-                                         Eigen::placeholders::all, wavelidx));
+                m_geometry_sparse.standard() *
+                (m_solar_transmission.geometry_matrix() *
+                 m_atmosphere->storage().total_extinction(
+                     Eigen::placeholders::all, wavelidx));
         }
 
         m_solar_trans[threadidx] =
@@ -170,12 +173,12 @@ namespace sasktran2::solartransmission {
             const auto extinction = wavelength_middle_cols(
                 m_atmosphere->storage().total_extinction, batch);
             if (m_geometry_matrix.size() > 0 &&
-                double(m_geometry_sparse.nonZeros()) /
+                double(m_geometry_sparse.non_zeros()) /
                         double(m_geometry_matrix.size()) >
                     DENSE_GEOMETRY_THRESHOLD) {
                 solar_trans.noalias() = m_geometry_matrix * extinction;
             } else {
-                solar_trans.noalias() = m_geometry_sparse * extinction;
+                m_geometry_sparse.multiply(extinction, solar_trans);
             }
             solar_trans = (-solar_trans.array()).exp().matrix();
             for (int lane = 0; lane < batch.count; ++lane) {
@@ -239,13 +242,8 @@ namespace sasktran2::solartransmission {
 
             const double solar_trans = solar_transmission_value(
                 wavelidx, wavel_threadidx, solar_index);
-            double solar_od_jvp = 0.0;
-            for (Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator
-                     derivative(m_geometry_sparse, solar_index);
-                 derivative; ++derivative) {
-                solar_od_jvp +=
-                    derivative.value() * native_tangent(derivative.index());
-            }
+            const double solar_od_jvp =
+                m_geometry_sparse.row_dot(solar_index, native_tangent);
             const double solar_trans_jvp = -solar_trans * solar_od_jvp;
 
             Eigen::Vector<double, NSTOKES> phase;
@@ -316,12 +314,9 @@ namespace sasktran2::solartransmission {
                 native_gradient(m_atmosphere->ssa_deriv_start_index() +
                                 weight.first) += weight.second * ssa_cotangent;
             }
-            for (Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator
-                     derivative(m_geometry_sparse, solar_index);
-                 derivative; ++derivative) {
-                native_gradient(derivative.index()) -=
-                    derivative.value() * solar_trans * solar_trans_cotangent;
-            }
+            m_geometry_sparse.accumulate_row(
+                solar_index, -solar_trans * solar_trans_cotangent,
+                native_gradient);
             m_phase_handler.scatter_vjp(wavel_threadidx, losidx, layeridx,
                                         wavelidx, weights, is_entrance,
                                         amplitude * cotangent, native_gradient);
@@ -357,12 +352,8 @@ namespace sasktran2::solartransmission {
             double solar_od_jvp = 0.0;
             if (m_config->wf_precision() !=
                 sasktran2::Config::WeightingFunctionPrecision::limited) {
-                for (Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator
-                         derivative(m_geometry_sparse, solar_index);
-                     derivative; ++derivative) {
-                    solar_od_jvp +=
-                        derivative.value() * native_tangent(derivative.index());
-                }
+                solar_od_jvp =
+                    m_geometry_sparse.row_dot(solar_index, native_tangent);
             }
             const double solar_trans_jvp = -solar_trans * solar_od_jvp;
             const auto brdf =
@@ -418,13 +409,9 @@ namespace sasktran2::solartransmission {
                 mu_in * cotangent.dot(brdf(Eigen::placeholders::all, 0));
             if (m_config->wf_precision() !=
                 sasktran2::Config::WeightingFunctionPrecision::limited) {
-                for (Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator
-                         derivative(m_geometry_sparse, solar_index);
-                     derivative; ++derivative) {
-                    native_gradient(derivative.index()) -=
-                        derivative.value() * solar_trans *
-                        solar_trans_cotangent;
-                }
+                m_geometry_sparse.accumulate_row(
+                    solar_index, -solar_trans * solar_trans_cotangent,
+                    native_gradient);
             }
             for (int derivative = 0;
                  derivative < m_atmosphere->surface().num_deriv();
@@ -489,9 +476,8 @@ namespace sasktran2::solartransmission {
                             limited) {
                         // Have to apply the solar transmission derivative
                         // factors
-                        for (Eigen::SparseMatrix<double,
-                                                 Eigen::RowMajor>::InnerIterator
-                                 it(m_geometry_sparse, exit_index);
+                        for (SolarGeometryMatrix::InnerIterator it(
+                                 m_geometry_sparse, exit_index);
                              it; ++it) {
                             source.deriv(Eigen::placeholders::all,
                                          it.index()) -=
@@ -558,9 +544,8 @@ namespace sasktran2::solartransmission {
                 }
                 if (m_config->wf_precision() !=
                     sasktran2::Config::WeightingFunctionPrecision::limited) {
-                    for (Eigen::SparseMatrix<double,
-                                             Eigen::RowMajor>::InnerIterator
-                             derivative(m_geometry_sparse, exit_index);
+                    for (SolarGeometryMatrix::InnerIterator derivative(
+                             m_geometry_sparse, exit_index);
                          derivative; ++derivative) {
                         source.derivative(derivative.index(), batch)
                             .col(lane) -= derivative.value() * source_value;
@@ -597,8 +582,8 @@ namespace sasktran2::solartransmission {
         if (m_config->wf_precision() !=
             sasktran2::Config::WeightingFunctionPrecision::limited) {
             const int exit_index = m_index_map[losidx][0];
-            for (Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator
-                     derivative(m_geometry_sparse, exit_index);
+            for (SolarGeometryMatrix::InnerIterator derivative(
+                     m_geometry_sparse, exit_index);
                  derivative; ++derivative) {
                 derivative_indices.push_back(derivative.index());
             }
@@ -660,7 +645,8 @@ namespace sasktran2::solartransmission {
                     this->m_solar_transmission.generate_geometry_matrix(
                         internal_viewing.traced_rays, m_geometry_matrix,
                         m_ground_hit_flag);
-                    m_geometry_sparse = m_geometry_matrix.sparseView();
+                    m_geometry_sparse.use_standard() =
+                        m_geometry_matrix.sparseView();
                 } else {
 #ifdef SKTRAN_RUST_SUPPORT
                     // Higher-dimensional solar paths remain sparse.
@@ -678,7 +664,7 @@ namespace sasktran2::solartransmission {
         }
         if constexpr (std::is_same_v<S, SolarTransmissionTable>) {
             this->m_solar_transmission.generate_interpolation_matrix(
-                internal_viewing.traced_rays, m_geometry_sparse,
+                internal_viewing.traced_rays, m_geometry_sparse.use_standard(),
                 m_ground_hit_flag);
         }
 
@@ -734,12 +720,12 @@ namespace sasktran2::solartransmission {
                 std::vector<int>& result) {
                 result.clear();
                 result.reserve(
-                    m_geometry_sparse.innerVector(solar_index).nonZeros() +
+                    m_geometry_sparse.row_nonzeros(solar_index) +
                     geometry_weights.size() *
                         (2 + m_atmosphere->num_scattering_deriv_groups()));
 
-                for (Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator
-                         it(m_geometry_sparse, solar_index);
+                for (SolarGeometryMatrix::InnerIterator it(m_geometry_sparse,
+                                                           solar_index);
                      it; ++it) {
                     result.push_back(it.index());
                 }
@@ -862,16 +848,16 @@ namespace sasktran2::solartransmission {
                     m_phase_handler, wavel_threadidx, losidx, layeridx,
                     wavelidx, *start_weights, start_is_entrance,
                     solar_trans_entrance, *m_atmosphere,
-                    Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator(
-                        m_geometry_sparse, entrance_index),
+                    SolarGeometryMatrix::InnerIterator(m_geometry_sparse,
+                                                       entrance_index),
                     source_factor * layer.od_quad_start, source);
             const Eigen::Vector<double, NSTOKES> end_value =
                 accumulate_exact_scattering_source(
                     m_phase_handler, wavel_threadidx, losidx, layeridx,
                     wavelidx, *end_weights, end_is_entrance, solar_trans_exit,
                     *m_atmosphere,
-                    Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator(
-                        m_geometry_sparse, exit_index),
+                    SolarGeometryMatrix::InnerIterator(m_geometry_sparse,
+                                                       exit_index),
                     source_factor * layer.od_quad_end, source);
 
             const Eigen::Vector<double, NSTOKES> source_value =
@@ -900,52 +886,48 @@ namespace sasktran2::solartransmission {
 
         if (use_lower_interpolation) {
             if (layer.r_exit > layer.r_entrance) {
-                scattering_source(
-                    m_phase_handler, wavel_threadidx, losidx, layeridx,
-                    wavelidx, entrance_weights, true, solar_trans_entrance,
-                    *m_atmosphere,
-                    Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator(
-                        m_geometry_sparse, entrance_index),
-                    calculate_derivatives, start_phase);
+                scattering_source(m_phase_handler, wavel_threadidx, losidx,
+                                  layeridx, wavelidx, entrance_weights, true,
+                                  solar_trans_entrance, *m_atmosphere,
+                                  SolarGeometryMatrix::InnerIterator(
+                                      m_geometry_sparse, entrance_index),
+                                  calculate_derivatives, start_phase);
 
-                scattering_source(
-                    m_phase_handler, wavel_threadidx, losidx, layeridx,
-                    wavelidx, entrance_weights, true, solar_trans_exit,
-                    *m_atmosphere,
-                    Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator(
-                        m_geometry_sparse, exit_index),
-                    calculate_derivatives, end_phase);
+                scattering_source(m_phase_handler, wavel_threadidx, losidx,
+                                  layeridx, wavelidx, entrance_weights, true,
+                                  solar_trans_exit, *m_atmosphere,
+                                  SolarGeometryMatrix::InnerIterator(
+                                      m_geometry_sparse, exit_index),
+                                  calculate_derivatives, end_phase);
             } else {
-                scattering_source(
-                    m_phase_handler, wavel_threadidx, losidx, layeridx,
-                    wavelidx, exit_weights, false, solar_trans_entrance,
-                    *m_atmosphere,
-                    Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator(
-                        m_geometry_sparse, entrance_index),
-                    calculate_derivatives, start_phase);
+                scattering_source(m_phase_handler, wavel_threadidx, losidx,
+                                  layeridx, wavelidx, exit_weights, false,
+                                  solar_trans_entrance, *m_atmosphere,
+                                  SolarGeometryMatrix::InnerIterator(
+                                      m_geometry_sparse, entrance_index),
+                                  calculate_derivatives, start_phase);
 
-                scattering_source(
-                    m_phase_handler, wavel_threadidx, losidx, layeridx,
-                    wavelidx, exit_weights, false, solar_trans_exit,
-                    *m_atmosphere,
-                    Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator(
-                        m_geometry_sparse, exit_index),
-                    calculate_derivatives, end_phase);
+                scattering_source(m_phase_handler, wavel_threadidx, losidx,
+                                  layeridx, wavelidx, exit_weights, false,
+                                  solar_trans_exit, *m_atmosphere,
+                                  SolarGeometryMatrix::InnerIterator(
+                                      m_geometry_sparse, exit_index),
+                                  calculate_derivatives, end_phase);
             }
         } else {
-            scattering_source(
-                m_phase_handler, wavel_threadidx, losidx, layeridx, wavelidx,
-                entrance_weights, true, solar_trans_entrance, *m_atmosphere,
-                Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator(
-                    m_geometry_sparse, entrance_index),
-                calculate_derivatives, start_phase);
+            scattering_source(m_phase_handler, wavel_threadidx, losidx,
+                              layeridx, wavelidx, entrance_weights, true,
+                              solar_trans_entrance, *m_atmosphere,
+                              SolarGeometryMatrix::InnerIterator(
+                                  m_geometry_sparse, entrance_index),
+                              calculate_derivatives, start_phase);
 
-            scattering_source(
-                m_phase_handler, wavel_threadidx, losidx, layeridx, wavelidx,
-                exit_weights, false, solar_trans_exit, *m_atmosphere,
-                Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator(
-                    m_geometry_sparse, exit_index),
-                calculate_derivatives, end_phase);
+            scattering_source(m_phase_handler, wavel_threadidx, losidx,
+                              layeridx, wavelidx, exit_weights, false,
+                              solar_trans_exit, *m_atmosphere,
+                              SolarGeometryMatrix::InnerIterator(
+                                  m_geometry_sparse, exit_index),
+                              calculate_derivatives, end_phase);
         }
 
         double source_factor1;
@@ -1266,8 +1248,8 @@ namespace sasktran2::solartransmission {
                 m_phase_handler, wavel_threadidx, losidx, layeridx, batch,
                 *start_weights, start_is_entrance, solar_trans_entrance,
                 *m_atmosphere,
-                Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator(
-                    m_geometry_sparse, entrance_index),
+                SolarGeometryMatrix::InnerIterator(m_geometry_sparse,
+                                                   entrance_index),
                 start_derivative_scale, source, start_cache);
             const auto start_value =
                 wavelength_left_cols(start_cache.endpoint_source, batch);
@@ -1279,8 +1261,8 @@ namespace sasktran2::solartransmission {
             accumulate_exact_scattering_source_block<NSTOKES, N>(
                 m_phase_handler, wavel_threadidx, losidx, layeridx, batch,
                 *end_weights, end_is_entrance, solar_trans_exit, *m_atmosphere,
-                Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator(
-                    m_geometry_sparse, exit_index),
+                SolarGeometryMatrix::InnerIterator(m_geometry_sparse,
+                                                   exit_index),
                 end_derivative_scale, source, end_cache);
             const auto end_value =
                 wavelength_left_cols(end_cache.endpoint_source, batch);

--- a/cpp/lib/solar/singlescattersource.cpp
+++ b/cpp/lib/solar/singlescattersource.cpp
@@ -69,6 +69,12 @@ namespace sasktran2::solartransmission {
         this->m_solar_transmission->initialize_config(config);
 #ifdef SKTRAN_RUST_SUPPORT
         if constexpr (exact_transmission) {
+            if (m_geometry_2d != nullptr && config.solar_refraction() &&
+                m_shared_solar_table_2d == nullptr) {
+                m_shared_solar_table_2d =
+                    std::make_shared<SolarTransmissionTable2D>(*m_geometry_2d,
+                                                               *m_raytracer_2d);
+            }
             if (m_shared_solar_table_2d != nullptr) {
                 m_shared_solar_table_2d->initialize_config(config);
             }

--- a/cpp/lib/solar/solartransmissionexact.cpp
+++ b/cpp/lib/solar/solartransmissionexact.cpp
@@ -194,7 +194,8 @@ namespace sasktran2::solartransmission {
                         ground_hit_flag[row] = true;
                         append_empty_row(row);
                     } else {
-                        m_raytracer_2d->trace_ray(ray_to_sun, traced_ray);
+                        m_raytracer_2d->trace_ray_optical_depth(ray_to_sun,
+                                                                traced_ray);
                         append_ray(row);
                     }
                     ++row;
@@ -205,7 +206,8 @@ namespace sasktran2::solartransmission {
                     ground_hit_flag[row] = true;
                     append_empty_row(row);
                 } else {
-                    m_raytracer_2d->trace_ray(ray_to_sun, traced_ray);
+                    m_raytracer_2d->trace_ray_optical_depth(ray_to_sun,
+                                                            traced_ray);
                     append_ray(row);
                 }
                 ++row;

--- a/cpp/lib/solar/solartransmissionexact.cpp
+++ b/cpp/lib/solar/solartransmissionexact.cpp
@@ -102,15 +102,20 @@ namespace sasktran2::solartransmission {
 
         od_matrix.resize(numpoints, m_geometry.size());
         ground_hit_flag.assign(numpoints, false);
-
-        std::vector<Eigen::Triplet<double>> triplets;
-        triplets.reserve(static_cast<std::size_t>(numpoints) * 16);
+        od_matrix.reserve(static_cast<Eigen::Index>(numpoints) * 16);
 
         sasktran2::viewinggeometry::ViewingRay ray_to_sun;
         ray_to_sun.look_away = m_geometry.coordinates().sun_unit();
         raytracing::TracedRay traced_ray;
+        std::vector<std::pair<int, double>> row_weights;
+        row_weights.reserve(static_cast<std::size_t>(
+                                m_geometry_2d->altitude_grid().grid().size() +
+                                m_geometry_2d->horizontal_angle_grid().size()) *
+                            4);
 
         const auto append_ray = [&](int row) {
+            od_matrix.startVec(row);
+            row_weights.clear();
             for (std::size_t layer_index = 0;
                  layer_index < traced_ray.layers.size(); ++layer_index) {
                 const auto weights =
@@ -118,11 +123,32 @@ namespace sasktran2::solartransmission {
                 for (std::size_t index = 0; index < weights.size(); ++index) {
                     const auto weight = weights[index];
                     if (weight.second != 0.0) {
-                        triplets.emplace_back(row, weight.first, weight.second);
+                        row_weights.push_back(weight);
                     }
                 }
             }
+
+            std::sort(row_weights.begin(), row_weights.end(),
+                      [](const auto& left, const auto& right) {
+                          return left.first < right.first;
+                      });
+            for (std::size_t begin = 0; begin < row_weights.size();) {
+                const int column = row_weights[begin].first;
+                double value = 0.0;
+                std::size_t end = begin;
+                while (end < row_weights.size() &&
+                       row_weights[end].first == column) {
+                    value += row_weights[end].second;
+                    ++end;
+                }
+                if (value != 0.0) {
+                    od_matrix.insertBackByOuterInner(row, column) = value;
+                }
+                begin = end;
+            }
         };
+
+        const auto append_empty_row = [&](int row) { od_matrix.startVec(row); };
 
         int row = 0;
         for (const auto& ray : rays) {
@@ -133,6 +159,7 @@ namespace sasktran2::solartransmission {
                     ray_to_sun.observer = layer.exit;
                     if (solar_ray_hits_ground(layer.exit, *m_geometry_2d)) {
                         ground_hit_flag[row] = true;
+                        append_empty_row(row);
                     } else {
                         m_raytracer_2d->trace_ray(ray_to_sun, traced_ray);
                         append_ray(row);
@@ -143,6 +170,7 @@ namespace sasktran2::solartransmission {
                 ray_to_sun.observer = layer.entrance;
                 if (solar_ray_hits_ground(layer.entrance, *m_geometry_2d)) {
                     ground_hit_flag[row] = true;
+                    append_empty_row(row);
                 } else {
                     m_raytracer_2d->trace_ray(ray_to_sun, traced_ray);
                     append_ray(row);
@@ -150,7 +178,8 @@ namespace sasktran2::solartransmission {
                 ++row;
             }
         }
-        od_matrix.setFromTriplets(triplets.begin(), triplets.end());
+        od_matrix.finalize();
+        od_matrix.data().squeeze();
     }
 #endif
 } // namespace sasktran2::solartransmission

--- a/cpp/lib/solar/solartransmissionexact.cpp
+++ b/cpp/lib/solar/solartransmissionexact.cpp
@@ -222,5 +222,121 @@ namespace sasktran2::solartransmission {
             std::count(ground_hit_flag.begin(), ground_hit_flag.end(), true),
             od_matrix.is_compact());
     }
+
+    void SolarTransmissionExact::generate_refracted_geometry_matrix(
+        const std::vector<sasktran2::raytracing::TracedRay>& rays,
+        const std::vector<Eigen::Vector3d>& solar_propagation_directions,
+        SolarGeometryMatrix& od_matrix,
+        std::vector<bool>& ground_hit_flag) const {
+        int numpoints = 0;
+        for (const auto& ray : rays) {
+            numpoints += static_cast<int>(ray.layers.size()) + 1;
+        }
+        if (solar_propagation_directions.size() !=
+                static_cast<std::size_t>(numpoints) ||
+            ground_hit_flag.size() != static_cast<std::size_t>(numpoints)) {
+            throw std::invalid_argument(
+                "Refracted exact solar geometry has inconsistent endpoint "
+                "storage");
+        }
+
+        const Eigen::Index dominant_grid_size =
+            std::max(m_geometry_2d->altitude_grid().grid().size(),
+                     m_geometry_2d->horizontal_angle_grid().size());
+        const Eigen::Index initial_entries_per_row = std::max<Eigen::Index>(
+            16, dominant_grid_size - dominant_grid_size / 16);
+        od_matrix.initialize_exact(numpoints, m_geometry.size(),
+                                   static_cast<Eigen::Index>(numpoints) *
+                                       initial_entries_per_row);
+
+        sasktran2::viewinggeometry::ViewingRay ray_to_sun;
+        raytracing::TracedRay traced_ray;
+        std::vector<std::pair<int, double>> row_weights;
+        row_weights.reserve(static_cast<std::size_t>(
+                                m_geometry_2d->altitude_grid().grid().size() +
+                                m_geometry_2d->horizontal_angle_grid().size()) *
+                            4);
+
+        const auto append_ray = [&](int row) {
+            row_weights.clear();
+            for (std::size_t layer_index = 0;
+                 layer_index < traced_ray.layers.size(); ++layer_index) {
+                const auto weights =
+                    traced_ray.optical_depth_weights(layer_index);
+                for (std::size_t index = 0; index < weights.size(); ++index) {
+                    if (weights[index].second != 0.0) {
+                        row_weights.push_back(weights[index]);
+                    }
+                }
+            }
+            std::sort(row_weights.begin(), row_weights.end(),
+                      [](const auto& left, const auto& right) {
+                          return left.first < right.first;
+                      });
+            std::size_t write = 0;
+            for (std::size_t begin = 0; begin < row_weights.size();) {
+                const int column = row_weights[begin].first;
+                double value = 0.0;
+                std::size_t end = begin;
+                while (end < row_weights.size() &&
+                       row_weights[end].first == column) {
+                    value += row_weights[end].second;
+                    ++end;
+                }
+                if (value != 0.0) {
+                    row_weights[write++] = {column, value};
+                }
+                begin = end;
+            }
+            row_weights.resize(write);
+            od_matrix.ensure_capacity(
+                static_cast<Eigen::Index>(row_weights.size()));
+            od_matrix.start_row(row);
+            for (const auto& [column, value] : row_weights) {
+                od_matrix.insert_back(row, column, value);
+            }
+        };
+
+        const auto append_endpoint = [&](const Location& endpoint, int row) {
+            if (ground_hit_flag[row]) {
+                od_matrix.start_row(row);
+                return;
+            }
+            ray_to_sun.observer = endpoint;
+            // The table returns photon propagation toward the endpoint; exact
+            // optical depth is traced in the reverse direction back to TOA.
+            ray_to_sun.look_away =
+                -solar_propagation_directions[row].normalized();
+            m_raytracer_2d->trace_ray_optical_depth(
+                ray_to_sun, m_geometry_2d->refractive_index(), traced_ray);
+            if (traced_ray.ground_is_hit) {
+                ground_hit_flag[row] = true;
+                od_matrix.start_row(row);
+            } else {
+                append_ray(row);
+            }
+        };
+
+        int row = 0;
+        for (const auto& ray : rays) {
+            if (ray.layers.empty()) {
+                od_matrix.start_row(row++);
+                continue;
+            }
+            for (int layer_index = 0; layer_index < ray.layers.size();
+                 ++layer_index) {
+                if (layer_index == 0) {
+                    append_endpoint(ray.layers[layer_index].exit, row++);
+                }
+                append_endpoint(ray.layers[layer_index].entrance, row++);
+            }
+        }
+        od_matrix.finalize();
+        spdlog::debug(
+            "Geometry2D refracted exact solar matrix: {} rows, {} nonzeros, "
+            "{} ground-blocked rows",
+            od_matrix.rows(), od_matrix.non_zeros(),
+            std::count(ground_hit_flag.begin(), ground_hit_flag.end(), true));
+    }
 #endif
 } // namespace sasktran2::solartransmission

--- a/cpp/lib/solar/solartransmissionexact.cpp
+++ b/cpp/lib/solar/solartransmissionexact.cpp
@@ -1,5 +1,7 @@
 #include <sasktran2/solartransmission.h>
 
+#include <spdlog/spdlog.h>
+
 namespace {
     bool solar_ray_hits_ground(const sasktran2::Location& location,
                                const sasktran2::Geometry2D& geometry) {
@@ -93,16 +95,27 @@ namespace sasktran2::solartransmission {
 #ifdef SKTRAN_RUST_SUPPORT
     void SolarTransmissionExact::generate_geometry_matrix(
         const std::vector<sasktran2::raytracing::TracedRay>& rays,
-        Eigen::SparseMatrix<double, Eigen::RowMajor>& od_matrix,
+        SolarGeometryMatrix& od_matrix,
         std::vector<bool>& ground_hit_flag) const {
         int numpoints = 0;
         for (const auto& ray : rays) {
             numpoints += static_cast<int>(ray.layers.size()) + 1;
         }
 
-        od_matrix.resize(numpoints, m_geometry.size());
         ground_hit_flag.assign(numpoints, false);
-        od_matrix.reserve(static_cast<Eigen::Index>(numpoints) * 16);
+        // A straight path through a structured grid usually accumulates about
+        // one sparse coefficient per point along its dominant grid dimension.
+        // Reserving at that scale avoids Eigen's doubling growth for large 2D
+        // matrices while the bounded-growth fallback below handles longer
+        // paths without assuming a hard upper limit.
+        const Eigen::Index dominant_grid_size =
+            std::max(m_geometry_2d->altitude_grid().grid().size(),
+                     m_geometry_2d->horizontal_angle_grid().size());
+        const Eigen::Index initial_entries_per_row = std::max<Eigen::Index>(
+            16, dominant_grid_size - dominant_grid_size / 16);
+        od_matrix.initialize_exact(numpoints, m_geometry.size(),
+                                   static_cast<Eigen::Index>(numpoints) *
+                                       initial_entries_per_row);
 
         sasktran2::viewinggeometry::ViewingRay ray_to_sun;
         ray_to_sun.look_away = m_geometry.coordinates().sun_unit();
@@ -113,8 +126,17 @@ namespace sasktran2::solartransmission {
                                 m_geometry_2d->horizontal_angle_grid().size()) *
                             4);
 
+        const auto ensure_entry_capacity = [&](Eigen::Index additional) {
+            // Eigen doubles compressed storage when insertBack exhausts its
+            // reservation. Large 2D calculations can therefore retain almost
+            // twice their final matrix size because shrinking reallocations are
+            // commonly kept in place by the system allocator. Grow explicitly
+            // by 50% instead, bounding unused retained capacity without adding
+            // a counting/tracing pass.
+            od_matrix.ensure_capacity(additional);
+        };
+
         const auto append_ray = [&](int row) {
-            od_matrix.startVec(row);
             row_weights.clear();
             for (std::size_t layer_index = 0;
                  layer_index < traced_ray.layers.size(); ++layer_index) {
@@ -132,6 +154,7 @@ namespace sasktran2::solartransmission {
                       [](const auto& left, const auto& right) {
                           return left.first < right.first;
                       });
+            std::size_t write = 0;
             for (std::size_t begin = 0; begin < row_weights.size();) {
                 const int column = row_weights[begin].first;
                 double value = 0.0;
@@ -142,13 +165,23 @@ namespace sasktran2::solartransmission {
                     ++end;
                 }
                 if (value != 0.0) {
-                    od_matrix.insertBackByOuterInner(row, column) = value;
+                    row_weights[write++] = {column, value};
                 }
                 begin = end;
             }
+            row_weights.resize(write);
+
+            ensure_entry_capacity(
+                static_cast<Eigen::Index>(row_weights.size()));
+            od_matrix.start_row(row);
+            for (const auto& [column, value] : row_weights) {
+                od_matrix.insert_back(row, column, value);
+            }
         };
 
-        const auto append_empty_row = [&](int row) { od_matrix.startVec(row); };
+        const auto append_empty_row = [&](int row) {
+            od_matrix.start_row(row);
+        };
 
         int row = 0;
         for (const auto& ray : rays) {
@@ -178,8 +211,14 @@ namespace sasktran2::solartransmission {
                 ++row;
             }
         }
+        const Eigen::Index construction_capacity = od_matrix.allocated_size();
         od_matrix.finalize();
-        od_matrix.data().squeeze();
+        spdlog::debug(
+            "Geometry2D exact solar matrix: {} rows, {} nonzeros, {} peak "
+            "construction entries, {} ground-blocked rows, compact storage {}",
+            od_matrix.rows(), od_matrix.non_zeros(), construction_capacity,
+            std::count(ground_hit_flag.begin(), ground_hit_flag.end(), true),
+            od_matrix.is_compact());
     }
 #endif
 } // namespace sasktran2::solartransmission

--- a/cpp/lib/solar/solartransmissiontable.cpp
+++ b/cpp/lib/solar/solartransmissiontable.cpp
@@ -3,6 +3,113 @@
 
 namespace sasktran2::solartransmission {
 
+    void SolarTableInterpolation::clear() {
+        std::vector<std::uint32_t>().swap(m_outer);
+        std::vector<std::uint32_t>().swap(m_inner);
+        std::vector<double>().swap(m_values);
+        m_rows = 0;
+        m_cols = 0;
+        m_next_row = 0;
+    }
+
+    void SolarTableInterpolation::initialize(Eigen::Index rows,
+                                             Eigen::Index cols,
+                                             Eigen::Index capacity) {
+        if (rows < 0 || cols < 0 || capacity < 0 ||
+            cols > static_cast<Eigen::Index>(
+                       std::numeric_limits<std::uint32_t>::max())) {
+            throw std::invalid_argument(
+                "Invalid compact solar interpolation dimensions");
+        }
+        m_rows = rows;
+        m_cols = cols;
+        m_next_row = 0;
+        m_outer.assign(static_cast<std::size_t>(rows) + 1, 0);
+        m_inner.clear();
+        m_values.clear();
+        m_inner.reserve(static_cast<std::size_t>(capacity));
+        m_values.reserve(static_cast<std::size_t>(capacity));
+    }
+
+    void SolarTableInterpolation::append_row(
+        const std::vector<std::pair<int, double>>& interpolation_weights) {
+        if (m_next_row >= m_rows) {
+            throw std::logic_error(
+                "Too many rows appended to compact solar interpolation");
+        }
+        m_outer[static_cast<std::size_t>(m_next_row)] =
+            static_cast<std::uint32_t>(m_values.size());
+        for (const auto& [column, value] : interpolation_weights) {
+            if (column < 0 || column >= m_cols || !std::isfinite(value)) {
+                throw std::invalid_argument(
+                    "Invalid compact solar interpolation entry");
+            }
+            if (value == 0.0) {
+                continue;
+            }
+            if (m_values.size() == std::numeric_limits<std::uint32_t>::max()) {
+                throw std::length_error(
+                    "Compact solar interpolation has too many entries");
+            }
+            m_inner.push_back(static_cast<std::uint32_t>(column));
+            m_values.push_back(value);
+        }
+        ++m_next_row;
+    }
+
+    void SolarTableInterpolation::finalize() {
+        if (m_next_row != m_rows) {
+            throw std::logic_error(
+                "Compact solar interpolation has missing rows");
+        }
+        m_outer[static_cast<std::size_t>(m_rows)] =
+            static_cast<std::uint32_t>(m_values.size());
+        m_inner.shrink_to_fit();
+        m_values.shrink_to_fit();
+    }
+
+    void SolarTableInterpolation::apply(
+        Eigen::Ref<const Eigen::VectorXd> table_values,
+        Eigen::Ref<Eigen::VectorXd> endpoint_values) const {
+        if (table_values.size() != m_cols || endpoint_values.size() != m_rows) {
+            throw std::invalid_argument(
+                "Invalid compact solar interpolation product dimensions");
+        }
+        for (Eigen::Index row = 0; row < m_rows; ++row) {
+            double result = 0.0;
+            const auto begin = m_outer[static_cast<std::size_t>(row)];
+            const auto end = m_outer[static_cast<std::size_t>(row) + 1];
+            for (std::uint32_t entry = begin; entry < end; ++entry) {
+                result += m_values[entry] * table_values(m_inner[entry]);
+            }
+            endpoint_values(row) = result;
+        }
+    }
+
+    void SolarTableInterpolation::apply_transpose(
+        Eigen::Ref<const Eigen::VectorXd> endpoint_values,
+        Eigen::Ref<Eigen::VectorXd> table_values) const {
+        if (endpoint_values.size() != m_rows || table_values.size() != m_cols) {
+            throw std::invalid_argument(
+                "Invalid compact solar interpolation transpose dimensions");
+        }
+        table_values.setZero();
+        for (Eigen::Index row = 0; row < m_rows; ++row) {
+            const double value = endpoint_values(row);
+            const auto begin = m_outer[static_cast<std::size_t>(row)];
+            const auto end = m_outer[static_cast<std::size_t>(row) + 1];
+            for (std::uint32_t entry = begin; entry < end; ++entry) {
+                table_values(m_inner[entry]) += m_values[entry] * value;
+            }
+        }
+    }
+
+    std::size_t SolarTableInterpolation::storage_bytes() const {
+        return m_outer.capacity() * sizeof(std::uint32_t) +
+               m_inner.capacity() * sizeof(std::uint32_t) +
+               m_values.capacity() * sizeof(double);
+    }
+
     void SolarTransmissionTable::initialize_geometry(
         const std::vector<sasktran2::raytracing::TracedRay>& integration_rays) {
         // find the min/max SZA from the LOS rays and generate the cos_sza_grid
@@ -128,5 +235,81 @@ namespace sasktran2::solartransmission {
             }
         }
         interpolator.setFromTriplets(tripletList.begin(), tripletList.end());
+    }
+
+    void SolarTransmissionTable::generate_interpolation(
+        const std::vector<sasktran2::raytracing::TracedRay>& rays,
+        SolarTableInterpolation& interpolator,
+        std::vector<bool>& ground_hit_flag,
+        std::vector<Eigen::Vector3d>* solar_propagation_directions) const {
+        Eigen::Index numpoints = 0;
+        for (const auto& ray : rays) {
+            numpoints += static_cast<Eigen::Index>(ray.layers.size()) + 1;
+        }
+        interpolator.initialize(numpoints,
+                                m_location_interpolator->num_interior_points(),
+                                numpoints * 4);
+        ground_hit_flag.assign(static_cast<std::size_t>(numpoints), false);
+        if (solar_propagation_directions != nullptr) {
+            solar_propagation_directions->assign(
+                static_cast<std::size_t>(numpoints),
+                -m_geometry.coordinates().sun_unit());
+        }
+
+        std::vector<std::pair<int, double>> weights;
+        int num_weights = 0;
+        for (const auto& ray : rays) {
+            if (ray.layers.empty()) {
+                weights.clear();
+                interpolator.append_row(weights);
+                continue;
+            }
+            for (int layer_index = 0; layer_index < ray.layers.size();
+                 ++layer_index) {
+                const auto& layer = ray.layers[layer_index];
+                if (layer_index == 0) {
+                    m_location_interpolator->interior_interpolation_weights(
+                        m_geometry.coordinates(), layer.exit, weights,
+                        num_weights);
+                    weights.resize(num_weights);
+                    interpolator.append_row(weights);
+                }
+                m_location_interpolator->interior_interpolation_weights(
+                    m_geometry.coordinates(), layer.entrance, weights,
+                    num_weights);
+                weights.resize(num_weights);
+                interpolator.append_row(weights);
+            }
+        }
+        interpolator.finalize();
+    }
+
+    void
+    SolarTransmissionTable::apply(Eigen::Ref<const Eigen::VectorXd> extinction,
+                                  Eigen::Ref<Eigen::VectorXd> table_od) const {
+        if (extinction.size() != m_geometry_matrix.cols() ||
+            table_od.size() != m_geometry_matrix.rows()) {
+            throw std::invalid_argument(
+                "Invalid 1D solar-table product dimensions");
+        }
+        table_od.noalias() = m_geometry_matrix * extinction;
+    }
+
+    void SolarTransmissionTable::accumulate_transpose(
+        Eigen::Ref<const Eigen::VectorXd> table_cotangent,
+        Eigen::Ref<Eigen::VectorXd> extinction_cotangent, double scale) const {
+        if (table_cotangent.size() != m_geometry_matrix.rows() ||
+            extinction_cotangent.size() != m_geometry_matrix.cols()) {
+            throw std::invalid_argument(
+                "Invalid 1D solar-table transpose dimensions");
+        }
+        extinction_cotangent.noalias() +=
+            scale * m_geometry_matrix.transpose() * table_cotangent;
+    }
+
+    std::size_t SolarTransmissionTable::storage_bytes() const {
+        return static_cast<std::size_t>(m_geometry_matrix.size()) *
+                   sizeof(double) +
+               m_ground_hit_flag.capacity() * sizeof(bool);
     }
 } // namespace sasktran2::solartransmission

--- a/cpp/lib/solar/solartransmissiontable2d.cpp
+++ b/cpp/lib/solar/solartransmissiontable2d.cpp
@@ -1,0 +1,898 @@
+#include <sasktran2/solartransmission.h>
+
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+
+#ifdef SKTRAN_RUST_SUPPORT
+namespace sasktran2::solartransmission {
+    namespace {
+        constexpr double pi = 3.141592653589793238462643383279502884;
+        constexpr double two_pi = 2.0 * pi;
+        constexpr int maximum_segment_weights = 4;
+
+        int number_of_endpoint_rows(
+            const std::vector<sasktran2::raytracing::TracedRay>& rays) {
+            std::size_t rows = 0;
+            for (const auto& ray : rays) {
+                rows += ray.layers.size() + 1;
+            }
+            if (rows > static_cast<std::size_t>(
+                           std::numeric_limits<int>::max())) {
+                throw std::length_error(
+                    "Solar-table endpoint count exceeds the public index "
+                    "range");
+            }
+            return static_cast<int>(rows);
+        }
+
+        void consolidate_weights(
+            std::vector<std::pair<int, double>>& weights) {
+            std::sort(weights.begin(), weights.end(),
+                      [](const auto& left, const auto& right) {
+                          return left.first < right.first;
+                      });
+            std::size_t output = 0;
+            for (std::size_t begin = 0; begin < weights.size();) {
+                const int index = weights[begin].first;
+                double value = 0.0;
+                std::size_t end = begin;
+                while (end < weights.size() && weights[end].first == index) {
+                    value += weights[end].second;
+                    ++end;
+                }
+                if (value != 0.0) {
+                    weights[output++] = {index, value};
+                }
+                begin = end;
+            }
+            weights.resize(output);
+        }
+    } // namespace
+
+    class SolarTransmissionTable2D::Impl {
+      private:
+        struct SliceEntry {
+            double cos_sza = 0.0;
+            std::uint32_t impact_index = 0;
+            std::uint8_t side = 0;
+        };
+
+        const Geometry2D& m_geometry;
+        const sasktran2::raytracing::RustRayTracer2D& m_raytracer;
+        const sasktran2::Config* m_config = nullptr;
+
+        Eigen::Vector3d m_sun;
+        Eigen::Vector3d m_azimuth_zero;
+        Eigen::Vector3d m_azimuth_quarter;
+        std::vector<double> m_radii;
+        std::vector<double> m_impact_parameters;
+        std::vector<std::vector<SliceEntry>> m_altitude_slices;
+
+        int m_num_azimuths = 0;
+        int m_num_impacts = 0;
+        int m_num_nodes = 0;
+        bool m_compact_indices = false;
+        bool m_initialized = false;
+
+        // Characteristic rays are stored as a compact collection of
+        // incremental atmosphere-cell stencils.
+        std::vector<std::uint32_t> m_ray_segment_offsets;
+        std::vector<std::uint8_t> m_segment_weight_counts;
+        std::vector<std::uint16_t> m_segment_indices16;
+        std::vector<std::uint32_t> m_segment_indices32;
+        std::vector<double> m_segment_weights;
+        std::vector<std::int32_t> m_segment_nodes;
+
+        // (azimuth, impact, altitude, side), where side 0 is the first
+        // sun-inward crossing and side 1 is the crossing after the tangent.
+        std::vector<std::int32_t> m_node_lookup;
+
+        std::size_t ray_index(int azimuth, int impact) const {
+            return static_cast<std::size_t>(azimuth) * m_num_impacts + impact;
+        }
+
+        std::size_t lookup_index(int azimuth, int impact, int altitude,
+                                 int side) const {
+            return (((static_cast<std::size_t>(azimuth) * m_num_impacts +
+                      impact) *
+                         m_radii.size() +
+                     altitude) *
+                        2 +
+                    side);
+        }
+
+        int node(int azimuth, const SliceEntry& entry, int altitude) const {
+            return m_node_lookup[lookup_index(
+                azimuth, static_cast<int>(entry.impact_index), altitude,
+                static_cast<int>(entry.side))];
+        }
+
+        std::uint32_t segment_atmosphere_index(std::size_t segment,
+                                               int slot) const {
+            const std::size_t position =
+                segment * maximum_segment_weights + slot;
+            return m_compact_indices ? m_segment_indices16[position]
+                                     : m_segment_indices32[position];
+        }
+
+        std::uint32_t current_segment_offset() const {
+            if (m_segment_weight_counts.size() >
+                std::numeric_limits<std::uint32_t>::max()) {
+                throw std::length_error(
+                    "Solar-table segment count exceeds the compact offset "
+                    "range");
+            }
+            return static_cast<std::uint32_t>(
+                m_segment_weight_counts.size());
+        }
+
+        int altitude_index(double radius) const {
+            const auto upper =
+                std::lower_bound(m_radii.begin(), m_radii.end(), radius);
+            int candidate;
+            if (upper == m_radii.end()) {
+                candidate = static_cast<int>(m_radii.size()) - 1;
+            } else if (upper == m_radii.begin()) {
+                candidate = 0;
+            } else {
+                const int upper_index =
+                    static_cast<int>(upper - m_radii.begin());
+                candidate = std::abs(radius - m_radii[upper_index - 1]) <
+                                    std::abs(radius - m_radii[upper_index])
+                                ? upper_index - 1
+                                : upper_index;
+            }
+            const double tolerance =
+                std::max(1.0e-3, 128.0 * std::numeric_limits<double>::epsilon() *
+                                       m_radii[candidate]);
+            return std::abs(radius - m_radii[candidate]) <= tolerance
+                       ? candidate
+                       : -1;
+        }
+
+        Eigen::Vector3d impact_direction(double azimuth) const {
+            return std::cos(azimuth) * m_azimuth_zero +
+                   std::sin(azimuth) * m_azimuth_quarter;
+        }
+
+        double position_azimuth(const Eigen::Vector3d& position,
+                                double cos_sza) const {
+            Eigen::Vector3d transverse =
+                position.normalized() - cos_sza * m_sun;
+            if (transverse.squaredNorm() < 1.0e-28) {
+                return 0.0;
+            }
+            transverse.normalize();
+            double result = std::atan2(transverse.dot(m_azimuth_quarter),
+                                       transverse.dot(m_azimuth_zero));
+            if (result < 0.0) {
+                result += two_pi;
+            }
+            return result;
+        }
+
+        void construct_axes() {
+            m_sun = m_geometry.coordinates().sun_unit().normalized();
+            const Eigen::Vector3d reference =
+                m_geometry.coordinates().reference_z();
+            m_azimuth_zero = reference - reference.dot(m_sun) * m_sun;
+            if (m_azimuth_zero.squaredNorm() < 1.0e-24) {
+                const Eigen::Vector3d fallback =
+                    m_geometry.coordinates().reference_x();
+                m_azimuth_zero = fallback - fallback.dot(m_sun) * m_sun;
+            }
+            m_azimuth_zero.normalize();
+            m_azimuth_quarter = m_sun.cross(m_azimuth_zero).normalized();
+        }
+
+        void construct_impact_grid() {
+            const bool refracted = m_config->solar_refraction();
+            const auto& refractive_index = m_geometry.refractive_index();
+            const double top_radius = m_radii.back();
+            const double top_parameter =
+                top_radius * (refracted ? refractive_index[m_radii.size() - 1]
+                                        : 1.0);
+            const double grazing_parameter =
+                std::min(std::nextafter(top_parameter, 0.0),
+                         m_radii.front() *
+                             (refracted ? refractive_index[0] : 1.0));
+
+            m_impact_parameters.clear();
+            const int interior_count =
+                std::max(16, 2 * m_geometry.num_horizontal_locations());
+            for (int index = 0; index < interior_count; ++index) {
+                const double angle =
+                    0.5 * pi * index / static_cast<double>(interior_count - 1);
+                m_impact_parameters.push_back(grazing_parameter *
+                                              std::sin(angle));
+            }
+            for (int altitude = 0; altitude < m_geometry.num_altitudes();
+                 ++altitude) {
+                const double impact =
+                    m_radii[altitude] *
+                    (refracted ? refractive_index[altitude] : 1.0);
+                m_impact_parameters.push_back(
+                    std::min(impact, std::nextafter(top_parameter, 0.0)));
+            }
+            std::sort(m_impact_parameters.begin(), m_impact_parameters.end());
+            const auto new_end = std::unique(
+                m_impact_parameters.begin(), m_impact_parameters.end(),
+                [](double left, double right) {
+                    return std::abs(left - right) <=
+                           64.0 * std::numeric_limits<double>::epsilon() *
+                               std::max({1.0, std::abs(left), std::abs(right)});
+                });
+            m_impact_parameters.erase(new_end, m_impact_parameters.end());
+            m_num_impacts = static_cast<int>(m_impact_parameters.size());
+        }
+
+        void reserve_characteristics() {
+            const std::size_t rays =
+                static_cast<std::size_t>(m_num_azimuths) * m_num_impacts;
+            const std::size_t estimated_segments =
+                rays * static_cast<std::size_t>(
+                           3 * (m_geometry.num_altitudes() +
+                                m_geometry.num_horizontal_locations()) /
+                           2);
+            m_ray_segment_offsets.assign(rays + 1, 0);
+            m_segment_weight_counts.clear();
+            m_segment_nodes.clear();
+            m_segment_weights.clear();
+            m_segment_indices16.clear();
+            m_segment_indices32.clear();
+            m_segment_weight_counts.reserve(estimated_segments);
+            m_segment_nodes.reserve(estimated_segments);
+            m_segment_weights.reserve(estimated_segments *
+                                      maximum_segment_weights);
+            if (m_compact_indices) {
+                m_segment_indices16.reserve(estimated_segments *
+                                            maximum_segment_weights);
+            } else {
+                m_segment_indices32.reserve(estimated_segments *
+                                            maximum_segment_weights);
+            }
+        }
+
+        int allocate_node(int azimuth, int impact, int altitude, int side) {
+            const auto lookup = lookup_index(azimuth, impact, altitude, side);
+            if (m_node_lookup[lookup] >= 0) {
+                return m_node_lookup[lookup];
+            }
+            if (m_num_nodes == std::numeric_limits<int>::max()) {
+                throw std::length_error(
+                    "Solar-table node count exceeds the public index range");
+            }
+            const int result = m_num_nodes++;
+            m_node_lookup[lookup] = result;
+            return result;
+        }
+
+        void append_segment(
+            const sasktran2::raytracing::TracedRay& ray,
+            std::size_t layer_index, std::int32_t node_after) {
+            const auto weights = ray.optical_depth_weights(layer_index);
+            if (weights.size() > maximum_segment_weights) {
+                throw std::logic_error(
+                    "Structured 2D solar sweep encountered a non-cell "
+                    "optical-depth stencil");
+            }
+            m_segment_weight_counts.push_back(
+                static_cast<std::uint8_t>(weights.size()));
+            m_segment_nodes.push_back(node_after);
+            for (int slot = 0; slot < maximum_segment_weights; ++slot) {
+                std::uint32_t atmosphere_index = 0;
+                double weight = 0.0;
+                if (slot < weights.size()) {
+                    const auto value = weights[slot];
+                    atmosphere_index = static_cast<std::uint32_t>(value.first);
+                    weight = value.second;
+                }
+                if (m_compact_indices) {
+                    m_segment_indices16.push_back(
+                        static_cast<std::uint16_t>(atmosphere_index));
+                } else {
+                    m_segment_indices32.push_back(atmosphere_index);
+                }
+                m_segment_weights.push_back(weight);
+            }
+        }
+
+        void trace_characteristic(int azimuth_index, int impact_index) {
+            const double azimuth =
+                two_pi * azimuth_index / static_cast<double>(m_num_azimuths);
+            const double impact = m_impact_parameters[impact_index];
+            const double top_radius = m_radii.back();
+            const double top_refractive_index =
+                m_config->solar_refraction()
+                    ? m_geometry.refractive_index()[m_radii.size() - 1]
+                    : 1.0;
+            const double geometric_impact = impact / top_refractive_index;
+            const double toa_along_sun =
+                std::sqrt(std::max(0.0, top_radius * top_radius -
+                                            geometric_impact *
+                                                geometric_impact));
+            const double observer_radius = top_radius + 1.0;
+            const double observer_along_sun =
+                std::sqrt(std::max(0.0, observer_radius * observer_radius -
+                                            geometric_impact *
+                                                geometric_impact));
+            const Eigen::Vector3d transverse =
+                geometric_impact * impact_direction(azimuth);
+            const Eigen::Vector3d toa_position =
+                transverse + toa_along_sun * m_sun;
+
+            sasktran2::viewinggeometry::ViewingRay incoming;
+            incoming.observer.position =
+                transverse + observer_along_sun * m_sun;
+            incoming.look_away = -m_sun;
+
+            sasktran2::raytracing::TracedRay traced;
+            if (m_config->solar_refraction()) {
+                m_raytracer.trace_ray(incoming, m_geometry.refractive_index(),
+                                      traced);
+            } else {
+                m_raytracer.trace_ray(incoming, traced);
+            }
+
+            const std::size_t ray = ray_index(azimuth_index, impact_index);
+            m_ray_segment_offsets[ray] = current_segment_offset();
+            std::vector<std::uint8_t> crossings(m_radii.size(), 0);
+
+            const int top_altitude = static_cast<int>(m_radii.size()) - 1;
+            allocate_node(azimuth_index, impact_index, top_altitude, 0);
+            crossings[top_altitude] = 1;
+            if (azimuth_index == 0) {
+                m_altitude_slices[top_altitude].push_back(
+                    {toa_position.normalized().dot(m_sun),
+                     static_cast<std::uint32_t>(impact_index), 0});
+            }
+
+            for (std::size_t reverse_index = traced.layers.size();
+                 reverse_index-- > 0;) {
+                const auto& layer = traced.layers[reverse_index];
+                const int altitude = altitude_index(layer.exit.radius());
+                std::int32_t node_after = -1;
+                if (altitude >= 0 && crossings[altitude] < 2) {
+                    const int side = crossings[altitude]++;
+                    node_after = allocate_node(azimuth_index, impact_index,
+                                               altitude, side);
+                    if (azimuth_index == 0) {
+                        m_altitude_slices[altitude].push_back(
+                            {layer.exit.position.normalized().dot(m_sun),
+                             static_cast<std::uint32_t>(impact_index),
+                             static_cast<std::uint8_t>(side)});
+                    }
+                }
+                append_segment(traced, reverse_index, node_after);
+            }
+            m_ray_segment_offsets[ray + 1] = current_segment_offset();
+        }
+
+        void finalize_slices() {
+            for (auto& slice : m_altitude_slices) {
+                std::sort(slice.begin(), slice.end(),
+                          [](const SliceEntry& left, const SliceEntry& right) {
+                              if (left.cos_sza != right.cos_sza) {
+                                  return left.cos_sza < right.cos_sza;
+                              }
+                              if (left.impact_index != right.impact_index) {
+                                  return left.impact_index < right.impact_index;
+                              }
+                              return left.side < right.side;
+                          });
+                if (slice.empty()) {
+                    throw std::runtime_error(
+                        "Solar characteristic table has an empty altitude "
+                        "slice");
+                }
+            }
+        }
+
+        bool straight_ray_hits_ground(const Location& location) const {
+            const double ground_radius = m_radii.front();
+            const double projected_distance = location.position.dot(m_sun);
+            double discriminant =
+                projected_distance * projected_distance -
+                (location.position.squaredNorm() -
+                 ground_radius * ground_radius);
+            const double scale =
+                std::max({1.0, projected_distance * projected_distance,
+                          std::abs(location.position.squaredNorm() -
+                                   ground_radius * ground_radius)});
+            const double tolerance =
+                128.0 * std::numeric_limits<double>::epsilon() * scale;
+            if (discriminant < -tolerance) {
+                return false;
+            }
+            discriminant = std::max(0.0, discriminant);
+            const double far_intersection =
+                -projected_distance + std::sqrt(discriminant);
+            return far_intersection >
+                   64.0 * std::numeric_limits<double>::epsilon() *
+                       ground_radius;
+        }
+
+        std::array<std::pair<int, double>, 2>
+        altitude_weights(double radius) const {
+            if (radius <= m_radii.front()) {
+                return {{{0, 1.0}, {0, 0.0}}};
+            }
+            const int last = static_cast<int>(m_radii.size()) - 1;
+            if (radius >= m_radii.back()) {
+                return {{{last, 1.0}, {last, 0.0}}};
+            }
+            const auto upper =
+                std::upper_bound(m_radii.begin(), m_radii.end(), radius);
+            const int upper_index = static_cast<int>(upper - m_radii.begin());
+            const int lower_index = upper_index - 1;
+            const double upper_weight =
+                (radius - m_radii[lower_index]) /
+                (m_radii[upper_index] - m_radii[lower_index]);
+            return {{{lower_index, 1.0 - upper_weight},
+                     {upper_index, upper_weight}}};
+        }
+
+        std::array<std::pair<int, double>, 2>
+        azimuth_weights(double azimuth) const {
+            const double scaled =
+                azimuth * m_num_azimuths / static_cast<double>(two_pi);
+            int lower = static_cast<int>(std::floor(scaled));
+            double upper_weight = scaled - lower;
+            lower %= m_num_azimuths;
+            if (lower < 0) {
+                lower += m_num_azimuths;
+            }
+            const int upper = (lower + 1) % m_num_azimuths;
+            return {{{lower, 1.0 - upper_weight}, {upper, upper_weight}}};
+        }
+
+        std::array<std::pair<const SliceEntry*, double>, 2>
+        slice_weights(const std::vector<SliceEntry>& slice,
+                      double cos_sza) const {
+            if (cos_sza <= slice.front().cos_sza) {
+                return {{{&slice.front(), 1.0}, {&slice.front(), 0.0}}};
+            }
+            if (cos_sza >= slice.back().cos_sza) {
+                return {{{&slice.back(), 1.0}, {&slice.back(), 0.0}}};
+            }
+            const auto upper = std::upper_bound(
+                slice.begin(), slice.end(), cos_sza,
+                [](double value, const SliceEntry& entry) {
+                    return value < entry.cos_sza;
+                });
+            const auto lower = upper - 1;
+            const double width = upper->cos_sza - lower->cos_sza;
+            if (std::abs(width) <=
+                32.0 * std::numeric_limits<double>::epsilon()) {
+                return {{{&*lower, 1.0}, {&*lower, 0.0}}};
+            }
+            const double upper_weight =
+                (cos_sza - lower->cos_sza) / width;
+            return {{{&*lower, 1.0 - upper_weight},
+                     {&*upper, upper_weight}}};
+        }
+
+        double visibility_limit(
+            const std::array<std::pair<int, double>, 2>& altitude) const {
+            double result = 0.0;
+            for (const auto& [index, weight] : altitude) {
+                result += weight * m_altitude_slices[index].front().cos_sza;
+            }
+            return result;
+        }
+
+        Eigen::Vector3d node_propagation_direction(
+            int azimuth_index, const SliceEntry& entry,
+            int altitude_index) const {
+            if (!m_config->solar_refraction()) {
+                return -m_sun;
+            }
+            const double cos_sza =
+                std::clamp(entry.cos_sza, -1.0, 1.0);
+            const double sin_sza =
+                std::sqrt(std::max(0.0, 1.0 - cos_sza * cos_sza));
+            const double azimuth = two_pi * azimuth_index /
+                                   static_cast<double>(m_num_azimuths);
+            const Eigen::Vector3d transverse = impact_direction(azimuth);
+            const Eigen::Vector3d radial =
+                cos_sza * m_sun + sin_sza * transverse;
+            const Eigen::Vector3d angular =
+                -sin_sza * m_sun + cos_sza * transverse;
+            const double refractive_index =
+                m_geometry.refractive_index()[altitude_index];
+            const double sin_alpha = std::clamp(
+                m_impact_parameters[entry.impact_index] /
+                    (refractive_index * m_radii[altitude_index]),
+                0.0, 1.0);
+            const double cos_alpha =
+                std::sqrt(std::max(0.0, 1.0 - sin_alpha * sin_alpha));
+            const double radial_sign = entry.side == 0 ? -1.0 : 1.0;
+            return (radial_sign * cos_alpha * radial + sin_alpha * angular)
+                .normalized();
+        }
+
+      public:
+        Impl(const Geometry2D& geometry,
+             const sasktran2::raytracing::RustRayTracer2D& raytracer)
+            : m_geometry(geometry), m_raytracer(raytracer) {}
+
+        void initialize_config(const sasktran2::Config& config) {
+            if (m_initialized && m_config != nullptr &&
+                m_config->solar_refraction() != config.solar_refraction()) {
+                throw std::logic_error(
+                    "A shared Geometry2D solar table cannot be reconfigured "
+                    "after geometry initialization");
+            }
+            m_config = &config;
+        }
+
+        void initialize_geometry(
+            const std::vector<sasktran2::raytracing::TracedRay>&) {
+            if (m_config == nullptr) {
+                throw std::logic_error(
+                    "SolarTransmissionTable2D requires configuration before "
+                    "geometry initialization");
+            }
+            if (m_initialized) {
+                return;
+            }
+            construct_axes();
+            const auto& altitudes = m_geometry.altitude_grid().grid();
+            m_radii.resize(static_cast<std::size_t>(altitudes.size()));
+            for (Eigen::Index index = 0; index < altitudes.size(); ++index) {
+                m_radii[index] =
+                    m_geometry.coordinates().earth_radius() + altitudes[index];
+            }
+            // The off-plane axis still scales with horizontal atmospheric
+            // resolution, but half-resolution is a substantially better
+            // setup/memory tradeoff for the smoothly interpolated OD field.
+            m_num_azimuths = std::max(
+                8, (m_geometry.num_horizontal_locations() + 1) / 2);
+            construct_impact_grid();
+            m_compact_indices =
+                m_geometry.size() <=
+                static_cast<int>(std::numeric_limits<std::uint16_t>::max()) + 1;
+            m_num_nodes = 0;
+            m_altitude_slices.assign(m_radii.size(), {});
+            m_node_lookup.assign(
+                static_cast<std::size_t>(m_num_azimuths) * m_num_impacts *
+                    m_radii.size() * 2,
+                -1);
+            reserve_characteristics();
+
+            for (int azimuth = 0; azimuth < m_num_azimuths; ++azimuth) {
+                for (int impact = 0; impact < m_num_impacts; ++impact) {
+                    trace_characteristic(azimuth, impact);
+                }
+            }
+            finalize_slices();
+            m_initialized = true;
+
+            spdlog::debug(
+                "Geometry2D solar characteristic table: {} azimuths, {} "
+                "impact rays, {} nodes, {} segments, compact indices {}",
+                m_num_azimuths, m_num_impacts, m_num_nodes,
+                m_segment_weight_counts.size(), m_compact_indices);
+        }
+
+        void interpolation_weights(
+            const Location& location,
+            std::vector<std::pair<int, double>>& result,
+            bool& ground_hit,
+            Eigen::Vector3d* solar_propagation_direction = nullptr) const {
+            result.clear();
+            const double radius = location.radius();
+            const Eigen::Vector3d radial = location.position / radius;
+            const double cos_sza =
+                std::clamp(radial.dot(m_sun), -1.0, 1.0);
+            const auto altitude = altitude_weights(radius);
+
+            ground_hit =
+                m_config->solar_refraction()
+                    ? cos_sza < visibility_limit(altitude) - 1.0e-12
+                    : straight_ray_hits_ground(location);
+            if (ground_hit) {
+                if (solar_propagation_direction != nullptr) {
+                    *solar_propagation_direction = -m_sun;
+                }
+                return;
+            }
+
+            const double azimuth = position_azimuth(location.position, cos_sza);
+            const auto azimuth_interpolation = azimuth_weights(azimuth);
+            result.reserve(8);
+            Eigen::Vector3d direction = Eigen::Vector3d::Zero();
+            for (const auto& [altitude_index, altitude_weight] : altitude) {
+                if (altitude_weight == 0.0) {
+                    continue;
+                }
+                const auto characteristic =
+                    slice_weights(m_altitude_slices[altitude_index], cos_sza);
+                for (const auto& [azimuth_index, azimuth_weight] :
+                     azimuth_interpolation) {
+                    if (azimuth_weight == 0.0) {
+                        continue;
+                    }
+                    for (const auto& [entry, characteristic_weight] :
+                         characteristic) {
+                        const double weight = altitude_weight * azimuth_weight *
+                                              characteristic_weight;
+                        if (weight == 0.0) {
+                            continue;
+                        }
+                        const int table_node =
+                            node(azimuth_index, *entry, altitude_index);
+                        if (table_node < 0) {
+                            spdlog::error(
+                                "Missing solar table node: azimuth {}, impact "
+                                "{}, altitude {}, side {}, cos_sza {}",
+                                azimuth_index, entry->impact_index,
+                                altitude_index, entry->side, entry->cos_sza);
+                            throw std::logic_error(
+                                "Solar characteristic table topology differs "
+                                "between azimuth planes");
+                        }
+                        result.emplace_back(table_node, weight);
+                        if (solar_propagation_direction != nullptr) {
+                            direction += weight * node_propagation_direction(
+                                                      azimuth_index, *entry,
+                                                      altitude_index);
+                        }
+                    }
+                }
+            }
+            consolidate_weights(result);
+            if (solar_propagation_direction != nullptr) {
+                *solar_propagation_direction =
+                    direction.squaredNorm() > 1.0e-28
+                        ? direction.normalized()
+                        : -m_sun;
+            }
+        }
+
+        void generate_interpolation(
+            const std::vector<sasktran2::raytracing::TracedRay>& rays,
+            SolarTableInterpolation& interpolator,
+            std::vector<bool>& ground_hit_flag,
+            std::vector<Eigen::Vector3d>* solar_propagation_directions) const {
+            const int rows = number_of_endpoint_rows(rays);
+            interpolator.initialize(rows, m_num_nodes,
+                                    static_cast<Eigen::Index>(rows) * 8);
+            ground_hit_flag.assign(static_cast<std::size_t>(rows), false);
+            if (solar_propagation_directions != nullptr) {
+                solar_propagation_directions->assign(
+                    static_cast<std::size_t>(rows), -m_sun);
+            }
+            std::vector<std::pair<int, double>> weights;
+            int row = 0;
+            for (const auto& ray : rays) {
+                if (ray.layers.empty()) {
+                    weights.clear();
+                    interpolator.append_row(weights);
+                    ++row;
+                    continue;
+                }
+                for (int layer = 0; layer < ray.layers.size(); ++layer) {
+                    if (layer == 0) {
+                        bool ground_hit = false;
+                        interpolation_weights(
+                            ray.layers[layer].exit, weights, ground_hit,
+                            solar_propagation_directions == nullptr
+                                ? nullptr
+                                : &(*solar_propagation_directions)[row]);
+                        ground_hit_flag[row] = ground_hit;
+                        interpolator.append_row(weights);
+                        ++row;
+                    }
+                    bool ground_hit = false;
+                    interpolation_weights(ray.layers[layer].entrance, weights,
+                                          ground_hit,
+                                          solar_propagation_directions ==
+                                                  nullptr
+                                              ? nullptr
+                                              : &(*solar_propagation_directions)
+                                                     [row]);
+                    ground_hit_flag[row] = ground_hit;
+                    interpolator.append_row(weights);
+                    ++row;
+                }
+            }
+            interpolator.finalize();
+            spdlog::debug(
+                "Geometry2D solar table interpolation: {} rows, {} entries, "
+                "{} ground-blocked rows",
+                interpolator.rows(), interpolator.non_zeros(),
+                std::count(ground_hit_flag.begin(), ground_hit_flag.end(), true));
+        }
+
+        void generate_solar_geometry(
+            const std::vector<sasktran2::raytracing::TracedRay>& rays,
+            std::vector<bool>& ground_hit_flag,
+            std::vector<Eigen::Vector3d>& solar_propagation_directions) const {
+            const int rows = number_of_endpoint_rows(rays);
+            ground_hit_flag.assign(static_cast<std::size_t>(rows), false);
+            solar_propagation_directions.assign(static_cast<std::size_t>(rows),
+                                                -m_sun);
+            std::vector<std::pair<int, double>> unused_weights;
+            int row = 0;
+            for (const auto& ray : rays) {
+                if (ray.layers.empty()) {
+                    ++row;
+                    continue;
+                }
+                for (int layer = 0; layer < ray.layers.size(); ++layer) {
+                    if (layer == 0) {
+                        bool ground_hit = false;
+                        interpolation_weights(
+                            ray.layers[layer].exit, unused_weights,
+                            ground_hit,
+                            &solar_propagation_directions[row]);
+                        ground_hit_flag[row] = ground_hit;
+                        ++row;
+                    }
+                    bool ground_hit = false;
+                    interpolation_weights(
+                        ray.layers[layer].entrance, unused_weights,
+                        ground_hit,
+                        &solar_propagation_directions[row]);
+                    ground_hit_flag[row] = ground_hit;
+                    ++row;
+                }
+            }
+        }
+
+        int table_size() const { return m_num_nodes; }
+        int atmosphere_size() const { return m_geometry.size(); }
+
+        void apply(Eigen::Ref<const Eigen::VectorXd> extinction,
+                   Eigen::Ref<Eigen::VectorXd> table_od) const {
+            if (extinction.size() != atmosphere_size() ||
+                table_od.size() != table_size()) {
+                throw std::invalid_argument(
+                    "Invalid Geometry2D solar characteristic product "
+                    "dimensions");
+            }
+            table_od.setZero();
+            const std::size_t num_rays = m_ray_segment_offsets.size() - 1;
+            for (std::size_t ray = 0; ray < num_rays; ++ray) {
+                double cumulative = 0.0;
+                const std::size_t begin = m_ray_segment_offsets[ray];
+                const std::size_t end = m_ray_segment_offsets[ray + 1];
+                for (std::size_t segment = begin; segment < end; ++segment) {
+                    const int count = m_segment_weight_counts[segment];
+                    const std::size_t weight_offset =
+                        segment * maximum_segment_weights;
+                    for (int slot = 0; slot < count; ++slot) {
+                        cumulative +=
+                            m_segment_weights[weight_offset + slot] *
+                            extinction(segment_atmosphere_index(segment, slot));
+                    }
+                    const int node_after = m_segment_nodes[segment];
+                    if (node_after >= 0) {
+                        table_od(node_after) = cumulative;
+                    }
+                }
+            }
+        }
+
+        void accumulate_transpose(
+            Eigen::Ref<const Eigen::VectorXd> table_cotangent,
+            Eigen::Ref<Eigen::VectorXd> extinction_cotangent,
+            double scale) const {
+            if (table_cotangent.size() != table_size() ||
+                extinction_cotangent.size() != atmosphere_size()) {
+                throw std::invalid_argument(
+                    "Invalid Geometry2D solar characteristic transpose "
+                    "dimensions");
+            }
+            const std::size_t num_rays = m_ray_segment_offsets.size() - 1;
+            for (std::size_t ray = 0; ray < num_rays; ++ray) {
+                double cumulative = 0.0;
+                const std::size_t begin = m_ray_segment_offsets[ray];
+                const std::size_t end = m_ray_segment_offsets[ray + 1];
+                for (std::size_t segment = end; segment-- > begin;) {
+                    const int node_after = m_segment_nodes[segment];
+                    if (node_after >= 0) {
+                        cumulative += table_cotangent(node_after);
+                    }
+                    if (cumulative == 0.0) {
+                        continue;
+                    }
+                    const int count = m_segment_weight_counts[segment];
+                    const std::size_t weight_offset =
+                        segment * maximum_segment_weights;
+                    for (int slot = 0; slot < count; ++slot) {
+                        extinction_cotangent(
+                            segment_atmosphere_index(segment, slot)) +=
+                            scale * cumulative *
+                            m_segment_weights[weight_offset + slot];
+                    }
+                }
+            }
+        }
+
+        std::size_t storage_bytes() const {
+            std::size_t result =
+                m_radii.capacity() * sizeof(double) +
+                m_impact_parameters.capacity() * sizeof(double) +
+                m_ray_segment_offsets.capacity() * sizeof(std::uint32_t) +
+                m_segment_weight_counts.capacity() * sizeof(std::uint8_t) +
+                m_segment_indices16.capacity() * sizeof(std::uint16_t) +
+                m_segment_indices32.capacity() * sizeof(std::uint32_t) +
+                m_segment_weights.capacity() * sizeof(double) +
+                m_segment_nodes.capacity() * sizeof(std::int32_t) +
+                m_node_lookup.capacity() * sizeof(std::int32_t);
+            for (const auto& slice : m_altitude_slices) {
+                result += slice.capacity() * sizeof(SliceEntry);
+            }
+            return result;
+        }
+    };
+
+    SolarTransmissionTable2D::SolarTransmissionTable2D(
+        const Geometry2D& geometry,
+        const sasktran2::raytracing::RustRayTracer2D& raytracer)
+        : m_impl(std::make_unique<Impl>(geometry, raytracer)) {}
+
+    SolarTransmissionTable2D::~SolarTransmissionTable2D() = default;
+
+    void SolarTransmissionTable2D::initialize_config(
+        const sasktran2::Config& config) {
+        m_impl->initialize_config(config);
+    }
+
+    void SolarTransmissionTable2D::initialize_geometry(
+        const std::vector<sasktran2::raytracing::TracedRay>& integration_rays) {
+        m_impl->initialize_geometry(integration_rays);
+    }
+
+    void SolarTransmissionTable2D::generate_interpolation(
+        const std::vector<sasktran2::raytracing::TracedRay>& rays,
+        SolarTableInterpolation& interpolator,
+        std::vector<bool>& ground_hit_flag,
+        std::vector<Eigen::Vector3d>* solar_propagation_directions) const {
+        m_impl->generate_interpolation(rays, interpolator, ground_hit_flag,
+                                       solar_propagation_directions);
+    }
+
+    void SolarTransmissionTable2D::generate_solar_geometry(
+        const std::vector<sasktran2::raytracing::TracedRay>& rays,
+        std::vector<bool>& ground_hit_flag,
+        std::vector<Eigen::Vector3d>& solar_propagation_directions) const {
+        m_impl->generate_solar_geometry(rays, ground_hit_flag,
+                                        solar_propagation_directions);
+    }
+
+    Eigen::Index SolarTransmissionTable2D::table_size() const {
+        return m_impl->table_size();
+    }
+
+    Eigen::Index SolarTransmissionTable2D::atmosphere_size() const {
+        return m_impl->atmosphere_size();
+    }
+
+    void SolarTransmissionTable2D::apply(
+        Eigen::Ref<const Eigen::VectorXd> extinction,
+        Eigen::Ref<Eigen::VectorXd> table_od) const {
+        m_impl->apply(extinction, table_od);
+    }
+
+    void SolarTransmissionTable2D::accumulate_transpose(
+        Eigen::Ref<const Eigen::VectorXd> table_cotangent,
+        Eigen::Ref<Eigen::VectorXd> extinction_cotangent,
+        double scale) const {
+        m_impl->accumulate_transpose(table_cotangent, extinction_cotangent,
+                                     scale);
+    }
+
+    std::size_t SolarTransmissionTable2D::storage_bytes() const {
+        return m_impl->storage_bytes();
+    }
+} // namespace sasktran2::solartransmission
+#endif

--- a/cpp/lib/solar/solartransmissiontable2d.cpp
+++ b/cpp/lib/solar/solartransmissiontable2d.cpp
@@ -107,9 +107,33 @@ namespace sasktran2::solartransmission {
         }
 
         int node(int azimuth, const SliceEntry& entry, int altitude) const {
-            return m_node_lookup[lookup_index(
+            int result = m_node_lookup[lookup_index(
                 azimuth, static_cast<int>(entry.impact_index), altitude,
                 static_cast<int>(entry.side))];
+            if (result >= 0) {
+                return result;
+            }
+
+            const double shell_parameter =
+                m_radii[altitude] *
+                (m_config->solar_refraction()
+                     ? m_geometry.refractive_index()[altitude]
+                     : 1.0);
+            const double impact = m_impact_parameters[entry.impact_index];
+            const double parameter_tolerance =
+                64.0 * std::numeric_limits<double>::epsilon() *
+                std::max({1.0, std::abs(shell_parameter), std::abs(impact)});
+            constexpr double tangent_cos_tolerance = 1.0e-10;
+            if (std::abs(impact - shell_parameter) <= parameter_tolerance &&
+                std::abs(entry.cos_sza) <= tangent_cos_tolerance) {
+                // Exact shell tangencies have one physical node. Cartesian
+                // roundoff can label it side 0 in one azimuth plane and side 1
+                // in another, so use whichever label that plane recorded.
+                result = m_node_lookup[lookup_index(
+                    azimuth, static_cast<int>(entry.impact_index), altitude,
+                    1 - static_cast<int>(entry.side))];
+            }
+            return result;
         }
 
         std::uint32_t segment_atmosphere_index(std::size_t segment,

--- a/cpp/lib/solar/solartransmissiontable2d.cpp
+++ b/cpp/lib/solar/solartransmissiontable2d.cpp
@@ -22,8 +22,8 @@ namespace sasktran2::solartransmission {
             for (const auto& ray : rays) {
                 rows += ray.layers.size() + 1;
             }
-            if (rows > static_cast<std::size_t>(
-                           std::numeric_limits<int>::max())) {
+            if (rows >
+                static_cast<std::size_t>(std::numeric_limits<int>::max())) {
                 throw std::length_error(
                     "Solar-table endpoint count exceeds the public index "
                     "range");
@@ -31,8 +31,7 @@ namespace sasktran2::solartransmission {
             return static_cast<int>(rows);
         }
 
-        void consolidate_weights(
-            std::vector<std::pair<int, double>>& weights) {
+        void consolidate_weights(std::vector<std::pair<int, double>>& weights) {
             std::sort(weights.begin(), weights.end(),
                       [](const auto& left, const auto& right) {
                           return left.first < right.first;
@@ -99,12 +98,12 @@ namespace sasktran2::solartransmission {
 
         std::size_t lookup_index(int azimuth, int impact, int altitude,
                                  int side) const {
-            return (((static_cast<std::size_t>(azimuth) * m_num_impacts +
-                      impact) *
-                         m_radii.size() +
-                     altitude) *
-                        2 +
-                    side);
+            return (
+                ((static_cast<std::size_t>(azimuth) * m_num_impacts + impact) *
+                     m_radii.size() +
+                 altitude) *
+                    2 +
+                side);
         }
 
         int node(int azimuth, const SliceEntry& entry, int altitude) const {
@@ -128,8 +127,7 @@ namespace sasktran2::solartransmission {
                     "Solar-table segment count exceeds the compact offset "
                     "range");
             }
-            return static_cast<std::uint32_t>(
-                m_segment_weight_counts.size());
+            return static_cast<std::uint32_t>(m_segment_weight_counts.size());
         }
 
         int altitude_index(double radius) const {
@@ -148,9 +146,9 @@ namespace sasktran2::solartransmission {
                                 ? upper_index - 1
                                 : upper_index;
             }
-            const double tolerance =
-                std::max(1.0e-3, 128.0 * std::numeric_limits<double>::epsilon() *
-                                       m_radii[candidate]);
+            const double tolerance = std::max(
+                1.0e-3, 128.0 * std::numeric_limits<double>::epsilon() *
+                            m_radii[candidate]);
             return std::abs(radius - m_radii[candidate]) <= tolerance
                        ? candidate
                        : -1;
@@ -196,12 +194,11 @@ namespace sasktran2::solartransmission {
             const auto& refractive_index = m_geometry.refractive_index();
             const double top_radius = m_radii.back();
             const double top_parameter =
-                top_radius * (refracted ? refractive_index[m_radii.size() - 1]
-                                        : 1.0);
-            const double grazing_parameter =
-                std::min(std::nextafter(top_parameter, 0.0),
-                         m_radii.front() *
-                             (refracted ? refractive_index[0] : 1.0));
+                top_radius *
+                (refracted ? refractive_index[m_radii.size() - 1] : 1.0);
+            const double grazing_parameter = std::min(
+                std::nextafter(top_parameter, 0.0),
+                m_radii.front() * (refracted ? refractive_index[0] : 1.0));
 
             m_impact_parameters.clear();
             const int interior_count =
@@ -237,8 +234,9 @@ namespace sasktran2::solartransmission {
                 static_cast<std::size_t>(m_num_azimuths) * m_num_impacts;
             const std::size_t estimated_segments =
                 rays * static_cast<std::size_t>(
-                           3 * (m_geometry.num_altitudes() +
-                                m_geometry.num_horizontal_locations()) /
+                           3 *
+                           (m_geometry.num_altitudes() +
+                            m_geometry.num_horizontal_locations()) /
                            2);
             m_ray_segment_offsets.assign(rays + 1, 0);
             m_segment_weight_counts.clear();
@@ -273,9 +271,8 @@ namespace sasktran2::solartransmission {
             return result;
         }
 
-        void append_segment(
-            const sasktran2::raytracing::TracedRay& ray,
-            std::size_t layer_index, std::int32_t node_after) {
+        void append_segment(const sasktran2::raytracing::TracedRay& ray,
+                            std::size_t layer_index, std::int32_t node_after) {
             const auto weights = ray.optical_depth_weights(layer_index);
             if (weights.size() > maximum_segment_weights) {
                 throw std::logic_error(
@@ -313,15 +310,13 @@ namespace sasktran2::solartransmission {
                     ? m_geometry.refractive_index()[m_radii.size() - 1]
                     : 1.0;
             const double geometric_impact = impact / top_refractive_index;
-            const double toa_along_sun =
-                std::sqrt(std::max(0.0, top_radius * top_radius -
-                                            geometric_impact *
-                                                geometric_impact));
+            const double toa_along_sun = std::sqrt(
+                std::max(0.0, top_radius * top_radius -
+                                  geometric_impact * geometric_impact));
             const double observer_radius = top_radius + 1.0;
-            const double observer_along_sun =
-                std::sqrt(std::max(0.0, observer_radius * observer_radius -
-                                            geometric_impact *
-                                                geometric_impact));
+            const double observer_along_sun = std::sqrt(
+                std::max(0.0, observer_radius * observer_radius -
+                                  geometric_impact * geometric_impact));
             const Eigen::Vector3d transverse =
                 geometric_impact * impact_direction(azimuth);
             const Eigen::Vector3d toa_position =
@@ -397,10 +392,9 @@ namespace sasktran2::solartransmission {
         bool straight_ray_hits_ground(const Location& location) const {
             const double ground_radius = m_radii.front();
             const double projected_distance = location.position.dot(m_sun);
-            double discriminant =
-                projected_distance * projected_distance -
-                (location.position.squaredNorm() -
-                 ground_radius * ground_radius);
+            double discriminant = projected_distance * projected_distance -
+                                  (location.position.squaredNorm() -
+                                   ground_radius * ground_radius);
             const double scale =
                 std::max({1.0, projected_distance * projected_distance,
                           std::abs(location.position.squaredNorm() -
@@ -461,21 +455,19 @@ namespace sasktran2::solartransmission {
             if (cos_sza >= slice.back().cos_sza) {
                 return {{{&slice.back(), 1.0}, {&slice.back(), 0.0}}};
             }
-            const auto upper = std::upper_bound(
-                slice.begin(), slice.end(), cos_sza,
-                [](double value, const SliceEntry& entry) {
-                    return value < entry.cos_sza;
-                });
+            const auto upper =
+                std::upper_bound(slice.begin(), slice.end(), cos_sza,
+                                 [](double value, const SliceEntry& entry) {
+                                     return value < entry.cos_sza;
+                                 });
             const auto lower = upper - 1;
             const double width = upper->cos_sza - lower->cos_sza;
             if (std::abs(width) <=
                 32.0 * std::numeric_limits<double>::epsilon()) {
                 return {{{&*lower, 1.0}, {&*lower, 0.0}}};
             }
-            const double upper_weight =
-                (cos_sza - lower->cos_sza) / width;
-            return {{{&*lower, 1.0 - upper_weight},
-                     {&*upper, upper_weight}}};
+            const double upper_weight = (cos_sza - lower->cos_sza) / width;
+            return {{{&*lower, 1.0 - upper_weight}, {&*upper, upper_weight}}};
         }
 
         double visibility_limit(
@@ -487,18 +479,17 @@ namespace sasktran2::solartransmission {
             return result;
         }
 
-        Eigen::Vector3d node_propagation_direction(
-            int azimuth_index, const SliceEntry& entry,
-            int altitude_index) const {
+        Eigen::Vector3d node_propagation_direction(int azimuth_index,
+                                                   const SliceEntry& entry,
+                                                   int altitude_index) const {
             if (!m_config->solar_refraction()) {
                 return -m_sun;
             }
-            const double cos_sza =
-                std::clamp(entry.cos_sza, -1.0, 1.0);
+            const double cos_sza = std::clamp(entry.cos_sza, -1.0, 1.0);
             const double sin_sza =
                 std::sqrt(std::max(0.0, 1.0 - cos_sza * cos_sza));
-            const double azimuth = two_pi * azimuth_index /
-                                   static_cast<double>(m_num_azimuths);
+            const double azimuth =
+                two_pi * azimuth_index / static_cast<double>(m_num_azimuths);
             const Eigen::Vector3d transverse = impact_direction(azimuth);
             const Eigen::Vector3d radial =
                 cos_sza * m_sun + sin_sza * transverse;
@@ -506,10 +497,10 @@ namespace sasktran2::solartransmission {
                 -sin_sza * m_sun + cos_sza * transverse;
             const double refractive_index =
                 m_geometry.refractive_index()[altitude_index];
-            const double sin_alpha = std::clamp(
-                m_impact_parameters[entry.impact_index] /
-                    (refractive_index * m_radii[altitude_index]),
-                0.0, 1.0);
+            const double sin_alpha =
+                std::clamp(m_impact_parameters[entry.impact_index] /
+                               (refractive_index * m_radii[altitude_index]),
+                           0.0, 1.0);
             const double cos_alpha =
                 std::sqrt(std::max(0.0, 1.0 - sin_alpha * sin_alpha));
             const double radial_sign = entry.side == 0 ? -1.0 : 1.0;
@@ -552,18 +543,17 @@ namespace sasktran2::solartransmission {
             // The off-plane axis still scales with horizontal atmospheric
             // resolution, but half-resolution is a substantially better
             // setup/memory tradeoff for the smoothly interpolated OD field.
-            m_num_azimuths = std::max(
-                8, (m_geometry.num_horizontal_locations() + 1) / 2);
+            m_num_azimuths =
+                std::max(8, (m_geometry.num_horizontal_locations() + 1) / 2);
             construct_impact_grid();
             m_compact_indices =
                 m_geometry.size() <=
                 static_cast<int>(std::numeric_limits<std::uint16_t>::max()) + 1;
             m_num_nodes = 0;
             m_altitude_slices.assign(m_radii.size(), {});
-            m_node_lookup.assign(
-                static_cast<std::size_t>(m_num_azimuths) * m_num_impacts *
-                    m_radii.size() * 2,
-                -1);
+            m_node_lookup.assign(static_cast<std::size_t>(m_num_azimuths) *
+                                     m_num_impacts * m_radii.size() * 2,
+                                 -1);
             reserve_characteristics();
 
             for (int azimuth = 0; azimuth < m_num_azimuths; ++azimuth) {
@@ -583,20 +573,17 @@ namespace sasktran2::solartransmission {
 
         void interpolation_weights(
             const Location& location,
-            std::vector<std::pair<int, double>>& result,
-            bool& ground_hit,
+            std::vector<std::pair<int, double>>& result, bool& ground_hit,
             Eigen::Vector3d* solar_propagation_direction = nullptr) const {
             result.clear();
             const double radius = location.radius();
             const Eigen::Vector3d radial = location.position / radius;
-            const double cos_sza =
-                std::clamp(radial.dot(m_sun), -1.0, 1.0);
+            const double cos_sza = std::clamp(radial.dot(m_sun), -1.0, 1.0);
             const auto altitude = altitude_weights(radius);
 
-            ground_hit =
-                m_config->solar_refraction()
-                    ? cos_sza < visibility_limit(altitude) - 1.0e-12
-                    : straight_ray_hits_ground(location);
+            ground_hit = m_config->solar_refraction()
+                             ? cos_sza < visibility_limit(altitude) - 1.0e-12
+                             : straight_ray_hits_ground(location);
             if (ground_hit) {
                 if (solar_propagation_direction != nullptr) {
                     *solar_propagation_direction = -m_sun;
@@ -649,10 +636,9 @@ namespace sasktran2::solartransmission {
             }
             consolidate_weights(result);
             if (solar_propagation_direction != nullptr) {
-                *solar_propagation_direction =
-                    direction.squaredNorm() > 1.0e-28
-                        ? direction.normalized()
-                        : -m_sun;
+                *solar_propagation_direction = direction.squaredNorm() > 1.0e-28
+                                                   ? direction.normalized()
+                                                   : -m_sun;
             }
         }
 
@@ -691,13 +677,11 @@ namespace sasktran2::solartransmission {
                         ++row;
                     }
                     bool ground_hit = false;
-                    interpolation_weights(ray.layers[layer].entrance, weights,
-                                          ground_hit,
-                                          solar_propagation_directions ==
-                                                  nullptr
-                                              ? nullptr
-                                              : &(*solar_propagation_directions)
-                                                     [row]);
+                    interpolation_weights(
+                        ray.layers[layer].entrance, weights, ground_hit,
+                        solar_propagation_directions == nullptr
+                            ? nullptr
+                            : &(*solar_propagation_directions)[row]);
                     ground_hit_flag[row] = ground_hit;
                     interpolator.append_row(weights);
                     ++row;
@@ -708,7 +692,8 @@ namespace sasktran2::solartransmission {
                 "Geometry2D solar table interpolation: {} rows, {} entries, "
                 "{} ground-blocked rows",
                 interpolator.rows(), interpolator.non_zeros(),
-                std::count(ground_hit_flag.begin(), ground_hit_flag.end(), true));
+                std::count(ground_hit_flag.begin(), ground_hit_flag.end(),
+                           true));
         }
 
         void generate_solar_geometry(
@@ -730,17 +715,15 @@ namespace sasktran2::solartransmission {
                     if (layer == 0) {
                         bool ground_hit = false;
                         interpolation_weights(
-                            ray.layers[layer].exit, unused_weights,
-                            ground_hit,
+                            ray.layers[layer].exit, unused_weights, ground_hit,
                             &solar_propagation_directions[row]);
                         ground_hit_flag[row] = ground_hit;
                         ++row;
                     }
                     bool ground_hit = false;
-                    interpolation_weights(
-                        ray.layers[layer].entrance, unused_weights,
-                        ground_hit,
-                        &solar_propagation_directions[row]);
+                    interpolation_weights(ray.layers[layer].entrance,
+                                          unused_weights, ground_hit,
+                                          &solar_propagation_directions[row]);
                     ground_hit_flag[row] = ground_hit;
                     ++row;
                 }
@@ -781,10 +764,10 @@ namespace sasktran2::solartransmission {
             }
         }
 
-        void accumulate_transpose(
-            Eigen::Ref<const Eigen::VectorXd> table_cotangent,
-            Eigen::Ref<Eigen::VectorXd> extinction_cotangent,
-            double scale) const {
+        void
+        accumulate_transpose(Eigen::Ref<const Eigen::VectorXd> table_cotangent,
+                             Eigen::Ref<Eigen::VectorXd> extinction_cotangent,
+                             double scale) const {
             if (table_cotangent.size() != table_size() ||
                 extinction_cotangent.size() != atmosphere_size()) {
                 throw std::invalid_argument(
@@ -885,8 +868,7 @@ namespace sasktran2::solartransmission {
 
     void SolarTransmissionTable2D::accumulate_transpose(
         Eigen::Ref<const Eigen::VectorXd> table_cotangent,
-        Eigen::Ref<Eigen::VectorXd> extinction_cotangent,
-        double scale) const {
+        Eigen::Ref<Eigen::VectorXd> extinction_cotangent, double scale) const {
         m_impl->accumulate_transpose(table_cotangent, extinction_cotangent,
                                      scale);
     }

--- a/cpp/lib/successive_orders/factory.h
+++ b/cpp/lib/successive_orders/factory.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <sasktran2/source_interface.h>
+#include <sasktran2/solartransmission.h>
 
 #include <memory>
 
@@ -37,15 +38,21 @@ namespace sasktran2::successive_orders {
     template <int NSTOKES>
     std::unique_ptr<SourceTermInterface<NSTOKES>> make_successive_orders_source(
         const sasktran2::raytracing::RustRayTracer2D& raytracer,
-        const sasktran2::Geometry2D& geometry);
+        const sasktran2::Geometry2D& geometry,
+        std::shared_ptr<sasktran2::solartransmission::SolarTransmissionTable2D>
+            shared_solar_table = nullptr);
 
     extern template std::unique_ptr<SourceTermInterface<1>>
     make_successive_orders_source<1>(
         const sasktran2::raytracing::RustRayTracer2D&,
-        const sasktran2::Geometry2D&);
+        const sasktran2::Geometry2D&,
+        std::shared_ptr<
+            sasktran2::solartransmission::SolarTransmissionTable2D>);
     extern template std::unique_ptr<SourceTermInterface<3>>
     make_successive_orders_source<3>(
         const sasktran2::raytracing::RustRayTracer2D&,
-        const sasktran2::Geometry2D&);
+        const sasktran2::Geometry2D&,
+        std::shared_ptr<
+            sasktran2::solartransmission::SolarTransmissionTable2D>);
 #endif
 } // namespace sasktran2::successive_orders

--- a/cpp/lib/successive_orders/factory.h
+++ b/cpp/lib/successive_orders/factory.h
@@ -6,9 +6,15 @@
 
 namespace sasktran2 {
     class Geometry1D;
+#ifdef SKTRAN_RUST_SUPPORT
+    class Geometry2D;
+#endif
     namespace raytracing {
         class RayTracerBase;
-    }
+#ifdef SKTRAN_RUST_SUPPORT
+        class RustRayTracer2D;
+#endif
+    } // namespace raytracing
 } // namespace sasktran2
 
 namespace sasktran2::successive_orders {
@@ -26,4 +32,20 @@ namespace sasktran2::successive_orders {
     make_successive_orders_source<3>(
         const sasktran2::raytracing::RayTracerBase&,
         const sasktran2::Geometry1D&);
+
+#ifdef SKTRAN_RUST_SUPPORT
+    template <int NSTOKES>
+    std::unique_ptr<SourceTermInterface<NSTOKES>> make_successive_orders_source(
+        const sasktran2::raytracing::RustRayTracer2D& raytracer,
+        const sasktran2::Geometry2D& geometry);
+
+    extern template std::unique_ptr<SourceTermInterface<1>>
+    make_successive_orders_source<1>(
+        const sasktran2::raytracing::RustRayTracer2D&,
+        const sasktran2::Geometry2D&);
+    extern template std::unique_ptr<SourceTermInterface<3>>
+    make_successive_orders_source<3>(
+        const sasktran2::raytracing::RustRayTracer2D&,
+        const sasktran2::Geometry2D&);
+#endif
 } // namespace sasktran2::successive_orders

--- a/cpp/lib/successive_orders/first_order.cpp
+++ b/cpp/lib/successive_orders/first_order.cpp
@@ -155,9 +155,21 @@ namespace sasktran2::successive_orders {
     FirstOrderProvider<NSTOKES>::FirstOrderProvider(
         const sasktran2::Geometry1D& geometry,
         const sasktran2::raytracing::RayTracerBase& raytracer)
+        : m_geometry(geometry), m_geometry_1d(&geometry),
+          m_source(geometry, raytracer),
+          m_solar_table(std::make_unique<
+                        sasktran2::solartransmission::SolarTransmissionTable>(
+              geometry, raytracer)),
+          m_integrator(false), m_source_terms{&m_source} {}
+
+#ifdef SKTRAN_RUST_SUPPORT
+    template <int NSTOKES>
+    FirstOrderProvider<NSTOKES>::FirstOrderProvider(
+        const sasktran2::Geometry2D& geometry,
+        const sasktran2::raytracing::RustRayTracer2D& raytracer)
         : m_geometry(geometry), m_source(geometry, raytracer),
-          m_solar_table(geometry, raytracer), m_integrator(false),
-          m_source_terms{&m_source} {}
+          m_integrator(false), m_source_terms{&m_source} {}
+#endif
 
     template <int NSTOKES>
     void FirstOrderProvider<NSTOKES>::initialize_config(
@@ -200,7 +212,8 @@ namespace sasktran2::successive_orders {
         m_num_wavelength_threads = config.num_wavelength_threads();
         m_num_phase_moments = config.num_singlescatter_moments();
         m_compact_scalar_requested =
-            NSTOKES == 1 && !config.multiple_scatter_refraction() &&
+            m_geometry_1d != nullptr && NSTOKES == 1 &&
+            !config.multiple_scatter_refraction() &&
             config.singlescatter_phasemode() ==
                 sasktran2::Config::SingleScatterPhaseMode::from_legendre;
         m_use_compact_scalar = false;
@@ -211,7 +224,7 @@ namespace sasktran2::successive_orders {
                 "thread counts");
         }
         if (m_compact_scalar_requested) {
-            m_solar_table.initialize_config(config);
+            m_solar_table->initialize_config(config);
         } else {
             m_source.initialize_config(config);
             m_source.set_wavelength_block_capacity(1);
@@ -267,11 +280,12 @@ namespace sasktran2::successive_orders {
                 "contains a refracted incoming ray");
         }
         m_use_lower_interpolation =
-            m_geometry.altitude_grid().interpolation_method() ==
-            sasktran2::grids::interpolation::lower;
+            m_geometry_1d != nullptr &&
+            m_geometry_1d->altitude_grid().interpolation_method() ==
+                sasktran2::grids::interpolation::lower;
         if (m_use_compact_scalar) {
-            m_solar_table.initialize_geometry(viewing.traced_rays);
-            m_solar_table.generate_interpolation_matrix(
+            m_solar_table->initialize_geometry(viewing.traced_rays);
+            m_solar_table->generate_interpolation_matrix(
                 viewing.traced_rays, m_solar_interpolation, m_solar_ground_hit);
             m_solar_interpolation.makeCompressed();
         } else {
@@ -402,7 +416,7 @@ namespace sasktran2::successive_orders {
             for (int thread = 0; thread < m_num_threads; ++thread) {
                 m_solar_product_scratch[thread].resize(solar_offset);
                 m_solar_table_product_scratch[thread].resize(
-                    m_solar_table.geometry_matrix().rows());
+                    m_solar_table->geometry_matrix().rows());
                 auto& vjp = m_scalar_vjp_scratch[thread];
                 vjp.optical_depth.resize(maximum_layers);
                 vjp.attenuation.resize(maximum_layers);
@@ -426,7 +440,10 @@ namespace sasktran2::successive_orders {
         }
         m_atmosphere = nullptr;
         if (!m_use_compact_scalar) {
-            m_source.initialize_atmosphere(atmosphere);
+            // Successive orders evaluates this private exact source only via
+            // its primal, JVP, and VJP hooks. Avoid the large per-layer active
+            // derivative lists used exclusively by materialized Jacobians.
+            m_source.initialize_atmosphere_native(atmosphere);
         }
         if (!m_use_compact_scalar) {
             m_integrator.initialize_atmosphere(atmosphere);
@@ -579,7 +596,7 @@ namespace sasktran2::successive_orders {
         if (m_cached_solar_active.at(wavelength) == 0) {
             auto& table = m_solar_table_product_scratch[wavelength_thread];
             table.noalias() =
-                m_solar_table.geometry_matrix() *
+                m_solar_table->geometry_matrix() *
                 m_atmosphere->storage().total_extinction.col(wavelength);
             const double irradiance =
                 m_atmosphere->storage().solar_irradiance(wavelength);
@@ -1365,8 +1382,8 @@ namespace sasktran2::successive_orders {
         auto& solar_tangent = m_solar_product_scratch[wavelength_thread];
         auto& table_tangent = m_solar_table_product_scratch[wavelength_thread];
         const Eigen::Index solar_columns =
-            m_solar_table.geometry_matrix().cols();
-        table_tangent.noalias() = m_solar_table.geometry_matrix() *
+            m_solar_table->geometry_matrix().cols();
+        table_tangent.noalias() = m_solar_table->geometry_matrix() *
                                   native_tangent.head(solar_columns);
         solar_tangent.noalias() = m_solar_interpolation * table_tangent;
         solar_tangent.array() *= -solar.array();
@@ -2148,9 +2165,9 @@ namespace sasktran2::successive_orders {
             table_gradient.noalias() =
                 m_solar_interpolation.transpose() * solar_gradient;
             const Eigen::Index solar_columns =
-                m_solar_table.geometry_matrix().cols();
+                m_solar_table->geometry_matrix().cols();
             thread_gradient.head(solar_columns).noalias() -=
-                m_solar_table.geometry_matrix().transpose() * table_gradient;
+                m_solar_table->geometry_matrix().transpose() * table_gradient;
             native_gradient += thread_gradient;
         }
     }

--- a/cpp/lib/successive_orders/first_order.cpp
+++ b/cpp/lib/successive_orders/first_order.cpp
@@ -157,7 +157,7 @@ namespace sasktran2::successive_orders {
         const sasktran2::raytracing::RayTracerBase& raytracer)
         : m_geometry(geometry), m_geometry_1d(&geometry),
           m_source(geometry, raytracer),
-          m_solar_table(std::make_unique<
+          m_solar_table(std::make_shared<
                         sasktran2::solartransmission::SolarTransmissionTable>(
               geometry, raytracer)),
           m_integrator(false), m_source_terms{&m_source} {}
@@ -166,8 +166,17 @@ namespace sasktran2::successive_orders {
     template <int NSTOKES>
     FirstOrderProvider<NSTOKES>::FirstOrderProvider(
         const sasktran2::Geometry2D& geometry,
-        const sasktran2::raytracing::RustRayTracer2D& raytracer)
-        : m_geometry(geometry), m_source(geometry, raytracer),
+        const sasktran2::raytracing::RustRayTracer2D& raytracer,
+        std::shared_ptr<sasktran2::solartransmission::SolarTransmissionTable2D>
+            shared_solar_table)
+        : m_geometry(geometry),
+          m_source(geometry, raytracer, shared_solar_table),
+          m_solar_table(
+              shared_solar_table != nullptr
+                  ? std::move(shared_solar_table)
+                  : std::make_shared<
+                        sasktran2::solartransmission::SolarTransmissionTable2D>(
+                        geometry, raytracer)),
           m_integrator(false), m_source_terms{&m_source} {}
 #endif
 
@@ -205,15 +214,17 @@ namespace sasktran2::successive_orders {
         m_unique_endpoint_weights.clear();
         m_scalar_packed_rays.clear();
         m_scalar_packed_layers.clear();
-        m_solar_interpolation.resize(0, 0);
+        m_solar_interpolation.clear();
         m_solar_ground_hit.clear();
+        m_solar_propagation_directions.clear();
         m_num_threads = config.num_threads();
         m_num_source_threads = config.num_source_threads();
         m_num_wavelength_threads = config.num_wavelength_threads();
         m_num_phase_moments = config.num_singlescatter_moments();
+        m_solar_refraction = config.solar_refraction();
+        m_endpoint_phase_basis = false;
         m_compact_scalar_requested =
-            m_geometry_1d != nullptr && NSTOKES == 1 &&
-            !config.multiple_scatter_refraction() &&
+            NSTOKES == 1 && !config.multiple_scatter_refraction() &&
             config.singlescatter_phasemode() ==
                 sasktran2::Config::SingleScatterPhaseMode::from_legendre;
         m_use_compact_scalar = false;
@@ -265,8 +276,9 @@ namespace sasktran2::successive_orders {
         m_unique_endpoint_weights.clear();
         m_scalar_packed_rays.clear();
         m_scalar_packed_layers.clear();
-        m_solar_interpolation.resize(0, 0);
+        m_solar_interpolation.clear();
         m_solar_ground_hit.clear();
+        m_solar_propagation_directions.clear();
         const auto& viewing = source_geometry.incoming_viewing_geometry();
         m_num_rays = static_cast<int>(viewing.traced_rays.size());
         m_source_geometry = &source_geometry;
@@ -285,9 +297,9 @@ namespace sasktran2::successive_orders {
                 sasktran2::grids::interpolation::lower;
         if (m_use_compact_scalar) {
             m_solar_table->initialize_geometry(viewing.traced_rays);
-            m_solar_table->generate_interpolation_matrix(
-                viewing.traced_rays, m_solar_interpolation, m_solar_ground_hit);
-            m_solar_interpolation.makeCompressed();
+            m_solar_table->generate_interpolation(
+                viewing.traced_rays, m_solar_interpolation, m_solar_ground_hit,
+                m_solar_refraction ? &m_solar_propagation_directions : nullptr);
         } else {
             m_source.initialize_geometry(viewing);
         }
@@ -318,26 +330,62 @@ namespace sasktran2::successive_orders {
             m_solar_offsets.resize(static_cast<std::size_t>(m_num_rays) + 1);
             int solar_offset = 0;
             int maximum_layers = 0;
-            m_phase_basis.reserve(static_cast<std::size_t>(m_num_rays) *
-                                  m_num_phase_moments);
-            const auto& sun = m_geometry.coordinates().sun_unit();
             for (int ray = 0; ray < m_num_rays; ++ray) {
                 const auto& traced_ray = viewing.traced_rays[ray];
                 m_solar_offsets[ray] = solar_offset;
                 solar_offset += static_cast<int>(traced_ray.layers.size()) + 1;
                 maximum_layers = std::max(
                     maximum_layers, static_cast<int>(traced_ray.layers.size()));
-                const double cosine =
-                    traced_ray.layers.empty()
-                        ? 1.0
-                        : std::clamp(
-                              sun.dot(
-                                  traced_ray.layers.front().average_look_away),
-                              -1.0, 1.0);
-                append_legendre_basis(cosine, m_num_phase_moments,
-                                      m_phase_basis);
             }
             m_solar_offsets[m_num_rays] = solar_offset;
+            m_endpoint_phase_basis = m_solar_refraction;
+            if (m_endpoint_phase_basis &&
+                m_solar_propagation_directions.size() !=
+                    static_cast<std::size_t>(solar_offset)) {
+                throw std::logic_error(
+                    "Refracted successive-orders solar directions do not "
+                    "match the source endpoints");
+            }
+            m_phase_basis.reserve(
+                static_cast<std::size_t>(num_phase_basis_slots()) *
+                m_num_phase_moments);
+            const auto& sun = m_geometry.coordinates().sun_unit();
+            for (int ray = 0; ray < m_num_rays; ++ray) {
+                const auto& traced_ray = viewing.traced_rays[ray];
+                if (!m_endpoint_phase_basis) {
+                    const double cosine =
+                        traced_ray.layers.empty()
+                            ? 1.0
+                            : std::clamp(sun.dot(traced_ray.layers.front()
+                                                     .average_look_away),
+                                         -1.0, 1.0);
+                    append_legendre_basis(cosine, m_num_phase_moments,
+                                          m_phase_basis);
+                    continue;
+                }
+                if (traced_ray.layers.empty()) {
+                    append_legendre_basis(1.0, m_num_phase_moments,
+                                          m_phase_basis);
+                    continue;
+                }
+                const int offset = m_solar_offsets[ray];
+                const auto append_endpoint_basis =
+                    [&](int solar_index, const Eigen::Vector3d& look_away) {
+                        const double cosine = std::clamp(
+                            -m_solar_propagation_directions[solar_index].dot(
+                                look_away),
+                            -1.0, 1.0);
+                        append_legendre_basis(cosine, m_num_phase_moments,
+                                              m_phase_basis);
+                    };
+                append_endpoint_basis(
+                    offset, traced_ray.layers.front().average_look_away);
+                for (int layer = 0; layer < traced_ray.layers.size(); ++layer) {
+                    append_endpoint_basis(
+                        offset + layer + 1,
+                        traced_ray.layers[layer].average_look_away);
+                }
+            }
             if (!m_use_lower_interpolation) {
                 m_endpoint_slots.assign(solar_offset, -1);
                 m_unique_endpoint_offsets.push_back(0);
@@ -416,7 +464,7 @@ namespace sasktran2::successive_orders {
             for (int thread = 0; thread < m_num_threads; ++thread) {
                 m_solar_product_scratch[thread].resize(solar_offset);
                 m_solar_table_product_scratch[thread].resize(
-                    m_solar_table->geometry_matrix().rows());
+                    m_solar_table->table_size());
                 auto& vjp = m_scalar_vjp_scratch[thread];
                 vjp.optical_depth.resize(maximum_layers);
                 vjp.attenuation.resize(maximum_layers);
@@ -466,7 +514,8 @@ namespace sasktran2::successive_orders {
                                          atmosphere.num_wavel());
             m_uniform_phase_active.assign(atmosphere.num_wavel(), 0);
             m_uniform_phase_values.resize(
-                static_cast<std::size_t>(atmosphere.num_wavel()) * m_num_rays);
+                static_cast<std::size_t>(atmosphere.num_wavel()) *
+                num_phase_basis_slots());
             m_uniform_albedo_active.assign(atmosphere.num_wavel(), 0);
             m_uniform_albedo_values.resize(atmosphere.num_wavel());
             const auto& storage = atmosphere.storage();
@@ -513,13 +562,16 @@ namespace sasktran2::successive_orders {
                         [static_cast<std::size_t>(wavelength) * locations];
                     const double* coefficients =
                         &storage.leg_coeff(0, 0, wavelength);
-                    for (int ray = 0; ray < m_num_rays; ++ray) {
-                        const double* basis =
-                            m_phase_basis.data() +
-                            static_cast<std::size_t>(ray) * m_num_phase_moments;
-                        m_uniform_phase_values
-                            [static_cast<std::size_t>(wavelength) * m_num_rays +
-                             ray] = phase_dot(coefficients, basis, order);
+                    const int phase_slots = num_phase_basis_slots();
+                    for (int slot = 0; slot < phase_slots; ++slot) {
+                        const double* basis = m_phase_basis.data() +
+                                              static_cast<std::size_t>(slot) *
+                                                  m_num_phase_moments;
+                        m_uniform_phase_values[static_cast<std::size_t>(
+                                                   wavelength) *
+                                                   phase_slots +
+                                               slot] =
+                            phase_dot(coefficients, basis, order);
                     }
                 }
             }
@@ -595,12 +647,12 @@ namespace sasktran2::successive_orders {
         auto& transmission = m_cached_solar_transmission.at(wavelength);
         if (m_cached_solar_active.at(wavelength) == 0) {
             auto& table = m_solar_table_product_scratch[wavelength_thread];
-            table.noalias() =
-                m_solar_table->geometry_matrix() *
-                m_atmosphere->storage().total_extinction.col(wavelength);
+            m_solar_table->apply(
+                m_atmosphere->storage().total_extinction.col(wavelength),
+                table);
             const double irradiance =
                 m_atmosphere->storage().solar_irradiance(wavelength);
-            transmission.noalias() = m_solar_interpolation * table;
+            m_solar_interpolation.apply(table, transmission);
             transmission.array() = (-transmission.array()).exp() * irradiance;
             for (int row = 0; row < m_solar_interpolation.rows(); ++row) {
                 if (m_solar_ground_hit[row]) {
@@ -656,15 +708,17 @@ namespace sasktran2::successive_orders {
             result.albedo =
                 m_endpoint_medium_cache[wavelength].albedo(endpoint_slot);
         }
+        const int phase_slot = phase_basis_slot(ray, solar_index);
+        const int phase_slots = num_phase_basis_slots();
         const double* basis =
             m_phase_basis.data() +
-            static_cast<std::size_t>(ray) * m_num_phase_moments;
+            static_cast<std::size_t>(phase_slot) * m_num_phase_moments;
         const bool uniform_phase = m_uniform_phase_active[wavelength] != 0;
         if (uniform_phase) {
             result.phase =
                 m_uniform_phase_values[static_cast<std::size_t>(wavelength) *
-                                           m_num_rays +
-                                       ray];
+                                           phase_slots +
+                                       phase_slot];
         }
         if (use_endpoint_medium && uniform_phase) {
             return result;
@@ -714,9 +768,11 @@ namespace sasktran2::successive_orders {
         const auto& coefficient_tangent =
             m_phase_product_scratch[wavelength_thread];
         const auto& tangent_orders = m_phase_order_scratch[wavelength_thread];
+        const int phase_slot = phase_basis_slot(ray, solar_index);
+        const int phase_slots = num_phase_basis_slots();
         const double* basis =
             m_phase_basis.data() +
-            static_cast<std::size_t>(ray) * m_num_phase_moments;
+            static_cast<std::size_t>(phase_slot) * m_num_phase_moments;
         double extinction = 0.0;
         double extinction_tangent = 0.0;
         double albedo = 0.0;
@@ -728,8 +784,8 @@ namespace sasktran2::successive_orders {
         if (uniform_phase) {
             phase =
                 m_uniform_phase_values[static_cast<std::size_t>(wavelength) *
-                                           m_num_rays +
-                                       ray];
+                                           phase_slots +
+                                       phase_slot];
         }
         if constexpr (USE_ENDPOINT_MEDIUM) {
             const int endpoint_slot = m_endpoint_slots[solar_index];
@@ -847,9 +903,10 @@ namespace sasktran2::successive_orders {
         const double phase_cotangent = scale * endpoint.extinction *
                                        endpoint.albedo *
                                        endpoint.solar_transmission;
+        const int phase_slot = phase_basis_slot(ray, solar_index);
         const double* basis =
             m_phase_basis.data() +
-            static_cast<std::size_t>(ray) * m_num_phase_moments;
+            static_cast<std::size_t>(phase_slot) * m_num_phase_moments;
         for (std::size_t index = 0; index < weights.size(); ++index) {
             const auto [atmosphere_index, weight] = weights[index];
             if (weight == 0.0) {
@@ -870,6 +927,23 @@ namespace sasktran2::successive_orders {
         solar_gradient(solar_index) += solar_cotangent;
         (void)layer;
         (void)entrance;
+    }
+
+    template <int NSTOKES>
+    bool FirstOrderProvider<NSTOKES>::ground_scattering_geometry(
+        int solar_index, const sasktran2::raytracing::TracedLayer& ground_layer,
+        double& mu_in, double& mu_out, double& phi) const {
+        Eigen::Vector3d direction_to_sun = m_geometry.coordinates().sun_unit();
+        if (!m_solar_propagation_directions.empty()) {
+            direction_to_sun = -m_solar_propagation_directions[solar_index];
+        }
+        sasktran2::raytracing::calculate_csz_saz(
+            direction_to_sun.normalized(), ground_layer.exit,
+            ground_layer.average_look_away, mu_in, phi,
+            m_geometry.coordinates().geometry_type());
+        mu_out =
+            -ground_layer.exit.cos_zenith_angle(ground_layer.average_look_away);
+        return mu_in > 0.0;
     }
 
     template <int NSTOKES>
@@ -1006,13 +1080,14 @@ namespace sasktran2::successive_orders {
             }
             if (traced_ray.ground_is_hit && !traced_ray.layers.empty()) {
                 const auto& ground_layer = traced_ray.layers.front();
-                const double mu_in = ground_layer.exit.cos_zenith_angle(
-                    m_geometry.coordinates().sun_unit());
-                if (mu_in > 0.0) {
-                    const double mu_out = -ground_layer.exit.cos_zenith_angle(
-                        ground_layer.average_look_away);
+                double mu_in;
+                double mu_out;
+                double phi;
+                if (ground_scattering_geometry(m_solar_offsets[ray],
+                                               ground_layer, mu_in, mu_out,
+                                               phi)) {
                     const auto brdf = m_atmosphere->surface().brdf(
-                        wavelength, mu_in, mu_out, ground_layer.saz_exit);
+                        wavelength, mu_in, mu_out, phi);
                     radiance += prefix * solar(m_solar_offsets[ray]) * mu_in *
                                 brdf(0, 0);
                 }
@@ -1030,7 +1105,8 @@ namespace sasktran2::successive_orders {
         int wavelength, int wavelength_thread,
         Eigen::Ref<Eigen::VectorXd> forcing, TransportOperator* transport) {
         if constexpr (!LOWER_INTERPOLATION) {
-            if (m_uniform_phase_active[wavelength] != 0) {
+            if (m_uniform_phase_active[wavelength] != 0 &&
+                !m_endpoint_phase_basis) {
                 calculate_scalar_uniform_impl<WITH_TRANSPORT>(
                     wavelength, wavelength_thread, forcing, transport);
                 return;
@@ -1166,13 +1242,14 @@ namespace sasktran2::successive_orders {
             }
             if (traced_ray.ground_is_hit && !traced_ray.layers.empty()) {
                 const auto& ground_layer = traced_ray.layers.front();
-                const double mu_in = ground_layer.exit.cos_zenith_angle(
-                    m_geometry.coordinates().sun_unit());
-                if (mu_in > 0.0) {
-                    const double mu_out = -ground_layer.exit.cos_zenith_angle(
-                        ground_layer.average_look_away);
+                double mu_in;
+                double mu_out;
+                double phi;
+                if (ground_scattering_geometry(m_solar_offsets[ray],
+                                               ground_layer, mu_in, mu_out,
+                                               phi)) {
                     const auto brdf = m_atmosphere->surface().brdf(
-                        wavelength, mu_in, mu_out, ground_layer.saz_exit);
+                        wavelength, mu_in, mu_out, phi);
                     radiance += prefix * solar(m_solar_offsets[ray]) * mu_in *
                                 brdf(0, 0);
                 }
@@ -1330,12 +1407,12 @@ namespace sasktran2::successive_orders {
             }
             if (traced_ray.ground_is_hit && !traced_ray.layers.empty()) {
                 const auto& ground_layer = traced_ray.layers.front();
-                const double mu_in = ground_layer.exit.cos_zenith_angle(
-                    m_geometry.coordinates().sun_unit());
-                if (mu_in > 0.0) {
-                    const double mu_out = -ground_layer.exit.cos_zenith_angle(
-                        ground_layer.average_look_away);
-                    const double phi = ground_layer.saz_exit;
+                double mu_in;
+                double mu_out;
+                double phi;
+                if (ground_scattering_geometry(m_solar_offsets[ray],
+                                               ground_layer, mu_in, mu_out,
+                                               phi)) {
                     const auto brdf = m_atmosphere->surface().brdf(
                         wavelength, mu_in, mu_out, phi);
                     double brdf_tangent = 0.0;
@@ -1381,11 +1458,9 @@ namespace sasktran2::successive_orders {
             ensure_solar_transmission(wavelength, wavelength_thread);
         auto& solar_tangent = m_solar_product_scratch[wavelength_thread];
         auto& table_tangent = m_solar_table_product_scratch[wavelength_thread];
-        const Eigen::Index solar_columns =
-            m_solar_table->geometry_matrix().cols();
-        table_tangent.noalias() = m_solar_table->geometry_matrix() *
-                                  native_tangent.head(solar_columns);
-        solar_tangent.noalias() = m_solar_interpolation * table_tangent;
+        const Eigen::Index solar_columns = m_solar_table->atmosphere_size();
+        m_solar_table->apply(native_tangent.head(solar_columns), table_tangent);
+        m_solar_interpolation.apply(table_tangent, solar_tangent);
         solar_tangent.array() *= -solar.array();
         auto& coefficient_tangent = m_phase_product_scratch[wavelength_thread];
         auto& tangent_orders = m_phase_order_scratch[wavelength_thread];
@@ -1478,8 +1553,9 @@ namespace sasktran2::successive_orders {
         }
         if constexpr (WITH_TRANSPORT && !LOWER_INTERPOLATION) {
             if (m_uniform_phase_active[wavelength] != 0 &&
-                !phase_tangent_active && proportional_extinction_direction &&
-                uniform_albedo && uniform_albedo_direction) {
+                !m_endpoint_phase_basis && !phase_tangent_active &&
+                proportional_extinction_direction && uniform_albedo &&
+                uniform_albedo_direction) {
                 if (layer_state_projection == nullptr ||
                     ground_state_projection == nullptr ||
                     direct_transport_tangent == nullptr) {
@@ -1685,12 +1761,12 @@ namespace sasktran2::successive_orders {
             }
             if (traced_ray.ground_is_hit && !traced_ray.layers.empty()) {
                 const auto& ground_layer = traced_ray.layers.front();
-                const double mu_in = ground_layer.exit.cos_zenith_angle(
-                    m_geometry.coordinates().sun_unit());
-                if (mu_in > 0.0) {
-                    const double mu_out = -ground_layer.exit.cos_zenith_angle(
-                        ground_layer.average_look_away);
-                    const double phi = ground_layer.saz_exit;
+                double mu_in;
+                double mu_out;
+                double phi;
+                if (ground_scattering_geometry(m_solar_offsets[ray],
+                                               ground_layer, mu_in, mu_out,
+                                               phi)) {
                     const auto brdf = m_atmosphere->surface().brdf(
                         wavelength, mu_in, mu_out, phi);
                     double brdf_tangent = 0.0;
@@ -1870,13 +1946,6 @@ namespace sasktran2::successive_orders {
             if constexpr (!LOWER_INTERPOLATION) {
                 if (num_layers > 0) {
                     scratch.endpoint_cotangent.head(num_layers + 1).setZero();
-                    const double phase =
-                        uniform_phase
-                            ? m_uniform_phase_values[static_cast<std::size_t>(
-                                                         wavelength) *
-                                                         m_num_rays +
-                                                     ray]
-                            : 0.0;
                     for (int endpoint = 0; endpoint <= num_layers; ++endpoint) {
                         const int solar_index = m_solar_offsets[ray] + endpoint;
                         auto& value = scratch.endpoints[endpoint];
@@ -1885,7 +1954,10 @@ namespace sasktran2::successive_orders {
                             value.extinction =
                                 endpoint_medium->extinction(slot);
                             value.albedo = endpoint_medium->albedo(slot);
-                            value.phase = phase;
+                            value.phase = m_uniform_phase_values
+                                [static_cast<std::size_t>(wavelength) *
+                                     num_phase_basis_slots() +
+                                 phase_basis_slot(ray, solar_index)];
                         } else {
                             const auto weights =
                                 endpoint == 0
@@ -1907,12 +1979,12 @@ namespace sasktran2::successive_orders {
             double prefix_cotangent = 0.0;
             if (traced_ray.ground_is_hit && !traced_ray.layers.empty()) {
                 const auto& ground_layer = traced_ray.layers.front();
-                const double mu_in = ground_layer.exit.cos_zenith_angle(
-                    m_geometry.coordinates().sun_unit());
-                if (mu_in > 0.0) {
-                    const double mu_out = -ground_layer.exit.cos_zenith_angle(
-                        ground_layer.average_look_away);
-                    const double phi = ground_layer.saz_exit;
+                double mu_in;
+                double mu_out;
+                double phi;
+                if (ground_scattering_geometry(m_solar_offsets[ray],
+                                               ground_layer, mu_in, mu_out,
+                                               phi)) {
                     const auto brdf = m_atmosphere->surface().brdf(
                         wavelength, mu_in, mu_out, phi);
                     const double ground_source =
@@ -2162,12 +2234,11 @@ namespace sasktran2::successive_orders {
             auto& solar_gradient = m_solar_product_scratch[thread];
             auto& table_gradient = m_solar_table_product_scratch[thread];
             solar_gradient.array() *= solar.array();
-            table_gradient.noalias() =
-                m_solar_interpolation.transpose() * solar_gradient;
-            const Eigen::Index solar_columns =
-                m_solar_table->geometry_matrix().cols();
-            thread_gradient.head(solar_columns).noalias() -=
-                m_solar_table->geometry_matrix().transpose() * table_gradient;
+            m_solar_interpolation.apply_transpose(solar_gradient,
+                                                  table_gradient);
+            const Eigen::Index solar_columns = m_solar_table->atmosphere_size();
+            m_solar_table->accumulate_transpose(
+                table_gradient, thread_gradient.head(solar_columns), -1.0);
             native_gradient += thread_gradient;
         }
     }
@@ -2447,7 +2518,10 @@ namespace sasktran2::successive_orders {
 
     template <int NSTOKES>
     std::size_t FirstOrderProvider<NSTOKES>::workspace_bytes() const {
-        std::size_t result = 0;
+        std::size_t result = m_solar_interpolation.storage_bytes();
+        if (m_solar_table != nullptr) {
+            result += m_solar_table->storage_bytes();
+        }
         for (const auto& scratch : m_primal_scratch) {
             result += static_cast<std::size_t>(scratch.value.size() +
                                                scratch.deriv.size()) *

--- a/cpp/lib/successive_orders/first_order.cpp
+++ b/cpp/lib/successive_orders/first_order.cpp
@@ -214,6 +214,7 @@ namespace sasktran2::successive_orders {
         m_unique_endpoint_weights.clear();
         m_scalar_packed_rays.clear();
         m_scalar_packed_layers.clear();
+        m_scalar_ground_geometry.clear();
         m_solar_interpolation.clear();
         m_solar_ground_hit.clear();
         m_solar_propagation_directions.clear();
@@ -276,6 +277,7 @@ namespace sasktran2::successive_orders {
         m_unique_endpoint_weights.clear();
         m_scalar_packed_rays.clear();
         m_scalar_packed_layers.clear();
+        m_scalar_ground_geometry.clear();
         m_solar_interpolation.clear();
         m_solar_ground_hit.clear();
         m_solar_propagation_directions.clear();
@@ -447,6 +449,15 @@ namespace sasktran2::successive_orders {
                     }
                     packed_ray.layer_end = static_cast<std::uint32_t>(
                         m_scalar_packed_layers.size());
+                    if (traced_ray.ground_is_hit &&
+                        !traced_ray.layers.empty()) {
+                        const auto& ground_layer = traced_ray.layers.front();
+                        packed_ray.ground_geometry = static_cast<std::int32_t>(
+                            m_scalar_ground_geometry.size());
+                        m_scalar_ground_geometry.push_back(
+                            {ground_layer.exit.position.normalized(),
+                             ground_layer.average_look_away});
+                    }
                 }
             }
             const int unique_endpoints =
@@ -691,10 +702,12 @@ namespace sasktran2::successive_orders {
     }
 
     template <int NSTOKES>
+    template <typename Weights>
     typename FirstOrderProvider<NSTOKES>::ScalarEndpoint
-    FirstOrderProvider<NSTOKES>::scalar_endpoint(
-        int wavelength, int ray, int layer, bool entrance, int solar_index,
-        const sasktran2::raytracing::GridWeightStencilView& weights) const {
+    FirstOrderProvider<NSTOKES>::scalar_endpoint(int wavelength, int ray,
+                                                 int layer, bool entrance,
+                                                 int solar_index,
+                                                 const Weights& weights) const {
         ScalarEndpoint result;
         const auto& storage = m_atmosphere->storage();
         const int endpoint_slot =
@@ -753,12 +766,11 @@ namespace sasktran2::successive_orders {
     }
 
     template <int NSTOKES>
-    template <bool USE_ENDPOINT_MEDIUM>
+    template <bool USE_ENDPOINT_MEDIUM, typename Weights>
     typename FirstOrderProvider<NSTOKES>::ScalarValueTangent
     FirstOrderProvider<NSTOKES>::scalar_endpoint_jvp(
         int wavelength, int wavelength_thread, int ray, int layer,
-        bool entrance, int solar_index,
-        const sasktran2::raytracing::GridWeightStencilView& weights,
+        bool entrance, int solar_index, const Weights& weights,
         const double* __restrict extinction_direction,
         const double* __restrict albedo_direction,
         const double* __restrict solar_tangent, bool uniform_albedo_direction,
@@ -880,11 +892,11 @@ namespace sasktran2::successive_orders {
     }
 
     template <int NSTOKES>
+    template <typename Weights>
     void FirstOrderProvider<NSTOKES>::accumulate_scalar_endpoint_vjp(
         int wavelength, int ray, int layer, bool entrance, int solar_index,
-        const sasktran2::raytracing::GridWeightStencilView& weights,
-        const ScalarEndpoint& endpoint, double source_cotangent,
-        Eigen::Ref<Eigen::VectorXd> native_gradient,
+        const Weights& weights, const ScalarEndpoint& endpoint,
+        double source_cotangent, Eigen::Ref<Eigen::VectorXd> native_gradient,
         Eigen::Ref<Eigen::VectorXd> solar_gradient,
         Eigen::Ref<Eigen::VectorXd> coefficient_gradient) const {
         if (source_cotangent == 0.0) {
@@ -931,18 +943,18 @@ namespace sasktran2::successive_orders {
 
     template <int NSTOKES>
     bool FirstOrderProvider<NSTOKES>::ground_scattering_geometry(
-        int solar_index, const sasktran2::raytracing::TracedLayer& ground_layer,
-        double& mu_in, double& mu_out, double& phi) const {
+        int solar_index, const ScalarGroundGeometry& ground, double& mu_in,
+        double& mu_out, double& phi) const {
         Eigen::Vector3d direction_to_sun = m_geometry.coordinates().sun_unit();
         if (!m_solar_propagation_directions.empty()) {
             direction_to_sun = -m_solar_propagation_directions[solar_index];
         }
+        sasktran2::Location ground_location;
+        ground_location.position = ground.up;
         sasktran2::raytracing::calculate_csz_saz(
-            direction_to_sun.normalized(), ground_layer.exit,
-            ground_layer.average_look_away, mu_in, phi,
-            m_geometry.coordinates().geometry_type());
-        mu_out =
-            -ground_layer.exit.cos_zenith_angle(ground_layer.average_look_away);
+            direction_to_sun.normalized(), ground_location, ground.look_away,
+            mu_in, phi, m_geometry.coordinates().geometry_type());
+        mu_out = -ground.up.dot(ground.look_away.normalized());
         return mu_in > 0.0;
     }
 
@@ -972,7 +984,6 @@ namespace sasktran2::successive_orders {
     void FirstOrderProvider<NSTOKES>::calculate_scalar_uniform_impl(
         int wavelength, int wavelength_thread,
         Eigen::Ref<Eigen::VectorXd> forcing, TransportOperator* transport) {
-        const auto& rays = m_source_geometry->incoming_rays();
         const auto& interpolation = m_source_geometry->incoming_interpolation();
         const auto& extinction = m_atmosphere->storage().total_extinction;
         const auto& ssa = m_atmosphere->storage().ssa;
@@ -995,7 +1006,6 @@ namespace sasktran2::successive_orders {
     num_threads(m_num_source_threads) schedule(dynamic)
         for (int ray = 0; ray < m_num_rays; ++ray) {
             const auto& packed_ray = m_scalar_packed_rays[ray];
-            const auto& traced_ray = rays[ray];
             const auto& ray_interpolation = interpolation[ray];
             const double phase_scale =
                 m_uniform_phase_values[static_cast<std::size_t>(wavelength) *
@@ -1018,7 +1028,7 @@ namespace sasktran2::successive_orders {
                 const auto local_layer = static_cast<std::size_t>(
                     flat_layer - packed_ray.layer_begin);
                 const auto optical_depth_weights =
-                    traced_ray.optical_depth_weights(local_layer);
+                    ray_interpolation.optical_depth_for_layer(local_layer);
                 const auto atmosphere_weights =
                     ray_interpolation.atmosphere_for_layer(local_layer);
                 double optical_depth = 0.0;
@@ -1078,14 +1088,14 @@ namespace sasktran2::successive_orders {
                         source.row_inner_index) += source.weight * prefix;
                 }
             }
-            if (traced_ray.ground_is_hit && !traced_ray.layers.empty()) {
-                const auto& ground_layer = traced_ray.layers.front();
+            if (packed_ray.ground_geometry >= 0) {
+                const auto& ground =
+                    m_scalar_ground_geometry[packed_ray.ground_geometry];
                 double mu_in;
                 double mu_out;
                 double phi;
-                if (ground_scattering_geometry(m_solar_offsets[ray],
-                                               ground_layer, mu_in, mu_out,
-                                               phi)) {
+                if (ground_scattering_geometry(m_solar_offsets[ray], ground,
+                                               mu_in, mu_out, phi)) {
                     const auto brdf = m_atmosphere->surface().brdf(
                         wavelength, mu_in, mu_out, phi);
                     radiance += prefix * solar(m_solar_offsets[ray]) * mu_in *
@@ -1134,19 +1144,40 @@ namespace sasktran2::successive_orders {
 #pragma omp parallel for if (m_num_source_threads > 1)                         \
     num_threads(m_num_source_threads) schedule(dynamic)
         for (int ray = 0; ray < m_num_rays; ++ray) {
-            const auto& traced_ray = rays[ray];
             const auto& ray_interpolation = interpolation[ray];
+            const ScalarPackedRay* packed_ray = nullptr;
+            if constexpr (!LOWER_INTERPOLATION) {
+                packed_ray = &m_scalar_packed_rays[ray];
+            }
             const int flat_layer_offset = m_solar_offsets[ray] - ray;
             double prefix = 1.0;
             double radiance = 0.0;
             ScalarEndpoint shared_endpoint;
             bool have_shared_endpoint = false;
-            for (int layer = static_cast<int>(traced_ray.layers.size()) - 1;
+            for (int layer =
+                     static_cast<int>(ray_interpolation.layers.size()) - 1;
                  layer >= 0; --layer) {
-                const auto& traced_layer = traced_ray.layers[layer];
+                double source_quad_start;
+                double source_quad_end;
+                double layer_distance;
+                if constexpr (LOWER_INTERPOLATION) {
+                    const auto& traced_layer = rays[ray].layers[layer];
+                    layer_distance = traced_layer.layer_distance;
+                    source_quad_start =
+                        layer_distance * traced_layer.od_quad_start_fraction;
+                    source_quad_end =
+                        layer_distance * traced_layer.od_quad_end_fraction;
+                } else {
+                    const auto& packed_layer =
+                        m_scalar_packed_layers[packed_ray->layer_begin + layer];
+                    source_quad_start = packed_layer.source_quad_start;
+                    source_quad_end = packed_layer.source_quad_end;
+                    layer_distance = source_quad_start + source_quad_end;
+                }
                 double optical_depth = 0.0;
                 double albedo = uniform_albedo_value;
-                const auto od_weights = traced_ray.optical_depth_weights(layer);
+                const auto od_weights =
+                    ray_interpolation.optical_depth_for_layer(layer);
                 for (std::size_t index = 0; index < od_weights.size();
                      ++index) {
                     const auto [atmosphere_index, weight] = od_weights[index];
@@ -1182,17 +1213,19 @@ namespace sasktran2::successive_orders {
                             source.weight * source_factor;
                     }
                 }
-                if (traced_layer.layer_distance < minimum_layer_distance_m) {
+                if (layer_distance < minimum_layer_distance_m) {
                     have_shared_endpoint = false;
                 }
-                if (traced_layer.layer_distance >= minimum_layer_distance_m) {
-                    auto entrance_weights = traced_ray.entrance_weights(layer);
-                    auto exit_weights = traced_ray.exit_weights(layer);
-                    const auto* start_weights = &entrance_weights;
-                    const auto* end_weights = &exit_weights;
-                    bool start_entrance = true;
-                    bool end_entrance = false;
+                if (layer_distance >= minimum_layer_distance_m) {
                     if constexpr (LOWER_INTERPOLATION) {
+                        const auto& traced_layer = rays[ray].layers[layer];
+                        auto entrance_weights =
+                            rays[ray].entrance_weights(layer);
+                        auto exit_weights = rays[ray].exit_weights(layer);
+                        const auto* start_weights = &entrance_weights;
+                        const auto* end_weights = &exit_weights;
+                        bool start_entrance = true;
+                        bool end_entrance = false;
                         if (traced_layer.r_exit > traced_layer.r_entrance) {
                             end_weights = &entrance_weights;
                             end_entrance = true;
@@ -1200,38 +1233,57 @@ namespace sasktran2::successive_orders {
                             start_weights = &exit_weights;
                             start_entrance = false;
                         }
-                    }
-                    const int exit_solar = m_solar_offsets[ray] + layer;
-                    auto start =
-                        have_shared_endpoint && !LOWER_INTERPOLATION
-                            ? shared_endpoint
-                            : scalar_endpoint(wavelength, ray, layer,
-                                              start_entrance, exit_solar + 1,
-                                              *start_weights);
-                    auto end =
-                        scalar_endpoint(wavelength, ray, layer, end_entrance,
-                                        exit_solar, *end_weights);
-                    if (!(have_shared_endpoint && !LOWER_INTERPOLATION)) {
+                        const int exit_solar = m_solar_offsets[ray] + layer;
+                        auto start = scalar_endpoint(
+                            wavelength, ray, layer, start_entrance,
+                            exit_solar + 1, *start_weights);
+                        auto end = scalar_endpoint(wavelength, ray, layer,
+                                                   end_entrance, exit_solar,
+                                                   *end_weights);
                         start.solar_transmission = solar(exit_solar + 1);
                         start.source = start.extinction * start.albedo *
                                        start.solar_transmission * start.phase *
                                        inverse_four_pi;
+                        end.solar_transmission = solar(exit_solar);
+                        end.source = end.extinction * end.albedo *
+                                     end.solar_transmission * end.phase *
+                                     inverse_four_pi;
+                        radiance += prefix * factor *
+                                    (start.source * source_quad_start +
+                                     end.source * source_quad_end);
+                    } else {
+                        const int exit_solar = m_solar_offsets[ray] + layer;
+                        auto start =
+                            have_shared_endpoint
+                                ? shared_endpoint
+                                : scalar_endpoint(
+                                      wavelength, ray, layer, true,
+                                      exit_solar + 1,
+                                      endpoint_weights(exit_solar + 1));
+                        auto end = scalar_endpoint(
+                            wavelength, ray, layer, false, exit_solar,
+                            endpoint_weights(exit_solar));
+                        if (!have_shared_endpoint) {
+                            start.solar_transmission = solar(exit_solar + 1);
+                            start.source = start.extinction * start.albedo *
+                                           start.solar_transmission *
+                                           start.phase * inverse_four_pi;
+                        }
+                        end.solar_transmission = solar(exit_solar);
+                        end.source = end.extinction * end.albedo *
+                                     end.solar_transmission * end.phase *
+                                     inverse_four_pi;
+                        radiance += prefix * factor *
+                                    (start.source * source_quad_start +
+                                     end.source * source_quad_end);
+                        shared_endpoint = end;
                     }
-                    end.solar_transmission = solar(exit_solar);
-                    end.source = end.extinction * end.albedo *
-                                 end.solar_transmission * end.phase *
-                                 inverse_four_pi;
-                    radiance +=
-                        prefix * factor * traced_layer.layer_distance *
-                        (start.source * traced_layer.od_quad_start_fraction +
-                         end.source * traced_layer.od_quad_end_fraction);
-                    shared_endpoint = end;
                     have_shared_endpoint = true;
                 }
                 prefix *= attenuation;
             }
             if constexpr (WITH_TRANSPORT) {
-                if (traced_ray.ground_is_hit) {
+                if (ray_interpolation.ground_is_hit()) {
                     for (const auto& source :
                          ray_interpolation.ground_weights) {
                         transport->values()(
@@ -1240,14 +1292,32 @@ namespace sasktran2::successive_orders {
                     }
                 }
             }
-            if (traced_ray.ground_is_hit && !traced_ray.layers.empty()) {
-                const auto& ground_layer = traced_ray.layers.front();
+            if constexpr (LOWER_INTERPOLATION) {
+                const auto& traced_ray = rays[ray];
+                if (traced_ray.ground_is_hit && !traced_ray.layers.empty()) {
+                    const auto& ground_layer = traced_ray.layers.front();
+                    ScalarGroundGeometry ground{
+                        ground_layer.exit.position.normalized(),
+                        ground_layer.average_look_away};
+                    double mu_in;
+                    double mu_out;
+                    double phi;
+                    if (ground_scattering_geometry(m_solar_offsets[ray], ground,
+                                                   mu_in, mu_out, phi)) {
+                        const auto brdf = m_atmosphere->surface().brdf(
+                            wavelength, mu_in, mu_out, phi);
+                        radiance += prefix * solar(m_solar_offsets[ray]) *
+                                    mu_in * brdf(0, 0);
+                    }
+                }
+            } else if (packed_ray->ground_geometry >= 0) {
+                const auto& ground =
+                    m_scalar_ground_geometry[packed_ray->ground_geometry];
                 double mu_in;
                 double mu_out;
                 double phi;
-                if (ground_scattering_geometry(m_solar_offsets[ray],
-                                               ground_layer, mu_in, mu_out,
-                                               phi)) {
+                if (ground_scattering_geometry(m_solar_offsets[ray], ground,
+                                               mu_in, mu_out, phi)) {
                     const auto brdf = m_atmosphere->surface().brdf(
                         wavelength, mu_in, mu_out, phi);
                     radiance += prefix * solar(m_solar_offsets[ray]) * mu_in *
@@ -1302,7 +1372,7 @@ namespace sasktran2::successive_orders {
         const Eigen::VectorXd& ground_state_projection,
         Eigen::VectorXd& direct_transport_tangent,
         Eigen::Ref<Eigen::VectorXd> forcing_tangent) {
-        const auto& rays = m_source_geometry->incoming_rays();
+        const auto& interpolation = m_source_geometry->incoming_interpolation();
         const auto& solar = m_cached_solar_transmission[wavelength];
         const auto& endpoint_medium = m_endpoint_medium_cache[wavelength];
         const auto& layer_cache = m_scalar_layer_cache[wavelength];
@@ -1400,19 +1470,18 @@ namespace sasktran2::successive_orders {
                     prefix_tangent * attenuation + prefix * attenuation_tangent;
                 prefix *= attenuation;
             }
-            const auto& traced_ray = rays[ray];
-            if (traced_ray.ground_is_hit) {
+            if (interpolation[ray].ground_is_hit()) {
                 direct_transport_tangent(ray) +=
                     ground_state_projection(ray) * prefix_tangent;
             }
-            if (traced_ray.ground_is_hit && !traced_ray.layers.empty()) {
-                const auto& ground_layer = traced_ray.layers.front();
+            if (packed_ray.ground_geometry >= 0) {
+                const auto& ground =
+                    m_scalar_ground_geometry[packed_ray.ground_geometry];
                 double mu_in;
                 double mu_out;
                 double phi;
-                if (ground_scattering_geometry(m_solar_offsets[ray],
-                                               ground_layer, mu_in, mu_out,
-                                               phi)) {
+                if (ground_scattering_geometry(m_solar_offsets[ray], ground,
+                                               mu_in, mu_out, phi)) {
                     const auto brdf = m_atmosphere->surface().brdf(
                         wavelength, mu_in, mu_out, phi);
                     double brdf_tangent = 0.0;
@@ -1633,17 +1702,37 @@ namespace sasktran2::successive_orders {
 #pragma omp parallel for if (m_num_source_threads > 1)                         \
     num_threads(m_num_source_threads) schedule(dynamic)
         for (int ray = 0; ray < m_num_rays; ++ray) {
-            const auto& traced_ray = rays[ray];
             const auto& ray_interpolation = interpolation[ray];
+            const ScalarPackedRay* packed_ray = nullptr;
+            if constexpr (!LOWER_INTERPOLATION) {
+                packed_ray = &m_scalar_packed_rays[ray];
+            }
             const int flat_layer_offset = m_solar_offsets[ray] - ray;
             double prefix = 1.0;
             double prefix_tangent = 0.0;
             double radiance_tangent = 0.0;
             ScalarValueTangent shared_endpoint;
             bool have_shared_endpoint = false;
-            for (int layer = static_cast<int>(traced_ray.layers.size()) - 1;
+            for (int layer =
+                     static_cast<int>(ray_interpolation.layers.size()) - 1;
                  layer >= 0; --layer) {
-                const auto& traced_layer = traced_ray.layers[layer];
+                double source_quad_start;
+                double source_quad_end;
+                double layer_distance;
+                if constexpr (LOWER_INTERPOLATION) {
+                    const auto& traced_layer = rays[ray].layers[layer];
+                    layer_distance = traced_layer.layer_distance;
+                    source_quad_start =
+                        layer_distance * traced_layer.od_quad_start_fraction;
+                    source_quad_end =
+                        layer_distance * traced_layer.od_quad_end_fraction;
+                } else {
+                    const auto& packed_layer =
+                        m_scalar_packed_layers[packed_ray->layer_begin + layer];
+                    source_quad_start = packed_layer.source_quad_start;
+                    source_quad_end = packed_layer.source_quad_end;
+                    layer_distance = source_quad_start + source_quad_end;
+                }
                 const int flat_layer = flat_layer_offset + layer;
                 const double optical_depth =
                     layer_cache.optical_depth(flat_layer);
@@ -1654,8 +1743,9 @@ namespace sasktran2::successive_orders {
                 double albedo = uniform_albedo_value;
                 double albedo_tangent =
                     uniform_albedo_direction ? uniform_albedo_tangent : 0.0;
-                const auto od_weights = traced_ray.optical_depth_weights(layer);
                 if (!proportional_extinction_direction) {
+                    const auto od_weights =
+                        ray_interpolation.optical_depth_for_layer(layer);
                     for (std::size_t index = 0; index < od_weights.size();
                          ++index) {
                         const auto [atmosphere_index, weight] =
@@ -1692,17 +1782,21 @@ namespace sasktran2::successive_orders {
                     direct_transport_direction[ray] +=
                         layer_state[flat_layer] * source_factor_tangent;
                 }
-                if (traced_layer.layer_distance < minimum_layer_distance_m) {
+                if (layer_distance < minimum_layer_distance_m) {
                     have_shared_endpoint = false;
                 }
-                if (traced_layer.layer_distance >= minimum_layer_distance_m) {
-                    auto entrance_weights = traced_ray.entrance_weights(layer);
-                    auto exit_weights = traced_ray.exit_weights(layer);
-                    const auto* start_weights = &entrance_weights;
-                    const auto* end_weights = &exit_weights;
-                    bool start_entrance = true;
-                    bool end_entrance = false;
+                if (layer_distance >= minimum_layer_distance_m) {
+                    ScalarValueTangent start;
+                    ScalarValueTangent end;
                     if constexpr (LOWER_INTERPOLATION) {
+                        const auto& traced_layer = rays[ray].layers[layer];
+                        auto entrance_weights =
+                            rays[ray].entrance_weights(layer);
+                        auto exit_weights = rays[ray].exit_weights(layer);
+                        const auto* start_weights = &entrance_weights;
+                        const auto* end_weights = &exit_weights;
+                        bool start_entrance = true;
+                        bool end_entrance = false;
                         if (traced_layer.r_exit > traced_layer.r_entrance) {
                             end_weights = &entrance_weights;
                             end_entrance = true;
@@ -1710,38 +1804,52 @@ namespace sasktran2::successive_orders {
                             start_weights = &exit_weights;
                             start_entrance = false;
                         }
+                        const int exit_solar = m_solar_offsets[ray] + layer;
+                        start = scalar_endpoint_jvp<false>(
+                            wavelength, wavelength_thread, ray, layer,
+                            start_entrance, exit_solar + 1, *start_weights,
+                            extinction_direction, albedo_direction,
+                            solar_direction, uniform_albedo_direction,
+                            uniform_albedo_tangent, phase_tangent_active);
+                        end = scalar_endpoint_jvp<false>(
+                            wavelength, wavelength_thread, ray, layer,
+                            end_entrance, exit_solar, *end_weights,
+                            extinction_direction, albedo_direction,
+                            solar_direction, uniform_albedo_direction,
+                            uniform_albedo_tangent, phase_tangent_active);
+                    } else {
+                        const int exit_solar = m_solar_offsets[ray] + layer;
+                        start =
+                            have_shared_endpoint
+                                ? shared_endpoint
+                                : scalar_endpoint_jvp<true>(
+                                      wavelength, wavelength_thread, ray, layer,
+                                      true, exit_solar + 1,
+                                      endpoint_weights(exit_solar + 1),
+                                      extinction_direction, albedo_direction,
+                                      solar_direction, uniform_albedo_direction,
+                                      uniform_albedo_tangent,
+                                      phase_tangent_active);
+                        end = scalar_endpoint_jvp<true>(
+                            wavelength, wavelength_thread, ray, layer, false,
+                            exit_solar, endpoint_weights(exit_solar),
+                            extinction_direction, albedo_direction,
+                            solar_direction, uniform_albedo_direction,
+                            uniform_albedo_tangent, phase_tangent_active);
                     }
-                    const int exit_solar = m_solar_offsets[ray] + layer;
-                    const auto start =
-                        have_shared_endpoint && !LOWER_INTERPOLATION
-                            ? shared_endpoint
-                            : scalar_endpoint_jvp<!LOWER_INTERPOLATION>(
-                                  wavelength, wavelength_thread, ray, layer,
-                                  start_entrance, exit_solar + 1,
-                                  *start_weights, extinction_direction,
-                                  albedo_direction, solar_direction,
-                                  uniform_albedo_direction,
-                                  uniform_albedo_tangent, phase_tangent_active);
-                    const auto end = scalar_endpoint_jvp<!LOWER_INTERPOLATION>(
-                        wavelength, wavelength_thread, ray, layer, end_entrance,
-                        exit_solar, *end_weights, extinction_direction,
-                        albedo_direction, solar_direction,
-                        uniform_albedo_direction, uniform_albedo_tangent,
-                        phase_tangent_active);
                     const double factor_tangent =
                         constant_source_factor_derivative(optical_depth,
                                                           factor) *
                         optical_depth_tangent;
                     const double endpoint_value =
-                        (start.value * traced_layer.od_quad_start_fraction +
-                         end.value * traced_layer.od_quad_end_fraction) *
-                        traced_layer.layer_distance;
+                        start.value * source_quad_start +
+                        end.value * source_quad_end;
                     const double endpoint_tangent =
-                        start.tangent * traced_layer.od_quad_start +
-                        end.tangent * traced_layer.od_quad_end;
+                        start.tangent * source_quad_start +
+                        end.tangent * source_quad_end;
                     const double optical_endpoint_value =
-                        start.value * traced_layer.od_quad_start +
-                        end.value * traced_layer.od_quad_end;
+                        start.value * source_quad_start +
+                        end.value * source_quad_end;
                     radiance_tangent +=
                         prefix_tangent * factor * endpoint_value +
                         prefix * (factor * endpoint_tangent +
@@ -1754,19 +1862,30 @@ namespace sasktran2::successive_orders {
                 prefix *= attenuation;
             }
             if constexpr (WITH_TRANSPORT) {
-                if (traced_ray.ground_is_hit) {
+                if (ray_interpolation.ground_is_hit()) {
                     direct_transport_direction[ray] +=
                         ground_state[ray] * prefix_tangent;
                 }
             }
-            if (traced_ray.ground_is_hit && !traced_ray.layers.empty()) {
-                const auto& ground_layer = traced_ray.layers.front();
+            ScalarGroundGeometry local_ground;
+            const ScalarGroundGeometry* ground = nullptr;
+            if constexpr (LOWER_INTERPOLATION) {
+                const auto& traced_ray = rays[ray];
+                if (traced_ray.ground_is_hit && !traced_ray.layers.empty()) {
+                    const auto& layer = traced_ray.layers.front();
+                    local_ground = {layer.exit.position.normalized(),
+                                    layer.average_look_away};
+                    ground = &local_ground;
+                }
+            } else if (packed_ray->ground_geometry >= 0) {
+                ground = &m_scalar_ground_geometry[packed_ray->ground_geometry];
+            }
+            if (ground != nullptr) {
                 double mu_in;
                 double mu_out;
                 double phi;
-                if (ground_scattering_geometry(m_solar_offsets[ray],
-                                               ground_layer, mu_in, mu_out,
-                                               phi)) {
+                if (ground_scattering_geometry(m_solar_offsets[ray], *ground,
+                                               mu_in, mu_out, phi)) {
                     const auto brdf = m_atmosphere->surface().brdf(
                         wavelength, mu_in, mu_out, phi);
                     double brdf_tangent = 0.0;
@@ -1882,7 +2001,6 @@ namespace sasktran2::successive_orders {
             auto& solar_gradient = m_solar_product_scratch[thread];
             auto& coefficient_gradient = m_phase_product_scratch[thread];
             auto& scratch = m_scalar_vjp_scratch[thread];
-            const auto& traced_ray = rays[ray];
             const auto& ray_interpolation = interpolation[ray];
             const ScalarPackedRay* packed_ray = nullptr;
             if constexpr (!LOWER_INTERPOLATION) {
@@ -1897,9 +2015,7 @@ namespace sasktran2::successive_orders {
                     : m_source_geometry->transport_columns_for_ray(ray);
             const int* transport_column_data = transport_columns.data();
             const int num_layers =
-                LOWER_INTERPOLATION ? static_cast<int>(traced_ray.layers.size())
-                                    : static_cast<int>(packed_ray->layer_end -
-                                                       packed_ray->layer_begin);
+                static_cast<int>(ray_interpolation.layers.size());
             double prefix = 1.0;
             for (int layer = num_layers - 1; layer >= 0; --layer) {
                 double optical_depth = 0.0;
@@ -1912,7 +2028,7 @@ namespace sasktran2::successive_orders {
                     attenuation = 1.0 - factor * optical_depth;
                 } else {
                     const auto od_weights =
-                        traced_ray.optical_depth_weights(layer);
+                        ray_interpolation.optical_depth_for_layer(layer);
                     for (std::size_t index = 0; index < od_weights.size();
                          ++index) {
                         const auto [atmosphere_index, weight] =
@@ -1959,10 +2075,7 @@ namespace sasktran2::successive_orders {
                                      num_phase_basis_slots() +
                                  phase_basis_slot(ray, solar_index)];
                         } else {
-                            const auto weights =
-                                endpoint == 0
-                                    ? traced_ray.exit_weights(0)
-                                    : traced_ray.entrance_weights(endpoint - 1);
+                            const auto weights = endpoint_weights(solar_index);
                             value = scalar_endpoint(
                                 wavelength, ray,
                                 endpoint == 0 ? 0 : endpoint - 1, endpoint != 0,
@@ -1977,14 +2090,25 @@ namespace sasktran2::successive_orders {
             }
             const double forcing_gradient = forcing_cotangent(ray);
             double prefix_cotangent = 0.0;
-            if (traced_ray.ground_is_hit && !traced_ray.layers.empty()) {
-                const auto& ground_layer = traced_ray.layers.front();
+            ScalarGroundGeometry local_ground;
+            const ScalarGroundGeometry* ground = nullptr;
+            if constexpr (LOWER_INTERPOLATION) {
+                const auto& traced_ray = rays[ray];
+                if (traced_ray.ground_is_hit && !traced_ray.layers.empty()) {
+                    const auto& layer = traced_ray.layers.front();
+                    local_ground = {layer.exit.position.normalized(),
+                                    layer.average_look_away};
+                    ground = &local_ground;
+                }
+            } else if (packed_ray->ground_geometry >= 0) {
+                ground = &m_scalar_ground_geometry[packed_ray->ground_geometry];
+            }
+            if (ground != nullptr) {
                 double mu_in;
                 double mu_out;
                 double phi;
-                if (ground_scattering_geometry(m_solar_offsets[ray],
-                                               ground_layer, mu_in, mu_out,
-                                               phi)) {
+                if (ground_scattering_geometry(m_solar_offsets[ray], *ground,
+                                               mu_in, mu_out, phi)) {
                     const auto brdf = m_atmosphere->surface().brdf(
                         wavelength, mu_in, mu_out, phi);
                     const double ground_source =
@@ -2006,7 +2130,7 @@ namespace sasktran2::successive_orders {
                 }
             }
             if constexpr (WITH_TRANSPORT) {
-                if (traced_ray.ground_is_hit) {
+                if (ray_interpolation.ground_is_hit()) {
                     if (ground_state != nullptr) {
                         prefix_cotangent +=
                             ground_state[ray] * forcing_gradient;
@@ -2030,7 +2154,7 @@ namespace sasktran2::successive_orders {
                 double source_quad_start;
                 double source_quad_end;
                 if constexpr (LOWER_INTERPOLATION) {
-                    traced_layer = &traced_ray.layers[layer];
+                    traced_layer = &rays[ray].layers[layer];
                     layer_distance = traced_layer->layer_distance;
                     source_quad_start = traced_layer->od_quad_start;
                     source_quad_end = traced_layer->od_quad_end;
@@ -2089,14 +2213,16 @@ namespace sasktran2::successive_orders {
                 }
                 if (layer_distance >= minimum_layer_distance_m &&
                     forcing_gradient != 0.0) {
-                    const auto entrance_weights =
-                        traced_ray.entrance_weights(layer);
-                    const auto exit_weights = traced_ray.exit_weights(layer);
+                    sasktran2::raytracing::GridWeightStencilView
+                        entrance_weights;
+                    sasktran2::raytracing::GridWeightStencilView exit_weights;
                     const auto* start_weights = &entrance_weights;
                     const auto* end_weights = &exit_weights;
                     bool start_entrance = true;
                     bool end_entrance = false;
                     if constexpr (LOWER_INTERPOLATION) {
+                        entrance_weights = rays[ray].entrance_weights(layer);
+                        exit_weights = rays[ray].exit_weights(layer);
                         if (traced_layer->r_exit > traced_layer->r_entrance) {
                             end_weights = &entrance_weights;
                             end_entrance = true;
@@ -2173,7 +2299,8 @@ namespace sasktran2::successive_orders {
                 layer_prefix_cotangent += prefix_cotangent * attenuation;
                 attenuation_cotangent += prefix_cotangent * layer_prefix;
                 optical_depth_cotangent -= attenuation * attenuation_cotangent;
-                const auto od_weights = traced_ray.optical_depth_weights(layer);
+                const auto od_weights =
+                    ray_interpolation.optical_depth_for_layer(layer);
                 for (std::size_t index = 0; index < od_weights.size();
                      ++index) {
                     const auto [atmosphere_index, weight] = od_weights[index];
@@ -2184,18 +2311,16 @@ namespace sasktran2::successive_orders {
             }
             if constexpr (!LOWER_INTERPOLATION) {
                 if (num_layers > 0) {
-                    const auto exit_weights = traced_ray.exit_weights(0);
                     accumulate_scalar_endpoint_vjp(
                         wavelength, ray, 0, false, m_solar_offsets[ray],
-                        exit_weights, scratch.endpoints[0],
-                        scratch.endpoint_cotangent(0), thread_gradient,
-                        solar_gradient, coefficient_gradient);
+                        endpoint_weights(m_solar_offsets[ray]),
+                        scratch.endpoints[0], scratch.endpoint_cotangent(0),
+                        thread_gradient, solar_gradient, coefficient_gradient);
                     for (int endpoint = 1; endpoint <= num_layers; ++endpoint) {
-                        const auto entrance_weights =
-                            traced_ray.entrance_weights(endpoint - 1);
+                        const int solar_index = m_solar_offsets[ray] + endpoint;
                         accumulate_scalar_endpoint_vjp(
-                            wavelength, ray, endpoint - 1, true,
-                            m_solar_offsets[ray] + endpoint, entrance_weights,
+                            wavelength, ray, endpoint - 1, true, solar_index,
+                            endpoint_weights(solar_index),
                             scratch.endpoints[endpoint],
                             scratch.endpoint_cotangent(endpoint),
                             thread_gradient, solar_gradient,
@@ -2560,8 +2685,10 @@ namespace sasktran2::successive_orders {
         result += m_uniform_phase_values.capacity() * sizeof(double);
         result += m_uniform_albedo_active.capacity() * sizeof(unsigned char);
         result += m_uniform_albedo_values.capacity() * sizeof(double);
-        result += m_scalar_packed_rays.capacity() * sizeof(ScalarPackedRay) +
-                  m_scalar_packed_layers.capacity() * sizeof(ScalarPackedLayer);
+        result +=
+            m_scalar_packed_rays.capacity() * sizeof(ScalarPackedRay) +
+            m_scalar_packed_layers.capacity() * sizeof(ScalarPackedLayer) +
+            m_scalar_ground_geometry.capacity() * sizeof(ScalarGroundGeometry);
         for (const auto& transmission : m_cached_solar_transmission) {
             result +=
                 static_cast<std::size_t>(transmission.size()) * sizeof(double);

--- a/cpp/lib/successive_orders/first_order.h
+++ b/cpp/lib/successive_orders/first_order.h
@@ -10,6 +10,7 @@
 #include <Eigen/SparseCore>
 
 #include <cstddef>
+#include <memory>
 #include <vector>
 
 namespace sasktran2::successive_orders {
@@ -26,6 +27,11 @@ namespace sasktran2::successive_orders {
         FirstOrderProvider(
             const sasktran2::Geometry1D& geometry,
             const sasktran2::raytracing::RayTracerBase& raytracer);
+#ifdef SKTRAN_RUST_SUPPORT
+        FirstOrderProvider(
+            const sasktran2::Geometry2D& geometry,
+            const sasktran2::raytracing::RustRayTracer2D& raytracer);
+#endif
 
         void initialize_config(const sasktran2::Config& config);
         void initialize_geometry(const SourceGeometry1D& source_geometry);
@@ -214,9 +220,11 @@ namespace sasktran2::successive_orders {
             Eigen::Ref<Eigen::VectorXd> solar_gradient,
             Eigen::Ref<Eigen::VectorXd> coefficient_gradient) const;
 
-        const sasktran2::Geometry1D& m_geometry;
+        const sasktran2::Geometry& m_geometry;
+        const sasktran2::Geometry1D* m_geometry_1d = nullptr;
         ExactSource m_source;
-        sasktran2::solartransmission::SolarTransmissionTable m_solar_table;
+        std::unique_ptr<sasktran2::solartransmission::SolarTransmissionTable>
+            m_solar_table;
         Eigen::SparseMatrix<double, Eigen::RowMajor> m_solar_interpolation;
         std::vector<bool> m_solar_ground_hit;
         sasktran2::SourceIntegrator<NSTOKES> m_integrator;

--- a/cpp/lib/successive_orders/first_order.h
+++ b/cpp/lib/successive_orders/first_order.h
@@ -30,7 +30,10 @@ namespace sasktran2::successive_orders {
 #ifdef SKTRAN_RUST_SUPPORT
         FirstOrderProvider(
             const sasktran2::Geometry2D& geometry,
-            const sasktran2::raytracing::RustRayTracer2D& raytracer);
+            const sasktran2::raytracing::RustRayTracer2D& raytracer,
+            std::shared_ptr<
+                sasktran2::solartransmission::SolarTransmissionTable2D>
+                shared_solar_table = nullptr);
 #endif
 
         void initialize_config(const sasktran2::Config& config);
@@ -220,13 +223,27 @@ namespace sasktran2::successive_orders {
             Eigen::Ref<Eigen::VectorXd> solar_gradient,
             Eigen::Ref<Eigen::VectorXd> coefficient_gradient) const;
 
+        int phase_basis_slot(int ray, int solar_index) const {
+            return m_endpoint_phase_basis ? solar_index : ray;
+        }
+        int num_phase_basis_slots() const {
+            return m_endpoint_phase_basis ? m_solar_offsets.back() : m_num_rays;
+        }
+        bool ground_scattering_geometry(
+            int solar_index,
+            const sasktran2::raytracing::TracedLayer& ground_layer,
+            double& mu_in, double& mu_out, double& phi) const;
+
         const sasktran2::Geometry& m_geometry;
         const sasktran2::Geometry1D* m_geometry_1d = nullptr;
         ExactSource m_source;
-        std::unique_ptr<sasktran2::solartransmission::SolarTransmissionTable>
+        std::shared_ptr<
+            sasktran2::solartransmission::SolarTransmissionTableEvaluator>
             m_solar_table;
-        Eigen::SparseMatrix<double, Eigen::RowMajor> m_solar_interpolation;
+        sasktran2::solartransmission::SolarTableInterpolation
+            m_solar_interpolation;
         std::vector<bool> m_solar_ground_hit;
+        std::vector<Eigen::Vector3d> m_solar_propagation_directions;
         sasktran2::SourceIntegrator<NSTOKES> m_integrator;
         std::vector<SourceTermInterface<NSTOKES>*> m_source_terms;
         const sasktran2::atmosphere::Atmosphere<NSTOKES>* m_atmosphere =
@@ -241,6 +258,8 @@ namespace sasktran2::successive_orders {
         bool m_compact_scalar_requested = false;
         bool m_use_compact_scalar = false;
         bool m_use_lower_interpolation = false;
+        bool m_solar_refraction = false;
+        bool m_endpoint_phase_basis = false;
 
         std::vector<int> m_solar_offsets;
         std::vector<double> m_phase_basis;

--- a/cpp/lib/successive_orders/first_order.h
+++ b/cpp/lib/successive_orders/first_order.h
@@ -48,6 +48,9 @@ namespace sasktran2::successive_orders {
                        Eigen::Ref<Eigen::VectorXd> forcing);
 
         bool uses_compact_scalar_kernel() const { return m_use_compact_scalar; }
+        bool can_release_incoming_geometry() const {
+            return m_use_compact_scalar && !m_use_lower_interpolation;
+        }
 
         void calculate_with_transport(int wavelength, int wavelength_thread,
                                       TransportOperator& transport,
@@ -148,6 +151,12 @@ namespace sasktran2::successive_orders {
         struct ScalarPackedRay {
             std::uint32_t layer_begin = 0;
             std::uint32_t layer_end = 0;
+            std::int32_t ground_geometry = -1;
+        };
+
+        struct ScalarGroundGeometry {
+            Eigen::Vector3d up;
+            Eigen::Vector3d look_away;
         };
 
         void calculate_scalar(int wavelength, int wavelength_thread,
@@ -204,24 +213,35 @@ namespace sasktran2::successive_orders {
             const Eigen::VectorXd* layer_state_projection,
             const Eigen::VectorXd* ground_state_projection);
 
-        ScalarEndpoint scalar_endpoint(
-            int wavelength, int ray, int layer, bool entrance, int solar_index,
-            const sasktran2::raytracing::GridWeightStencilView& weights) const;
-        template <bool USE_ENDPOINT_MEDIUM>
+        template <typename Weights>
+        ScalarEndpoint scalar_endpoint(int wavelength, int ray, int layer,
+                                       bool entrance, int solar_index,
+                                       const Weights& weights) const;
+        template <bool USE_ENDPOINT_MEDIUM, typename Weights>
         ScalarValueTangent scalar_endpoint_jvp(
             int wavelength, int wavelength_thread, int ray, int layer,
-            bool entrance, int solar_index,
-            const sasktran2::raytracing::GridWeightStencilView& weights,
+            bool entrance, int solar_index, const Weights& weights,
             const double* extinction_direction, const double* albedo_direction,
             const double* solar_tangent, bool uniform_albedo_direction,
             double uniform_albedo_tangent, bool phase_tangent_active) const;
+        template <typename Weights>
         void accumulate_scalar_endpoint_vjp(
             int wavelength, int ray, int layer, bool entrance, int solar_index,
-            const sasktran2::raytracing::GridWeightStencilView& weights,
-            const ScalarEndpoint& endpoint, double source_cotangent,
+            const Weights& weights, const ScalarEndpoint& endpoint,
+            double source_cotangent,
             Eigen::Ref<Eigen::VectorXd> native_gradient,
             Eigen::Ref<Eigen::VectorXd> solar_gradient,
             Eigen::Ref<Eigen::VectorXd> coefficient_gradient) const;
+
+        InterpolationView<InterpolationWeight>
+        endpoint_weights(int solar_index) const {
+            const int slot = m_endpoint_slots[solar_index];
+            return {
+                m_unique_endpoint_weights,
+                static_cast<std::size_t>(m_unique_endpoint_offsets[slot]),
+                static_cast<std::size_t>(m_unique_endpoint_offsets[slot + 1] -
+                                         m_unique_endpoint_offsets[slot])};
+        }
 
         int phase_basis_slot(int ray, int solar_index) const {
             return m_endpoint_phase_basis ? solar_index : ray;
@@ -229,10 +249,10 @@ namespace sasktran2::successive_orders {
         int num_phase_basis_slots() const {
             return m_endpoint_phase_basis ? m_solar_offsets.back() : m_num_rays;
         }
-        bool ground_scattering_geometry(
-            int solar_index,
-            const sasktran2::raytracing::TracedLayer& ground_layer,
-            double& mu_in, double& mu_out, double& phi) const;
+        bool ground_scattering_geometry(int solar_index,
+                                        const ScalarGroundGeometry& ground,
+                                        double& mu_in, double& mu_out,
+                                        double& phi) const;
 
         const sasktran2::Geometry& m_geometry;
         const sasktran2::Geometry1D* m_geometry_1d = nullptr;
@@ -268,6 +288,7 @@ namespace sasktran2::successive_orders {
         std::vector<InterpolationWeight> m_unique_endpoint_weights;
         std::vector<ScalarPackedRay> m_scalar_packed_rays;
         std::vector<ScalarPackedLayer> m_scalar_packed_layers;
+        std::vector<ScalarGroundGeometry> m_scalar_ground_geometry;
         mutable std::vector<sasktran2::WavelengthBlockDual<NSTOKES>>
             m_primal_scratch;
         mutable std::vector<Eigen::MatrixXd> m_gradient_scratch;

--- a/cpp/lib/successive_orders/geometry.cpp
+++ b/cpp/lib/successive_orders/geometry.cpp
@@ -545,6 +545,23 @@ namespace sasktran2::successive_orders {
         }
     }
 
+    void SourceGeometry1D::release_incoming_traced_rays() {
+        if (m_incoming_viewing.traced_rays.size() !=
+            m_incoming_interpolation.size()) {
+            throw std::logic_error(
+                "Successive-orders incoming geometry is inconsistent");
+        }
+        for (std::size_t ray = 0; ray < m_incoming_viewing.traced_rays.size();
+             ++ray) {
+            adopt_optical_depth_storage(m_incoming_viewing.traced_rays[ray],
+                                        m_incoming_interpolation[ray]);
+        }
+        m_incoming_viewing.traced_rays.clear();
+        m_incoming_viewing.traced_rays.shrink_to_fit();
+        m_incoming_viewing.flux_observers.clear();
+        m_incoming_viewing.flux_observers.shrink_to_fit();
+    }
+
     void SourceGeometry1D::initialize(
         const sasktran2::viewinggeometry::InternalViewingGeometry&
             internal_viewing,

--- a/cpp/lib/successive_orders/geometry.cpp
+++ b/cpp/lib/successive_orders/geometry.cpp
@@ -16,6 +16,154 @@
 
 namespace sasktran2::successive_orders {
     namespace {
+        class AltitudeAngleSourceLocationInterpolator final
+            : public sasktran2::grids::SourceLocationInterpolator {
+          public:
+            AltitudeAngleSourceLocationInterpolator(
+                sasktran2::grids::AltitudeGrid&& altitude_grid,
+                const sasktran2::Geometry2D& geometry,
+                int num_horizontal_points)
+                : SourceLocationInterpolator(std::move(altitude_grid)),
+                  m_geometry(geometry), m_horizontal_grid(make_horizontal_grid(
+                                            geometry, num_horizontal_points)) {}
+
+            const Eigen::VectorXd& horizontal_grid() const {
+                return m_horizontal_grid.grid();
+            }
+
+            int num_interior_points() const override {
+                return static_cast<int>(m_altitude_grid.grid().size() *
+                                        m_horizontal_grid.grid().size());
+            }
+
+            int num_ground_points() const override {
+                return static_cast<int>(m_horizontal_grid.grid().size());
+            }
+
+            Eigen::Vector3d
+            grid_location(const sasktran2::Coordinates& coordinates,
+                          int location_index) const override {
+                if (location_index < 0 ||
+                    location_index >= num_interior_points()) {
+                    throw std::out_of_range(
+                        "Successive-orders 2D source location is out of "
+                        "range");
+                }
+                const int num_altitudes =
+                    static_cast<int>(m_altitude_grid.grid().size());
+                const int altitude_index = location_index % num_altitudes;
+                const int horizontal_index = location_index / num_altitudes;
+                const double radius = coordinates.earth_radius() +
+                                      m_altitude_grid.grid()[altitude_index];
+                return radius *
+                       coordinates.unit_vector_from_angles(
+                           m_horizontal_grid.grid()[horizontal_index], 0.0);
+            }
+
+            Eigen::Vector3d
+            ground_location(const sasktran2::Coordinates& coordinates,
+                            int ground_index) const override {
+                if (ground_index < 0 || ground_index >= num_ground_points()) {
+                    throw std::out_of_range(
+                        "Successive-orders 2D ground location is out of "
+                        "range");
+                }
+                const double surface_radius =
+                    coordinates.earth_radius() +
+                    m_geometry.altitude_grid().grid()[0];
+                return surface_radius *
+                       coordinates.unit_vector_from_angles(
+                           m_horizontal_grid.grid()[ground_index], 0.0);
+            }
+
+            void interior_interpolation_weights(
+                const sasktran2::Coordinates&,
+                const sasktran2::Location& location,
+                std::vector<std::pair<int, double>>& weights,
+                int& num_interp) override {
+                std::array<int, 2> altitude_indices;
+                std::array<int, 2> horizontal_indices;
+                std::array<double, 2> altitude_weights;
+                std::array<double, 2> horizontal_weights;
+                int num_altitudes = 0;
+                int num_horizontal = 0;
+                m_altitude_grid.calculate_interpolation_weights(
+                    m_geometry.altitude_at(location), altitude_indices,
+                    altitude_weights, num_altitudes);
+                m_horizontal_grid.calculate_interpolation_weights(
+                    m_geometry.horizontal_angle_at(location),
+                    horizontal_indices, horizontal_weights, num_horizontal);
+
+                num_interp = num_altitudes * num_horizontal;
+                weights.resize(static_cast<std::size_t>(num_interp));
+                for (int horizontal = 0; horizontal < num_horizontal;
+                     ++horizontal) {
+                    for (int altitude = 0; altitude < num_altitudes;
+                         ++altitude) {
+                        const int output =
+                            altitude + horizontal * num_altitudes;
+                        weights[output] = {interior_linear_index(
+                                               altitude_indices[altitude],
+                                               horizontal_indices[horizontal]),
+                                           altitude_weights[altitude] *
+                                               horizontal_weights[horizontal]};
+                    }
+                }
+            }
+
+            void ground_interpolation_weights(
+                const sasktran2::Coordinates&,
+                const sasktran2::Location& location,
+                std::vector<std::pair<int, double>>& weights,
+                int& num_interp) const override {
+                std::array<int, 2> horizontal_indices;
+                std::array<double, 2> horizontal_weights;
+                m_horizontal_grid.calculate_interpolation_weights(
+                    m_geometry.horizontal_angle_at(location),
+                    horizontal_indices, horizontal_weights, num_interp);
+                weights.resize(static_cast<std::size_t>(num_interp));
+                for (int horizontal = 0; horizontal < num_interp;
+                     ++horizontal) {
+                    weights[horizontal] = {num_interior_points() +
+                                               horizontal_indices[horizontal],
+                                           horizontal_weights[horizontal]};
+                }
+            }
+
+          private:
+            static sasktran2::grids::Grid
+            make_horizontal_grid(const sasktran2::Geometry2D& geometry,
+                                 int num_horizontal_points) {
+                const auto& atmosphere_angles =
+                    geometry.horizontal_angle_grid();
+                Eigen::VectorXd horizontal_angles(num_horizontal_points);
+                if (num_horizontal_points == 1) {
+                    horizontal_angles[0] =
+                        0.5 * (atmosphere_angles[0] +
+                               atmosphere_angles[atmosphere_angles.size() - 1]);
+                } else {
+                    horizontal_angles.setLinSpaced(
+                        num_horizontal_points, atmosphere_angles[0],
+                        atmosphere_angles[atmosphere_angles.size() - 1]);
+                }
+                return sasktran2::grids::Grid(
+                    std::move(horizontal_angles),
+                    sasktran2::grids::gridspacing::automatic,
+                    sasktran2::grids::outofbounds::extend,
+                    sasktran2::grids::interpolation::linear);
+            }
+
+            int interior_linear_index(int altitude_index,
+                                      int horizontal_index) const {
+                return altitude_index +
+                       horizontal_index *
+                           static_cast<int>(m_altitude_grid.grid().size());
+            }
+
+            const sasktran2::Geometry2D& m_geometry;
+            const sasktran2::grids::Grid m_horizontal_grid;
+        };
+
         std::vector<InterpolationWeight>
         sorted_weights(const std::vector<std::pair<int, double>>& weights) {
             std::vector<InterpolationWeight> result;
@@ -77,12 +225,23 @@ namespace sasktran2::successive_orders {
     SourceGeometry1D::SourceGeometry1D(
         const sasktran2::raytracing::RayTracerBase& raytracer,
         const sasktran2::Geometry1D& geometry)
-        : m_raytracer(raytracer), m_geometry(geometry) {}
+        : m_geometry(geometry), m_geometry_1d(&geometry),
+          m_raytracer_1d(&raytracer) {}
+
+#ifdef SKTRAN_RUST_SUPPORT
+    SourceGeometry1D::SourceGeometry1D(
+        const sasktran2::raytracing::RustRayTracer2D& raytracer,
+        const sasktran2::Geometry2D& geometry)
+        : m_geometry(geometry), m_geometry_2d(&geometry),
+          m_raytracer_2d(&raytracer) {}
+#endif
 
     SourceGeometry1D::~SourceGeometry1D() = default;
 
     sasktran2::grids::AltitudeGrid SourceGeometry1D::make_altitude_grid() {
-        const auto& atmosphere_altitudes = m_geometry.altitude_grid().grid();
+        const auto& atmosphere_altitudes =
+            m_geometry_1d != nullptr ? m_geometry_1d->altitude_grid().grid()
+                                     : m_geometry_2d->altitude_grid().grid();
         Eigen::VectorXd altitudes;
         // Atmosphere layer midpoints inherit arbitrary spacing from the
         // atmosphere grid. Let Grid retain the constant fast path only when
@@ -131,6 +290,10 @@ namespace sasktran2::successive_orders {
     sasktran2::grids::Grid SourceGeometry1D::make_cos_sza_grid(
         const sasktran2::viewinggeometry::InternalViewingGeometry&
             internal_viewing) {
+        if (m_geometry_1d == nullptr) {
+            throw std::logic_error(
+                "Cannot construct an SZA source grid for Geometry2D");
+        }
         Eigen::VectorXd cos_sza;
         const auto geometry_type = m_geometry.coordinates().geometry_type();
         const auto bounds = sasktran2::raytracing::min_max_cos_sza_of_all_rays(
@@ -291,8 +454,7 @@ namespace sasktran2::successive_orders {
                         point.incoming_offset() + direction_index;
                     auto& traced_ray =
                         m_incoming_viewing.traced_rays[ray_index];
-                    m_raytracer.trace_ray(viewing_ray, traced_ray,
-                                          m_settings.include_refraction);
+                    trace_ray(viewing_ray, traced_ray);
                     compile_ray_interpolation(
                         traced_ray, m_geometry, *m_location_interpolator,
                         m_source_points, m_incoming_interpolation[ray_index],
@@ -388,13 +550,32 @@ namespace sasktran2::successive_orders {
             internal_viewing,
         const SourceGeometrySettings& settings) {
         settings.validate();
+        if (m_geometry_2d != nullptr && settings.include_refraction) {
+            throw std::invalid_argument(
+                "Geometry2D successive orders does not support diffuse-ray "
+                "refraction");
+        }
         m_settings = settings;
 
         auto altitude_grid = make_altitude_grid();
-        auto cos_sza_grid = make_cos_sza_grid(internal_viewing);
-        m_location_interpolator = std::make_unique<
-            sasktran2::grids::AltitudeSZASourceLocationInterpolator>(
-            std::move(altitude_grid), std::move(cos_sza_grid));
+        if (m_geometry_1d != nullptr) {
+            auto cos_sza_grid = make_cos_sza_grid(internal_viewing);
+            m_location_interpolator = std::make_unique<
+                sasktran2::grids::AltitudeSZASourceLocationInterpolator>(
+                std::move(altitude_grid), std::move(cos_sza_grid));
+            m_source_horizontal_angles_rad.clear();
+        } else {
+            m_source_cos_sza.clear();
+            auto interpolator =
+                std::make_unique<AltitudeAngleSourceLocationInterpolator>(
+                    std::move(altitude_grid), *m_geometry_2d,
+                    m_settings.num_sza);
+            const auto& horizontal_grid = interpolator->horizontal_grid();
+            m_source_horizontal_angles_rad.assign(horizontal_grid.data(),
+                                                  horizontal_grid.data() +
+                                                      horizontal_grid.size());
+            m_location_interpolator = std::move(interpolator);
+        }
 
         construct_source_points();
         trace_and_compile_incoming();
@@ -405,6 +586,24 @@ namespace sasktran2::successive_orders {
         compile_transport_topology(m_los_interpolation,
                                    m_los_transport_row_offsets,
                                    m_los_transport_column_indices);
+    }
+
+    void SourceGeometry1D::trace_ray(
+        const sasktran2::viewinggeometry::ViewingRay& viewing_ray,
+        sasktran2::raytracing::TracedRay& traced_ray) const {
+        if (m_raytracer_1d != nullptr) {
+            m_raytracer_1d->trace_ray(viewing_ray, traced_ray,
+                                      m_settings.include_refraction);
+            return;
+        }
+#ifdef SKTRAN_RUST_SUPPORT
+        if (m_raytracer_2d != nullptr) {
+            m_raytracer_2d->trace_ray(viewing_ray, traced_ray);
+            return;
+        }
+#endif
+        throw std::logic_error(
+            "Successive-orders source geometry has no ray tracer");
     }
 
 } // namespace sasktran2::successive_orders

--- a/cpp/lib/successive_orders/geometry.cpp
+++ b/cpp/lib/successive_orders/geometry.cpp
@@ -16,6 +16,92 @@
 
 namespace sasktran2::successive_orders {
     namespace {
+        class GroundUnitSphere final : public sasktran2::math::UnitSphere {
+          public:
+            GroundUnitSphere(std::unique_ptr<const UnitSphere>&& sphere,
+                             const Eigen::Vector3d& location)
+                : m_full_sphere(std::move(sphere)) {
+                m_contributing_map.reserve(m_full_sphere->num_points() / 2);
+                for (int index = 0; index < m_full_sphere->num_points();
+                     ++index) {
+                    if (m_full_sphere->get_quad_position(index).dot(location) >
+                        0) {
+                        m_contributing_map.push_back(index);
+                        m_quadrature_normalization +=
+                            m_full_sphere->quadrature_weight(index);
+                    }
+                }
+            }
+
+            int num_points() const override {
+                return static_cast<int>(m_contributing_map.size());
+            }
+
+            Eigen::Vector3d get_quad_position(int index) const override {
+                return m_full_sphere->get_quad_position(
+                    m_contributing_map[index]);
+            }
+
+            double quadrature_weight(int index) const override {
+                return m_full_sphere->quadrature_weight(
+                           m_contributing_map[index]) /
+                       m_quadrature_normalization * 0.5;
+            }
+
+            void interpolate(const Eigen::Vector3d& direction,
+                             std::vector<std::pair<int, double>>& index_weights,
+                             int& num_interp) const override {
+                num_interp = std::min(3, num_points());
+                index_weights.assign(
+                    static_cast<std::size_t>(num_interp),
+                    {-1, std::numeric_limits<double>::infinity()});
+
+                // Select neighbors directly from the upward hemisphere.
+                // Filtering a full-sphere stencil after selection can discard
+                // every neighbor for near-horizon directions.
+                for (int local_index = 0; local_index < num_points();
+                     ++local_index) {
+                    const double squared_distance =
+                        (get_quad_position(local_index) - direction)
+                            .squaredNorm();
+                    for (int slot = 0; slot < num_interp; ++slot) {
+                        if (squared_distance < index_weights[slot].second) {
+                            for (int shifted = num_interp - 1; shifted > slot;
+                                 --shifted) {
+                                index_weights[shifted] =
+                                    index_weights[shifted - 1];
+                            }
+                            index_weights[slot] = {local_index,
+                                                   squared_distance};
+                            break;
+                        }
+                    }
+                }
+
+                double total_inverse_distance = 0.0;
+                for (int slot = 0; slot < num_interp; ++slot) {
+                    if (index_weights[slot].second < 1.0e-8) {
+                        for (auto& weight : index_weights) {
+                            weight.second = 0.0;
+                        }
+                        index_weights[slot].second = 1.0;
+                        return;
+                    }
+                    total_inverse_distance +=
+                        1.0 / std::sqrt(index_weights[slot].second);
+                }
+                for (auto& weight : index_weights) {
+                    weight.second = (1.0 / std::sqrt(weight.second)) /
+                                    total_inverse_distance;
+                }
+            }
+
+          private:
+            std::unique_ptr<const UnitSphere> m_full_sphere;
+            std::vector<int> m_contributing_map;
+            double m_quadrature_normalization = 0.0;
+        };
+
         class AltitudeAngleSourceLocationInterpolator final
             : public sasktran2::grids::SourceLocationInterpolator {
           public:
@@ -349,16 +435,14 @@ namespace sasktran2::successive_orders {
                 m_location_interpolator->ground_location(
                     m_geometry.coordinates(), ground_index);
             auto ground_grid = std::make_unique<AngularGridPair>();
-            ground_grid->incoming =
-                std::make_unique<sasktran2::math::UnitSphereGround>(
-                    std::make_unique<sasktran2::math::LebedevSphere>(
-                        m_settings.num_incoming),
-                    location);
-            ground_grid->outgoing =
-                std::make_unique<sasktran2::math::UnitSphereGround>(
-                    std::make_unique<sasktran2::math::LebedevSphere>(
-                        m_settings.num_outgoing),
-                    location);
+            ground_grid->incoming = std::make_unique<GroundUnitSphere>(
+                std::make_unique<sasktran2::math::LebedevSphere>(
+                    m_settings.num_incoming),
+                location);
+            ground_grid->outgoing = std::make_unique<GroundUnitSphere>(
+                std::make_unique<sasktran2::math::LebedevSphere>(
+                    m_settings.num_outgoing),
+                location);
             m_angular_grids.push_back(std::move(ground_grid));
         }
 

--- a/cpp/lib/successive_orders/geometry.h
+++ b/cpp/lib/successive_orders/geometry.h
@@ -146,6 +146,10 @@ namespace sasktran2::successive_orders {
             return m_los_interpolation;
         }
 
+        /** Releases the construction-only diffuse traced layers after all
+         * scalar consumers have compiled their compact geometry. */
+        void release_incoming_traced_rays();
+
         /** CSR topology for outgoing-source transport to incoming rays. */
         const std::vector<int>& transport_row_offsets() const {
             return m_transport_row_offsets;

--- a/cpp/lib/successive_orders/geometry.h
+++ b/cpp/lib/successive_orders/geometry.h
@@ -14,7 +14,7 @@ namespace sasktran2::grids {
 }
 
 namespace sasktran2::successive_orders {
-    /** Geometry-only configuration for the one-dimensional source grid. */
+    /** Geometry-only configuration for the successive-orders source grid. */
     struct SourceGeometrySettings {
         int num_incoming = 110;
         int num_outgoing = 110;
@@ -63,7 +63,7 @@ namespace sasktran2::successive_orders {
         bool m_is_ground = false;
     };
 
-    /** Immutable one-dimensional source geometry and interpolation topology.
+    /** Immutable source geometry and interpolation topology.
      *
      * Atmospheric optical properties are intentionally absent. Incoming rays
      * are traced once and both incoming-ray and LOS source interpolation are
@@ -74,6 +74,11 @@ namespace sasktran2::successive_orders {
       public:
         SourceGeometry1D(const sasktran2::raytracing::RayTracerBase& raytracer,
                          const sasktran2::Geometry1D& geometry);
+#ifdef SKTRAN_RUST_SUPPORT
+        SourceGeometry1D(
+            const sasktran2::raytracing::RustRayTracer2D& raytracer,
+            const sasktran2::Geometry2D& geometry);
+#endif
         ~SourceGeometry1D();
 
         SourceGeometry1D(const SourceGeometry1D&) = delete;
@@ -92,6 +97,9 @@ namespace sasktran2::successive_orders {
         }
         const std::vector<double>& source_cos_sza() const {
             return m_source_cos_sza;
+        }
+        const std::vector<double>& source_horizontal_angles_rad() const {
+            return m_source_horizontal_angles_rad;
         }
 
         int num_interior_points() const { return m_num_interior_points; }
@@ -191,9 +199,17 @@ namespace sasktran2::successive_orders {
         compile_transport_topology(std::vector<RayInterpolation>& interpolation,
                                    std::vector<int>& row_offsets,
                                    std::vector<int>& column_indices);
+        void
+        trace_ray(const sasktran2::viewinggeometry::ViewingRay& viewing_ray,
+                  sasktran2::raytracing::TracedRay& traced_ray) const;
 
-        const sasktran2::raytracing::RayTracerBase& m_raytracer;
-        const sasktran2::Geometry1D& m_geometry;
+        const sasktran2::Geometry& m_geometry;
+        const sasktran2::Geometry1D* m_geometry_1d = nullptr;
+        const sasktran2::Geometry2D* m_geometry_2d = nullptr;
+        const sasktran2::raytracing::RayTracerBase* m_raytracer_1d = nullptr;
+#ifdef SKTRAN_RUST_SUPPORT
+        const sasktran2::raytracing::RustRayTracer2D* m_raytracer_2d = nullptr;
+#endif
         SourceGeometrySettings m_settings;
 
         std::unique_ptr<sasktran2::grids::SourceLocationInterpolator>
@@ -204,6 +220,7 @@ namespace sasktran2::successive_orders {
         std::vector<int> m_outgoing_point_offsets;
         std::vector<double> m_source_altitudes_m;
         std::vector<double> m_source_cos_sza;
+        std::vector<double> m_source_horizontal_angles_rad;
         int m_num_interior_points = 0;
         int m_num_ground_points = 0;
 

--- a/cpp/lib/successive_orders/interpolation.cpp
+++ b/cpp/lib/successive_orders/interpolation.cpp
@@ -86,7 +86,7 @@ namespace sasktran2::successive_orders {
 
         Eigen::Vector3d
         deterministic_horizontal(const Eigen::Vector3d& local_up,
-                                 const sasktran2::Geometry1D& geometry) {
+                                 const sasktran2::Geometry& geometry) {
             constexpr double singular_squared_tolerance = 1.0e-24;
             Eigen::Vector3d horizontal =
                 geometry.coordinates().reference_x() -
@@ -105,7 +105,7 @@ namespace sasktran2::successive_orders {
 
         Eigen::Vector3d
         horizontal_solar_reference(const Eigen::Vector3d& local_up,
-                                   const sasktran2::Geometry1D& geometry) {
+                                   const sasktran2::Geometry& geometry) {
             constexpr double singular_squared_tolerance = 1.0e-24;
             Eigen::Vector3d horizontal =
                 geometry.coordinates().sun_unit() -
@@ -120,7 +120,7 @@ namespace sasktran2::successive_orders {
         rotate_unit_vector(const Eigen::Vector3d& vector,
                            const Eigen::Vector3d& initial_position,
                            const Eigen::Vector3d& new_position,
-                           const sasktran2::Geometry1D& geometry) {
+                           const sasktran2::Geometry& geometry) {
             const double vector_norm = vector.norm();
             const double initial_norm = initial_position.norm();
             const double new_norm = new_position.norm();
@@ -165,7 +165,7 @@ namespace sasktran2::successive_orders {
         void compile_source_weights(
             const Eigen::Vector3d& direction,
             const sasktran2::Location& interpolation_location, bool ground,
-            const sasktran2::Geometry1D& geometry,
+            const sasktran2::Geometry& geometry,
             sasktran2::grids::SourceLocationInterpolator& location_interpolator,
             const std::vector<SourcePoint>& source_points,
             std::vector<SourceInterpolationWeight>& result,
@@ -284,7 +284,7 @@ namespace sasktran2::successive_orders {
 
     void compile_ray_interpolation(
         const sasktran2::raytracing::TracedRay& ray,
-        const sasktran2::Geometry1D& geometry,
+        const sasktran2::Geometry& geometry,
         sasktran2::grids::SourceLocationInterpolator& location_interpolator,
         const std::vector<SourcePoint>& source_points, RayInterpolation& result,
         InterpolationScratch& scratch) {

--- a/cpp/lib/successive_orders/interpolation.cpp
+++ b/cpp/lib/successive_orders/interpolation.cpp
@@ -290,6 +290,7 @@ namespace sasktran2::successive_orders {
         InterpolationScratch& scratch) {
         result = {};
         result.traced_ray = &ray;
+        result.ground_hit = ray.ground_is_hit;
         result.layers.resize(ray.layers.size());
         result.atmosphere_weights.reserve(ray.layers.size() * 2);
         // The common one-SZA grid uses at most two altitude locations and
@@ -301,6 +302,10 @@ namespace sasktran2::successive_orders {
              ++layer_index) {
             const auto& traced_layer = ray.layers[layer_index];
             auto& interpolation = result.layers[layer_index];
+
+            interpolation.optical_depth_offset =
+                traced_layer.grid_weight_offset;
+            interpolation.optical_depth_count = traced_layer.grid_weight_count;
 
             sasktran2::Location midpoint;
             midpoint.position = 0.5 * (traced_layer.entrance.position +
@@ -338,6 +343,24 @@ namespace sasktran2::successive_orders {
                 ground_location, true, geometry, location_interpolator,
                 source_points, result.ground_weights, scratch);
         }
+    }
+
+    void adopt_optical_depth_storage(sasktran2::raytracing::TracedRay& ray,
+                                     RayInterpolation& interpolation) {
+        if (interpolation.traced_ray != &ray ||
+            !interpolation.optical_depth_indices.empty() ||
+            !interpolation.optical_depth_weights.empty()) {
+            throw std::invalid_argument(
+                "Invalid successive-orders OD stencil ownership transfer");
+        }
+        ray.release_optical_depth_storage(interpolation.optical_depth_indices,
+                                          interpolation.optical_depth_weights);
+        if (interpolation.optical_depth_indices.size() !=
+            interpolation.optical_depth_weights.size()) {
+            throw std::logic_error(
+                "Successive-orders OD stencil arrays have different sizes");
+        }
+        interpolation.traced_ray = nullptr;
     }
 
     void compile_transport_row(RayInterpolation& interpolation,

--- a/cpp/lib/successive_orders/interpolation.h
+++ b/cpp/lib/successive_orders/interpolation.h
@@ -9,7 +9,7 @@
 #include <vector>
 
 namespace sasktran2 {
-    class Geometry1D;
+    class Geometry;
 }
 
 namespace sasktran2::grids {
@@ -137,7 +137,7 @@ namespace sasktran2::successive_orders {
     /** Compiles deterministic interpolation metadata for one traced ray. */
     void compile_ray_interpolation(
         const sasktran2::raytracing::TracedRay& ray,
-        const sasktran2::Geometry1D& geometry,
+        const sasktran2::Geometry& geometry,
         sasktran2::grids::SourceLocationInterpolator& location_interpolator,
         const std::vector<SourcePoint>& source_points, RayInterpolation& result,
         InterpolationScratch& scratch);

--- a/cpp/lib/successive_orders/interpolation.h
+++ b/cpp/lib/successive_orders/interpolation.h
@@ -85,21 +85,24 @@ namespace sasktran2::successive_orders {
         std::uint32_t atmosphere_count = 0;
         std::uint32_t source_offset = 0;
         std::uint32_t source_count = 0;
+        std::uint32_t optical_depth_offset = 0;
+        std::uint32_t optical_depth_count = 0;
     };
 
     /** Compiled source interpolation for one traced ray.
      *
-     * The pointed-to ray owns the optical-depth, entrance, and exit stencils.
-     * Incoming diffuse rays are owned by SourceGeometry1D; LOS rays remain
-     * owned by the engine's InternalViewingGeometry. Both owners must outlive
-     * this metadata.
+     * Optical-depth stencils are retained directly so transport calculations
+     * do not need the much larger traced-layer geometry after setup.
      */
     struct RayInterpolation {
         const sasktran2::raytracing::TracedRay* traced_ray = nullptr;
         std::vector<LayerInterpolation> layers;
         std::vector<InterpolationWeight> atmosphere_weights;
         std::vector<SourceInterpolationWeight> source_weights;
+        std::vector<int> optical_depth_indices;
+        std::vector<double> optical_depth_weights;
         std::vector<SourceInterpolationWeight> ground_weights;
+        bool ground_hit = false;
 
         /** Offset of this row in SourceGeometry1D::transport_column_indices. */
         std::size_t transport_value_offset = 0;
@@ -116,13 +119,25 @@ namespace sasktran2::successive_orders {
             const auto& layer = layers[layer_index];
             return {source_weights, layer.source_offset, layer.source_count};
         }
+        sasktran2::raytracing::GridWeightStencilView
+        optical_depth_for_layer(std::size_t layer_index) const {
+            const auto& layer = layers[layer_index];
+            if (!optical_depth_indices.empty()) {
+                return {
+                    optical_depth_indices.data() + layer.optical_depth_offset,
+                    optical_depth_weights.data() + layer.optical_depth_offset,
+                    layer.optical_depth_count};
+            }
+            if (traced_ray != nullptr) {
+                return traced_ray->optical_depth_weights(layer_index);
+            }
+            return {};
+        }
         InterpolationView<SourceInterpolationWeight> ground() const {
             return InterpolationView<SourceInterpolationWeight>(ground_weights);
         }
 
-        bool ground_is_hit() const {
-            return traced_ray != nullptr && traced_ray->ground_is_hit;
-        }
+        bool ground_is_hit() const { return ground_hit; }
     };
 
     /** Reusable temporary storage for compiling ray interpolation. */
@@ -141,6 +156,11 @@ namespace sasktran2::successive_orders {
         sasktran2::grids::SourceLocationInterpolator& location_interpolator,
         const std::vector<SourcePoint>& source_points, RayInterpolation& result,
         InterpolationScratch& scratch);
+
+    /** Moves the OD stencil buffers from a construction-time traced ray into
+     * its compact runtime interpolation record. */
+    void adopt_optical_depth_storage(sasktran2::raytracing::TracedRay& ray,
+                                     RayInterpolation& interpolation);
 
     /** Builds one sorted unique CSR row and assigns local slots to its source
      * interpolation entries. */

--- a/cpp/lib/successive_orders/ray_transport.cpp
+++ b/cpp/lib/successive_orders/ray_transport.cpp
@@ -28,11 +28,10 @@ namespace sasktran2::successive_orders {
             return result;
         }
 
-        double optical_depth(const sasktran2::raytracing::TracedRay& ray,
-                             int layer_index,
+        double optical_depth(const RayInterpolation& ray, int layer_index,
                              Eigen::Ref<const Eigen::VectorXd> extinction) {
             double result = 0.0;
-            const auto weights = ray.optical_depth_weights(layer_index);
+            const auto weights = ray.optical_depth_for_layer(layer_index);
             for (std::size_t index = 0; index < weights.size(); ++index) {
                 const auto [atmosphere_index, weight] = weights[index];
                 result += weight * extinction(atmosphere_index);
@@ -41,11 +40,10 @@ namespace sasktran2::successive_orders {
         }
 
         double
-        optical_depth_tangent(const sasktran2::raytracing::TracedRay& ray,
-                              int layer_index,
+        optical_depth_tangent(const RayInterpolation& ray, int layer_index,
                               Eigen::Ref<const Eigen::VectorXd> tangent) {
             double result = 0.0;
-            const auto weights = ray.optical_depth_weights(layer_index);
+            const auto weights = ray.optical_depth_for_layer(layer_index);
             for (std::size_t index = 0; index < weights.size(); ++index) {
                 const auto [atmosphere_index, weight] = weights[index];
                 result += weight * tangent(atmosphere_index);
@@ -82,8 +80,15 @@ namespace sasktran2::successive_orders {
         }
         for (std::size_t row = 0; row < rays.size(); ++row) {
             const auto& ray = rays[row];
-            if (ray.traced_ray == nullptr ||
-                ray.layers.size() != ray.traced_ray->layers.size()) {
+            const bool owns_optical_depth =
+                !ray.optical_depth_indices.empty() ||
+                !ray.optical_depth_weights.empty();
+            if ((ray.optical_depth_indices.size() !=
+                 ray.optical_depth_weights.size()) ||
+                (!ray.layers.empty() && !owns_optical_depth &&
+                 ray.traced_ray == nullptr) ||
+                (ray.traced_ray != nullptr &&
+                 ray.layers.size() != ray.traced_ray->layers.size())) {
                 throw std::invalid_argument(
                     "invalid successive-orders compiled ray interpolation");
             }
@@ -150,7 +155,6 @@ namespace sasktran2::successive_orders {
 
         for (int row = 0; row < num_rays(); ++row) {
             const auto& interpolation = (*m_rays)[row];
-            const auto& ray = *interpolation.traced_ray;
             double transmission_before = 1.0;
             for (int layer_index =
                      static_cast<int>(interpolation.layers.size()) - 1;
@@ -160,7 +164,7 @@ namespace sasktran2::successive_orders {
                 const auto source_weights =
                     interpolation.source_for_layer(layer_index);
                 const double layer_optical_depth =
-                    optical_depth(ray, layer_index, extinction);
+                    optical_depth(interpolation, layer_index, extinction);
                 const double layer_transmission =
                     std::exp(-layer_optical_depth);
                 const double albedo =
@@ -204,7 +208,6 @@ namespace sasktran2::successive_orders {
 
         for (int row = 0; row < num_rays(); ++row) {
             const auto& interpolation = (*m_rays)[row];
-            const auto& ray = *interpolation.traced_ray;
             double transmission_before = 1.0;
             double cumulative_tangent = 0.0;
             for (int layer_index =
@@ -215,9 +218,9 @@ namespace sasktran2::successive_orders {
                 const auto source_weights =
                     interpolation.source_for_layer(layer_index);
                 const double layer_optical_depth =
-                    optical_depth(ray, layer_index, extinction);
-                const double layer_tangent =
-                    optical_depth_tangent(ray, layer_index, native_tangent);
+                    optical_depth(interpolation, layer_index, extinction);
+                const double layer_tangent = optical_depth_tangent(
+                    interpolation, layer_index, native_tangent);
                 const double layer_transmission =
                     std::exp(-layer_optical_depth);
                 const double albedo =
@@ -273,7 +276,6 @@ namespace sasktran2::successive_orders {
 
         for (int row = 0; row < num_rays(); ++row) {
             const auto& interpolation = (*m_rays)[row];
-            const auto& ray = *interpolation.traced_ray;
             const int num_layers =
                 static_cast<int>(interpolation.layers.size());
             double transmission_before = 1.0;
@@ -284,7 +286,7 @@ namespace sasktran2::successive_orders {
                 const auto source_weights =
                     interpolation.source_for_layer(layer_index);
                 workspace.optical_depth(layer_index) =
-                    optical_depth(ray, layer_index, extinction);
+                    optical_depth(interpolation, layer_index, extinction);
                 workspace.albedo(layer_index) =
                     interpolate(atmosphere_weights, ssa, wavelength);
                 workspace.transmission_before(layer_index) =
@@ -335,7 +337,8 @@ namespace sasktran2::successive_orders {
                     cumulative_cotangent + factor_cotangent *
                                                transmission_before * albedo *
                                                layer_transmission;
-                const auto od_weights = ray.optical_depth_weights(layer_index);
+                const auto od_weights =
+                    interpolation.optical_depth_for_layer(layer_index);
                 for (std::size_t index = 0; index < od_weights.size();
                      ++index) {
                     const auto [atmosphere_index, weight] = od_weights[index];

--- a/cpp/lib/successive_orders/source.cpp
+++ b/cpp/lib/successive_orders/source.cpp
@@ -27,6 +27,11 @@ namespace sasktran2::successive_orders {
         SuccessiveOrdersSource(
             const sasktran2::raytracing::RayTracerBase& raytracer,
             const sasktran2::Geometry1D& geometry);
+#ifdef SKTRAN_RUST_SUPPORT
+        SuccessiveOrdersSource(
+            const sasktran2::raytracing::RustRayTracer2D& raytracer,
+            const sasktran2::Geometry2D& geometry);
+#endif
         ~SuccessiveOrdersSource() override;
 
         SuccessiveOrdersSource(const SuccessiveOrdersSource&) = delete;
@@ -58,7 +63,14 @@ namespace sasktran2::successive_orders {
         bool supports_linearization(
             sasktran2::LinearizationMode mode) const override;
         bool supports_geometry_dimension(int dimension) const override {
-            return dimension == 1;
+            if (dimension == 1) {
+                return true;
+            }
+#ifdef SKTRAN_RUST_SUPPORT
+            return dimension == 2;
+#else
+            return false;
+#endif
         }
         bool supports_sparse_derivative_tracking() const override {
             return true;
@@ -266,6 +278,14 @@ namespace sasktran2::successive_orders {
             const sasktran2::Geometry1D& geometry)
             : m_source_geometry(raytracer, geometry),
               m_first_order(geometry, raytracer) {}
+
+#ifdef SKTRAN_RUST_SUPPORT
+        SuccessiveOrdersImplementation(
+            const sasktran2::raytracing::RustRayTracer2D& raytracer,
+            const sasktran2::Geometry2D& geometry)
+            : m_source_geometry(raytracer, geometry),
+              m_first_order(geometry, raytracer) {}
+#endif
 
         void initialize_config(const sasktran2::Config& config) {
             invalidate_geometry();
@@ -806,6 +826,14 @@ namespace sasktran2::successive_orders {
         const sasktran2::Geometry1D& geometry)
         : m_impl(std::make_unique<Impl>(raytracer, geometry)) {}
 
+#ifdef SKTRAN_RUST_SUPPORT
+    template <int NSTOKES>
+    SuccessiveOrdersSource<NSTOKES>::SuccessiveOrdersSource(
+        const sasktran2::raytracing::RustRayTracer2D& raytracer,
+        const sasktran2::Geometry2D& geometry)
+        : m_impl(std::make_unique<Impl>(raytracer, geometry)) {}
+#endif
+
     template <int NSTOKES>
     SuccessiveOrdersSource<NSTOKES>::~SuccessiveOrdersSource() = default;
 
@@ -906,5 +934,24 @@ namespace sasktran2::successive_orders {
     make_successive_orders_source<3>(
         const sasktran2::raytracing::RayTracerBase&,
         const sasktran2::Geometry1D&);
+
+#ifdef SKTRAN_RUST_SUPPORT
+    template <int NSTOKES>
+    std::unique_ptr<SourceTermInterface<NSTOKES>> make_successive_orders_source(
+        const sasktran2::raytracing::RustRayTracer2D& raytracer,
+        const sasktran2::Geometry2D& geometry) {
+        return std::make_unique<SuccessiveOrdersSource<NSTOKES>>(raytracer,
+                                                                 geometry);
+    }
+
+    template std::unique_ptr<SourceTermInterface<1>>
+    make_successive_orders_source<1>(
+        const sasktran2::raytracing::RustRayTracer2D&,
+        const sasktran2::Geometry2D&);
+    template std::unique_ptr<SourceTermInterface<3>>
+    make_successive_orders_source<3>(
+        const sasktran2::raytracing::RustRayTracer2D&,
+        const sasktran2::Geometry2D&);
+#endif
 
 } // namespace sasktran2::successive_orders

--- a/cpp/lib/successive_orders/source.cpp
+++ b/cpp/lib/successive_orders/source.cpp
@@ -351,6 +351,9 @@ namespace sasktran2::successive_orders {
                 cotangent.setZero(output_size);
             }
             m_first_order.initialize_geometry(m_source_geometry);
+            if (m_first_order.can_release_incoming_geometry()) {
+                m_source_geometry.release_incoming_traced_rays();
+            }
             m_geometry_initialized = true;
         }
 

--- a/cpp/lib/successive_orders/source.cpp
+++ b/cpp/lib/successive_orders/source.cpp
@@ -30,7 +30,10 @@ namespace sasktran2::successive_orders {
 #ifdef SKTRAN_RUST_SUPPORT
         SuccessiveOrdersSource(
             const sasktran2::raytracing::RustRayTracer2D& raytracer,
-            const sasktran2::Geometry2D& geometry);
+            const sasktran2::Geometry2D& geometry,
+            std::shared_ptr<
+                sasktran2::solartransmission::SolarTransmissionTable2D>
+                shared_solar_table = nullptr);
 #endif
         ~SuccessiveOrdersSource() override;
 
@@ -282,9 +285,13 @@ namespace sasktran2::successive_orders {
 #ifdef SKTRAN_RUST_SUPPORT
         SuccessiveOrdersImplementation(
             const sasktran2::raytracing::RustRayTracer2D& raytracer,
-            const sasktran2::Geometry2D& geometry)
+            const sasktran2::Geometry2D& geometry,
+            std::shared_ptr<
+                sasktran2::solartransmission::SolarTransmissionTable2D>
+                shared_solar_table = nullptr)
             : m_source_geometry(raytracer, geometry),
-              m_first_order(geometry, raytracer) {}
+              m_first_order(geometry, raytracer,
+                            std::move(shared_solar_table)) {}
 #endif
 
         void initialize_config(const sasktran2::Config& config) {
@@ -830,8 +837,11 @@ namespace sasktran2::successive_orders {
     template <int NSTOKES>
     SuccessiveOrdersSource<NSTOKES>::SuccessiveOrdersSource(
         const sasktran2::raytracing::RustRayTracer2D& raytracer,
-        const sasktran2::Geometry2D& geometry)
-        : m_impl(std::make_unique<Impl>(raytracer, geometry)) {}
+        const sasktran2::Geometry2D& geometry,
+        std::shared_ptr<sasktran2::solartransmission::SolarTransmissionTable2D>
+            shared_solar_table)
+        : m_impl(std::make_unique<Impl>(raytracer, geometry,
+                                        std::move(shared_solar_table))) {}
 #endif
 
     template <int NSTOKES>
@@ -939,19 +949,25 @@ namespace sasktran2::successive_orders {
     template <int NSTOKES>
     std::unique_ptr<SourceTermInterface<NSTOKES>> make_successive_orders_source(
         const sasktran2::raytracing::RustRayTracer2D& raytracer,
-        const sasktran2::Geometry2D& geometry) {
-        return std::make_unique<SuccessiveOrdersSource<NSTOKES>>(raytracer,
-                                                                 geometry);
+        const sasktran2::Geometry2D& geometry,
+        std::shared_ptr<sasktran2::solartransmission::SolarTransmissionTable2D>
+            shared_solar_table) {
+        return std::make_unique<SuccessiveOrdersSource<NSTOKES>>(
+            raytracer, geometry, std::move(shared_solar_table));
     }
 
     template std::unique_ptr<SourceTermInterface<1>>
     make_successive_orders_source<1>(
         const sasktran2::raytracing::RustRayTracer2D&,
-        const sasktran2::Geometry2D&);
+        const sasktran2::Geometry2D&,
+        std::shared_ptr<
+            sasktran2::solartransmission::SolarTransmissionTable2D>);
     template std::unique_ptr<SourceTermInterface<3>>
     make_successive_orders_source<3>(
         const sasktran2::raytracing::RustRayTracer2D&,
-        const sasktran2::Geometry2D&);
+        const sasktran2::Geometry2D&,
+        std::shared_ptr<
+            sasktran2::solartransmission::SolarTransmissionTable2D>);
 #endif
 
 } // namespace sasktran2::successive_orders

--- a/cpp/lib/tests/geometry/test_geometry2d.cpp
+++ b/cpp/lib/tests/geometry/test_geometry2d.cpp
@@ -68,8 +68,27 @@ TEST_CASE("Geometry2D construction and metadata",
     REQUIRE(geometry.cell_shape() == std::make_pair(2, 2));
     REQUIRE(geometry.altitude_grid().grid().isApprox(grid({0.0, 10.0, 20.0})));
     REQUIRE(geometry.horizontal_angle_grid().isApprox(grid({-0.5, 0.0, 0.5})));
+    REQUIRE(geometry.refractive_index().isOnes());
     REQUIRE(geometry.altitude_grid().interpolation_method() ==
             sasktran2::grids::interpolation::linear);
+}
+
+TEST_CASE("Geometry2D validates its altitude-only refractive index",
+          "[sasktran2][geometry][geometry2d][validation][refraction]") {
+    auto geometry = geometry2d();
+    geometry.refractive_index() << 1.0003, 1.0001, 1.0;
+    REQUIRE_NOTHROW(geometry.validate());
+
+    geometry.refractive_index().resize(2);
+    REQUIRE_THROWS_AS(geometry.validate(), std::runtime_error);
+
+    geometry.refractive_index().resize(3);
+    geometry.refractive_index() << 1.0, 0.0, 1.0;
+    REQUIRE_THROWS_AS(geometry.validate(), std::runtime_error);
+
+    geometry.refractive_index() << 1.0,
+        std::numeric_limits<double>::quiet_NaN(), 1.0;
+    REQUIRE_THROWS_AS(geometry.validate(), std::runtime_error);
 }
 
 TEST_CASE("Geometry2D accepts an explicit rotated coordinate basis",

--- a/cpp/lib/tests/raytracing/test_rust_raytracer2d.cpp
+++ b/cpp/lib/tests/raytracing/test_rust_raytracer2d.cpp
@@ -121,6 +121,42 @@ TEST_CASE("RustRayTracer2D traces radial layers and exposes 2D cells",
     }
 }
 
+TEST_CASE("RustRayTracer2D optical-depth-only traces preserve OD stencils",
+          "[raytracing][rust][geometry2d]") {
+    auto geo = geometry();
+    sasktran2::raytracing::RustRayTracer2D tracer(geo);
+    const auto oblique_ray =
+        ray(15.0 * radial_direction(-0.75), Eigen::Vector3d::UnitX());
+    sasktran2::raytracing::TracedRay full;
+    sasktran2::raytracing::TracedRay optical_depth_only;
+    tracer.trace_ray(oblique_ray, full);
+    tracer.trace_ray_optical_depth(oblique_ray, optical_depth_only);
+
+    REQUIRE(optical_depth_only.ground_is_hit == full.ground_is_hit);
+    REQUIRE(optical_depth_only.layers.size() == full.layers.size());
+    for (std::size_t layer_index = 0; layer_index < full.layers.size();
+         ++layer_index) {
+        const auto expected = full.optical_depth_weights(layer_index);
+        const auto actual =
+            optical_depth_only.optical_depth_weights(layer_index);
+        REQUIRE(actual.size() == expected.size());
+        for (std::size_t weight_index = 0; weight_index < expected.size();
+             ++weight_index) {
+            REQUIRE(actual[weight_index].first == expected[weight_index].first);
+            require_close(actual[weight_index].second,
+                          expected[weight_index].second);
+            require_close(
+                optical_depth_only.entrance_weights(layer_index)[weight_index]
+                    .second,
+                0.0);
+            require_close(
+                optical_depth_only.exit_weights(layer_index)[weight_index]
+                    .second,
+                0.0);
+        }
+    }
+}
+
 TEST_CASE(
     "RustRayTracer2D preserves each Geometry2D altitude interpolation mode",
     "[raytracing][rust][geometry2d]") {

--- a/cpp/lib/tests/sourceintegrator/test_singlescatter2d.cpp
+++ b/cpp/lib/tests/sourceintegrator/test_singlescatter2d.cpp
@@ -44,6 +44,46 @@ namespace {
     }
 } // namespace
 
+TEST_CASE("Solar geometry storage uses compact indices with a wide fallback",
+          "[sourceintegrator][singlescatter]") {
+    for (const Eigen::Index columns : {Eigen::Index{10}, Eigen::Index{65537}}) {
+        sasktran2::solartransmission::SolarGeometryMatrix matrix;
+        matrix.initialize_exact(2, columns, 4);
+        REQUIRE(matrix.is_compact() == (columns == 10));
+
+        matrix.start_row(0);
+        matrix.insert_back(0, 0, 2.0);
+        matrix.insert_back(0, columns - 1, 3.0);
+        matrix.start_row(1);
+        matrix.insert_back(1, 1, -4.0);
+        matrix.finalize();
+
+        Eigen::VectorXd input = Eigen::VectorXd::Zero(columns);
+        input[0] = 5.0;
+        input[1] = 7.0;
+        input[columns - 1] = 11.0;
+        REQUIRE(matrix.row_dot(0, input) == Catch::Approx(43.0));
+
+        Eigen::VectorXd product(2);
+        matrix.multiply(input, product);
+        REQUIRE(product[0] == Catch::Approx(43.0));
+        REQUIRE(product[1] == Catch::Approx(-28.0));
+
+        Eigen::VectorXd accumulated = Eigen::VectorXd::Zero(columns);
+        matrix.accumulate_row(0, 0.5, accumulated);
+        REQUIRE(accumulated[0] == Catch::Approx(1.0));
+        REQUIRE(accumulated[columns - 1] == Catch::Approx(1.5));
+
+        int entries = 0;
+        for (sasktran2::solartransmission::SolarGeometryMatrix::InnerIterator
+                 entry(matrix, 0);
+             entry; ++entry) {
+            ++entries;
+        }
+        REQUIRE(entries == 2);
+    }
+}
+
 #ifdef SKTRAN_RUST_SUPPORT
 TEST_CASE("Exact solar transmission matrix matches direct Geometry2D rays",
           "[sourceintegrator][singlescatter][geometry2d]") {
@@ -58,7 +98,7 @@ TEST_CASE("Exact solar transmission matrix matches direct Geometry2D rays",
 
     sasktran2::solartransmission::SolarTransmissionExact transmission(
         geometry, raytracer);
-    Eigen::SparseMatrix<double, Eigen::RowMajor> matrix;
+    sasktran2::solartransmission::SolarGeometryMatrix matrix;
     std::vector<bool> ground_hit;
     transmission.generate_geometry_matrix({line_of_sight}, matrix, ground_hit);
 
@@ -79,8 +119,8 @@ TEST_CASE("Exact solar transmission matrix matches direct Geometry2D rays",
             REQUIRE(ground_hit[row] == traced_solar_ray.ground_is_hit);
 
             Eigen::VectorXd actual = Eigen::VectorXd::Zero(geometry.size());
-            for (Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator
-                     entry(matrix, row);
+            for (sasktran2::solartransmission::SolarGeometryMatrix::
+                     InnerIterator entry(matrix, row);
                  entry; ++entry) {
                 actual[entry.index()] = entry.value();
             }
@@ -120,14 +160,14 @@ TEST_CASE("Exact Geometry2D solar shadow is stable at a grazing surface ray",
 
     sasktran2::solartransmission::SolarTransmissionExact transmission(
         geometry, raytracer);
-    Eigen::SparseMatrix<double, Eigen::RowMajor> matrix;
+    sasktran2::solartransmission::SolarGeometryMatrix matrix;
     std::vector<bool> ground_hit;
     transmission.generate_geometry_matrix({line_of_sight}, matrix, ground_hit);
 
     REQUIRE(ground_hit.size() == 2);
     REQUIRE(ground_hit[0]);
     REQUIRE(ground_hit[1]);
-    REQUIRE(matrix.nonZeros() == 0);
+    REQUIRE(matrix.non_zeros() == 0);
 }
 
 TEST_CASE("Geometry2D exact single scatter is invariant across thread models",

--- a/cpp/lib/tests/sourceintegrator/test_singlescatter2d.cpp
+++ b/cpp/lib/tests/sourceintegrator/test_singlescatter2d.cpp
@@ -142,6 +142,173 @@ TEST_CASE("Exact solar transmission matrix matches direct Geometry2D rays",
     REQUIRE(row == matrix.rows());
 }
 
+TEST_CASE("Geometry2D characteristic solar table follows exact endpoint OD",
+          "[sourceintegrator][singlescatter][geometry2d][solartable]") {
+    const auto geometry = geometry2d();
+    sasktran2::raytracing::RustRayTracer2D raytracer(geometry);
+    sasktran2::raytracing::TracedRay line_of_sight;
+    line_of_sight.layers.resize(1);
+    const double query_radius = earth_radius + 20.0;
+    const double impact_parameter = earth_radius + 10.0;
+    const double query_cos_sza =
+        -std::sqrt(1.0 - impact_parameter * impact_parameter /
+                             (query_radius * query_radius));
+    line_of_sight.layers[0].entrance.position =
+        geometry.coordinates().solar_coordinate_vector(query_cos_sza, 0.0,
+                                                       20.0);
+    line_of_sight.layers[0].exit = line_of_sight.layers[0].entrance;
+
+    sasktran2::Config config;
+    sasktran2::solartransmission::SolarTransmissionTable2D table(geometry,
+                                                                 raytracer);
+    table.initialize_config(config);
+    table.initialize_geometry({line_of_sight});
+    sasktran2::solartransmission::SolarTableInterpolation interpolation;
+    std::vector<bool> table_ground_hit;
+    table.generate_interpolation({line_of_sight}, interpolation,
+                                 table_ground_hit);
+
+    Eigen::VectorXd extinction(geometry.size());
+    for (int index = 0; index < geometry.size(); ++index) {
+        extinction[index] = 0.01 * (1.0 + 0.07 * index);
+    }
+    Eigen::VectorXd table_nodes(table.table_size());
+    table.apply(extinction, table_nodes);
+    Eigen::VectorXd table_od(interpolation.rows());
+    interpolation.apply(table_nodes, table_od);
+
+    sasktran2::solartransmission::SolarTransmissionExact exact(geometry,
+                                                               raytracer);
+    sasktran2::solartransmission::SolarGeometryMatrix exact_matrix;
+    std::vector<bool> exact_ground_hit;
+    exact.generate_geometry_matrix({line_of_sight}, exact_matrix,
+                                   exact_ground_hit);
+    Eigen::VectorXd exact_od(exact_matrix.rows());
+    exact_matrix.multiply(extinction, exact_od);
+
+    REQUIRE(table_ground_hit == exact_ground_hit);
+    for (int row = 0; row < exact_od.size(); ++row) {
+        if (!exact_ground_hit[row]) {
+            INFO("row " << row << ", exact " << exact_od[row] << ", table "
+                        << table_od[row]);
+            REQUIRE(table_od[row] ==
+                    Catch::Approx(exact_od[row]).epsilon(1e-11));
+        }
+    }
+
+    const Eigen::VectorXd endpoint_cotangent =
+        Eigen::VectorXd::LinSpaced(interpolation.rows(), -0.7, 1.1);
+    Eigen::VectorXd table_cotangent(table.table_size());
+    interpolation.apply_transpose(endpoint_cotangent, table_cotangent);
+    REQUIRE(endpoint_cotangent.dot(table_od) ==
+            Catch::Approx(table_cotangent.dot(table_nodes)).epsilon(1e-12));
+
+    Eigen::VectorXd extinction_cotangent =
+        Eigen::VectorXd::Zero(geometry.size());
+    table.accumulate_transpose(table_cotangent, extinction_cotangent, 1.0);
+    REQUIRE(table_cotangent.dot(table_nodes) ==
+            Catch::Approx(extinction_cotangent.dot(extinction)).epsilon(1e-12));
+}
+
+TEST_CASE("Geometry2D characteristic solar table follows refracted endpoint "
+          "OD",
+          "[sourceintegrator][singlescatter][geometry2d][solartable]") {
+    auto geometry = geometry2d();
+    geometry.refractive_index() = vector({1.0003, 1.0001, 1.0});
+    geometry.validate();
+    sasktran2::raytracing::RustRayTracer2D raytracer(geometry);
+
+    const double query_radius = earth_radius + 20.0;
+    const double impact_parameter =
+        (earth_radius + 10.0) * geometry.refractive_index()[1];
+    const auto& sun = geometry.coordinates().sun_unit();
+    Eigen::Vector3d impact_direction =
+        geometry.coordinates().reference_z() -
+        geometry.coordinates().reference_z().dot(sun) * sun;
+    impact_direction.normalize();
+    const double observer_radius = query_radius + 1.0;
+    sasktran2::viewinggeometry::ViewingRay incoming;
+    incoming.observer.position =
+        impact_parameter * impact_direction +
+        std::sqrt(observer_radius * observer_radius -
+                  impact_parameter * impact_parameter) *
+            sun;
+    incoming.look_away = -sun;
+    sasktran2::raytracing::TracedRay characteristic;
+    raytracer.trace_ray(incoming, geometry.refractive_index(), characteristic);
+    REQUIRE(!characteristic.ground_is_hit);
+
+    sasktran2::Location far_top;
+    double far_top_cos_sza = 1.0;
+    for (const auto& layer : characteristic.layers) {
+        const double radius_error =
+            std::abs(layer.exit.radius() - query_radius);
+        const double cos_sza = layer.exit.position.normalized().dot(sun);
+        if (radius_error < 1.0e-8 && cos_sza < far_top_cos_sza) {
+            far_top = layer.exit;
+            far_top_cos_sza = cos_sza;
+        }
+    }
+    REQUIRE(far_top_cos_sza < 0.0);
+
+    sasktran2::raytracing::TracedRay line_of_sight;
+    line_of_sight.layers.resize(1);
+    line_of_sight.layers[0].entrance = far_top;
+    line_of_sight.layers[0].exit = line_of_sight.layers[0].entrance;
+
+    sasktran2::Config config;
+    config.set_solar_refraction(true);
+    sasktran2::solartransmission::SolarTransmissionTable2D table(geometry,
+                                                                 raytracer);
+    table.initialize_config(config);
+    table.initialize_geometry({line_of_sight});
+    sasktran2::solartransmission::SolarTableInterpolation interpolation;
+    std::vector<bool> table_ground_hit;
+    std::vector<Eigen::Vector3d> solar_propagation_directions;
+    table.generate_interpolation({line_of_sight}, interpolation,
+                                 table_ground_hit,
+                                 &solar_propagation_directions);
+
+    Eigen::VectorXd extinction(geometry.size());
+    for (int index = 0; index < geometry.size(); ++index) {
+        extinction[index] = 0.01 * (1.0 + 0.07 * index);
+    }
+    Eigen::VectorXd table_nodes(table.table_size());
+    table.apply(extinction, table_nodes);
+    Eigen::VectorXd table_od(interpolation.rows());
+    interpolation.apply(table_nodes, table_od);
+
+    const double exact_od =
+        direct_path_weights(characteristic, geometry).dot(extinction);
+
+    CAPTURE(far_top_cos_sza, table_ground_hit);
+    REQUIRE(std::none_of(table_ground_hit.begin(), table_ground_hit.end(),
+                         [](bool value) { return value; }));
+    for (Eigen::Index row = 0; row < table_od.size(); ++row) {
+        REQUIRE(table_od[row] == Catch::Approx(exact_od).epsilon(1e-11));
+    }
+
+    REQUIRE(solar_propagation_directions.size() == 2);
+    for (const auto& direction : solar_propagation_directions) {
+        REQUIRE(direction.norm() == Catch::Approx(1.0).epsilon(1e-13));
+        REQUIRE(direction.dot(-sun) < 0.999999999);
+    }
+
+    sasktran2::solartransmission::SolarTransmissionExact exact(geometry,
+                                                               raytracer);
+    sasktran2::solartransmission::SolarGeometryMatrix exact_matrix;
+    auto exact_ground_hit = table_ground_hit;
+    exact.generate_refracted_geometry_matrix({line_of_sight},
+                                             solar_propagation_directions,
+                                             exact_matrix, exact_ground_hit);
+    Eigen::VectorXd retraced_od(exact_matrix.rows());
+    exact_matrix.multiply(extinction, retraced_od);
+    REQUIRE(exact_ground_hit == table_ground_hit);
+    for (Eigen::Index row = 0; row < retraced_od.size(); ++row) {
+        REQUIRE(retraced_od[row] == Catch::Approx(exact_od).epsilon(2e-10));
+    }
+}
+
 TEST_CASE("Exact Geometry2D solar shadow is stable at a grazing surface ray",
           "[sourceintegrator][singlescatter][geometry2d]") {
     constexpr double target_radius = 20.0;

--- a/cpp/lib/tests/successive_orders/test_geometry.cpp
+++ b/cpp/lib/tests/successive_orders/test_geometry.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cmath>
 #include <limits>
+#include <numeric>
 #include <stdexcept>
 
 namespace {
@@ -24,6 +25,26 @@ namespace {
         raytracer.trace_ray(ray, result.traced_rays.front());
         return result;
     }
+
+#ifdef SKTRAN_RUST_SUPPORT
+    Eigen::VectorXd horizontal_angle_grid() {
+        return (Eigen::Vector3d() << -0.4, 0.0, 0.4).finished();
+    }
+
+    sasktran2::viewinggeometry::InternalViewingGeometry
+    make_los_geometry(const sasktran2::Geometry2D& geometry,
+                      const sasktran2::raytracing::RustRayTracer2D& raytracer) {
+        sasktran2::viewinggeometry::InternalViewingGeometry result;
+        result.traced_rays.resize(1);
+        sasktran2::viewinggeometry::ViewingRay ray;
+        ray.observer.position =
+            (geometry.coordinates().earth_radius() + 4000.0) *
+            geometry.coordinates().unit_vector_from_angles(0.0, 0.0);
+        ray.look_away = -ray.observer.position.normalized();
+        raytracer.trace_ray(ray, result.traced_rays.front());
+        return result;
+    }
+#endif
 
     class ThrowingRayTracer final
         : public sasktran2::raytracing::RayTracerBase {
@@ -187,6 +208,92 @@ TEST_CASE("Successive-orders 1D geometry compiles midpoint source and LOS "
                               source_geometry.los_transport_column_indices(),
                               source_geometry.total_num_outgoing());
 }
+
+#ifdef SKTRAN_RUST_SUPPORT
+TEST_CASE("Successive-orders 2D geometry uses an independent horizontal "
+          "source grid",
+          "[successive_orders][geometry][geometry2d]") {
+    sasktran2::Geometry2D geometry(0.6, 0.0, 6372000.0, altitude_grid(),
+                                   horizontal_angle_grid(),
+                                   sasktran2::grids::interpolation::linear);
+    sasktran2::raytracing::RustRayTracer2D raytracer(geometry);
+    const auto los = make_los_geometry(geometry, raytracer);
+
+    sasktran2::successive_orders::SourceGeometrySettings settings;
+    settings.num_incoming = 6;
+    settings.num_outgoing = 6;
+    settings.num_sza = 5;
+    settings.num_threads = 1;
+    sasktran2::successive_orders::SourceGeometry1D source_geometry(raytracer,
+                                                                   geometry);
+    source_geometry.initialize(los, settings);
+
+    REQUIRE(source_geometry.source_altitudes_m() ==
+            std::vector<double>{500.0, 2000.0});
+    REQUIRE(source_geometry.source_horizontal_angles_rad() ==
+            std::vector<double>{-0.4, -0.2, 0.0, 0.2, 0.4});
+    REQUIRE(source_geometry.num_interior_points() == 10);
+    REQUIRE(source_geometry.num_ground_points() == 5);
+    REQUIRE(source_geometry.num_points() == 15);
+
+    for (int horizontal = 0; horizontal < 5; ++horizontal) {
+        for (int altitude = 0; altitude < 2; ++altitude) {
+            const int point_index = altitude + 2 * horizontal;
+            const auto& point = source_geometry.source_point(point_index);
+            REQUIRE(
+                geometry.altitude_at(point.location()) ==
+                Catch::Approx(source_geometry.source_altitudes_m()[altitude])
+                    .margin(1.0e-8));
+            REQUIRE(
+                geometry.horizontal_angle_at(point.location()) ==
+                Catch::Approx(
+                    source_geometry.source_horizontal_angles_rad()[horizontal])
+                    .margin(1.0e-13));
+
+            std::vector<double> atmosphere_weights(geometry.size(), 0.0);
+            for (const auto& weight : point.atmosphere_weights()) {
+                atmosphere_weights[weight.index] += weight.weight;
+            }
+            REQUIRE(std::accumulate(atmosphere_weights.begin(),
+                                    atmosphere_weights.end(),
+                                    0.0) == Catch::Approx(1.0).margin(1.0e-13));
+        }
+    }
+
+    // The source column at -0.2 radians lies halfway between atmosphere
+    // columns. Combined with the midpoint altitude, it samples four native
+    // atmosphere locations with equal weight.
+    std::vector<double> midpoint_weights(geometry.size(), 0.0);
+    for (const auto& weight :
+         source_geometry.source_point(2).atmosphere_weights()) {
+        midpoint_weights[weight.index] += weight.weight;
+    }
+    REQUIRE(midpoint_weights[geometry.location_index(0, 0)] ==
+            Catch::Approx(0.25).margin(1.0e-13));
+    REQUIRE(midpoint_weights[geometry.location_index(1, 0)] ==
+            Catch::Approx(0.25).margin(1.0e-13));
+    REQUIRE(midpoint_weights[geometry.location_index(0, 1)] ==
+            Catch::Approx(0.25).margin(1.0e-13));
+    REQUIRE(midpoint_weights[geometry.location_index(1, 1)] ==
+            Catch::Approx(0.25).margin(1.0e-13));
+
+    require_compiled_topology(source_geometry.incoming_interpolation(),
+                              source_geometry.transport_row_offsets(),
+                              source_geometry.transport_column_indices(),
+                              source_geometry.total_num_outgoing());
+    require_compiled_topology(source_geometry.los_interpolation(),
+                              source_geometry.los_transport_row_offsets(),
+                              source_geometry.los_transport_column_indices(),
+                              source_geometry.total_num_outgoing());
+
+    settings.include_refraction = true;
+    sasktran2::successive_orders::SourceGeometry1D refracted(raytracer,
+                                                             geometry);
+    REQUIRE_THROWS_WITH(
+        refracted.initialize(los, settings),
+        "Geometry2D successive orders does not support diffuse-ray refraction");
+}
+#endif
 
 TEST_CASE("Successive-orders default source grid preserves nonuniform midpoint "
           "interpolation",

--- a/cpp/lib/tests/successive_orders/test_geometry.cpp
+++ b/cpp/lib/tests/successive_orders/test_geometry.cpp
@@ -98,8 +98,8 @@ namespace {
         REQUIRE(row_offsets.back() == static_cast<int>(column_indices.size()));
         for (std::size_t row = 0; row < rays.size(); ++row) {
             const auto& ray = rays[row];
-            REQUIRE(ray.traced_ray != nullptr);
-            REQUIRE(ray.layers.size() == ray.traced_ray->layers.size());
+            REQUIRE((ray.traced_ray != nullptr || ray.layers.empty() ||
+                     !ray.optical_depth_weights.empty()));
             REQUIRE(ray.transport_value_offset ==
                     static_cast<std::size_t>(row_offsets[row]));
             REQUIRE(ray.transport_row_nnz ==
@@ -111,6 +111,12 @@ namespace {
             REQUIRE(std::adjacent_find(begin, end) == end);
             for (std::size_t layer = 0; layer < ray.layers.size(); ++layer) {
                 require_sorted(ray.atmosphere_for_layer(layer));
+                const auto optical_depth = ray.optical_depth_for_layer(layer);
+                for (std::size_t index = 1; index < optical_depth.size();
+                     ++index) {
+                    REQUIRE(optical_depth[index - 1].first <=
+                            optical_depth[index].first);
+                }
                 const auto source = ray.source_for_layer(layer);
                 for (const auto& weight : source) {
                     REQUIRE(weight.source_index >= 0);
@@ -193,8 +199,10 @@ TEST_CASE("Successive-orders 1D geometry compiles midpoint source and LOS "
             static_cast<std::size_t>(source_geometry.total_num_incoming()));
     for (std::size_t ray = 0; ray < source_geometry.incoming_rays().size();
          ++ray) {
-        REQUIRE(source_geometry.incoming_interpolation()[ray].traced_ray ==
-                &source_geometry.incoming_rays()[ray]);
+        REQUIRE(source_geometry.incoming_interpolation()[ray].layers.size() ==
+                source_geometry.incoming_rays()[ray].layers.size());
+        REQUIRE(source_geometry.incoming_interpolation()[ray].ground_is_hit() ==
+                source_geometry.incoming_rays()[ray].ground_is_hit);
     }
     for (const auto& point : source_geometry.source_points()) {
         require_sorted(point.atmosphere_weights());

--- a/cpp/lib/tests/successive_orders/test_geometry.cpp
+++ b/cpp/lib/tests/successive_orders/test_geometry.cpp
@@ -264,8 +264,16 @@ TEST_CASE("Successive-orders 2D geometry uses an independent horizontal "
 
     REQUIRE(source_geometry.source_altitudes_m() ==
             std::vector<double>{500.0, 2000.0});
-    REQUIRE(source_geometry.source_horizontal_angles_rad() ==
-            std::vector<double>{-0.4, -0.2, 0.0, 0.2, 0.4});
+    const std::array<double, 5> expected_horizontal_angles = {-0.4, -0.2, 0.0,
+                                                              0.2, 0.4};
+    REQUIRE(source_geometry.source_horizontal_angles_rad().size() ==
+            expected_horizontal_angles.size());
+    for (std::size_t index = 0; index < expected_horizontal_angles.size();
+         ++index) {
+        REQUIRE(
+            source_geometry.source_horizontal_angles_rad()[index] ==
+            Catch::Approx(expected_horizontal_angles[index]).margin(1.0e-13));
+    }
     REQUIRE(source_geometry.num_interior_points() == 10);
     REQUIRE(source_geometry.num_ground_points() == 5);
     REQUIRE(source_geometry.num_points() == 15);

--- a/cpp/lib/tests/successive_orders/test_geometry.cpp
+++ b/cpp/lib/tests/successive_orders/test_geometry.cpp
@@ -193,6 +193,31 @@ TEST_CASE("Successive-orders 1D geometry compiles midpoint source and LOS "
     REQUIRE(source_geometry.num_interior_points() == 2);
     REQUIRE(source_geometry.num_ground_points() == 1);
     REQUIRE(source_geometry.num_points() == 3);
+
+    const auto& ground_point =
+        source_geometry.source_point(source_geometry.num_interior_points());
+    const std::array<Eigen::Vector3d, 3> ground_directions{
+        Eigen::Vector3d::UnitZ(), Eigen::Vector3d::UnitX(),
+        -Eigen::Vector3d::UnitZ()};
+    for (const auto& direction : ground_directions) {
+        std::vector<std::pair<int, double>> weights;
+        int count = 0;
+        ground_point.outgoing_sphere().interpolate(direction, weights, count);
+        REQUIRE(count == 3);
+        REQUIRE(weights.size() == 3);
+        double total_weight = 0.0;
+        for (const auto& [index, weight] : weights) {
+            REQUIRE(index >= 0);
+            REQUIRE(index < ground_point.outgoing_sphere().num_points());
+            REQUIRE(std::isfinite(weight));
+            REQUIRE(weight >= 0.0);
+            REQUIRE(ground_point.outgoing_sphere().get_quad_position(index).dot(
+                        ground_point.location().position.normalized()) > 0.0);
+            total_weight += weight;
+        }
+        REQUIRE(total_weight == Catch::Approx(1.0).margin(1.0e-13));
+    }
+
     REQUIRE(source_geometry.incoming_point_offsets().size() == 4);
     REQUIRE(source_geometry.outgoing_point_offsets().size() == 4);
     REQUIRE(source_geometry.incoming_rays().size() ==

--- a/cpp/lib/tests/successive_orders/test_geometry.cpp
+++ b/cpp/lib/tests/successive_orders/test_geometry.cpp
@@ -1,5 +1,6 @@
 #include "../../successive_orders/geometry.h"
 
+#include <sasktran2/solartransmission.h>
 #include <sasktran2/test_helper.h>
 
 #include <algorithm>
@@ -292,6 +293,95 @@ TEST_CASE("Successive-orders 2D geometry uses an independent horizontal "
     REQUIRE_THROWS_WITH(
         refracted.initialize(los, settings),
         "Geometry2D successive orders does not support diffuse-ray refraction");
+}
+
+TEST_CASE("Successive-orders 2D solar table resolves source-ray endpoint OD",
+          "[successive_orders][geometry][geometry2d][solartable]") {
+    constexpr int num_altitudes = 16;
+    constexpr int num_horizontal = 8;
+    Eigen::VectorXd altitudes =
+        Eigen::VectorXd::LinSpaced(num_altitudes, 0.0, 80000.0);
+    Eigen::VectorXd horizontal =
+        Eigen::VectorXd::LinSpaced(num_horizontal, -0.4, 0.4);
+    sasktran2::Geometry2D geometry(0.6, 0.0, 6372000.0, std::move(altitudes),
+                                   std::move(horizontal),
+                                   sasktran2::grids::interpolation::linear);
+    sasktran2::raytracing::RustRayTracer2D raytracer(geometry);
+    const auto los = make_los_geometry(geometry, raytracer);
+
+    sasktran2::successive_orders::SourceGeometrySettings settings;
+    settings.num_incoming = 14;
+    settings.num_outgoing = 6;
+    settings.num_sza = 3;
+    settings.num_threads = 1;
+    settings.altitude_grid_m.resize(7);
+    for (int index = 0; index < 7; ++index) {
+        settings.altitude_grid_m[index] = (index + 0.5) * 80000.0 / 7.0;
+    }
+    sasktran2::successive_orders::SourceGeometry1D source_geometry(raytracer,
+                                                                   geometry);
+    source_geometry.initialize(los, settings);
+    const auto& rays = source_geometry.incoming_rays();
+
+    sasktran2::Config config;
+    sasktran2::solartransmission::SolarTransmissionTable2D table(geometry,
+                                                                 raytracer);
+    table.initialize_config(config);
+    table.initialize_geometry(rays);
+    sasktran2::solartransmission::SolarTableInterpolation interpolation;
+    std::vector<bool> table_ground_hit;
+    table.generate_interpolation(rays, interpolation, table_ground_hit);
+
+    sasktran2::solartransmission::SolarTransmissionExact exact(geometry,
+                                                               raytracer);
+    sasktran2::solartransmission::SolarGeometryMatrix exact_matrix;
+    std::vector<bool> exact_ground_hit;
+    exact.generate_geometry_matrix(rays, exact_matrix, exact_ground_hit);
+    REQUIRE(table_ground_hit == exact_ground_hit);
+
+    Eigen::VectorXd extinction(geometry.size());
+    for (int horizontal_index = 0; horizontal_index < num_horizontal;
+         ++horizontal_index) {
+        for (int altitude_index = 0; altitude_index < num_altitudes;
+             ++altitude_index) {
+            const double altitude =
+                geometry.altitude_grid().grid()[altitude_index];
+            const double angle =
+                geometry.horizontal_angle_grid()[horizontal_index];
+            extinction[geometry.location_index(altitude_index,
+                                               horizontal_index)] =
+                1.5e-5 * std::exp(-altitude / 18000.0) *
+                (1.0 + 0.2 * std::sin(2.0 * EIGEN_PI * angle / 0.8));
+        }
+    }
+    Eigen::VectorXd table_nodes(table.table_size());
+    Eigen::VectorXd table_od(interpolation.rows());
+    Eigen::VectorXd exact_od(exact_matrix.rows());
+    table.apply(extinction, table_nodes);
+    interpolation.apply(table_nodes, table_od);
+    exact_matrix.multiply(extinction, exact_od);
+
+    double maximum_absolute = 0.0;
+    double maximum_relative = 0.0;
+    double mean_absolute = 0.0;
+    int active = 0;
+    for (Eigen::Index row = 0; row < exact_od.size(); ++row) {
+        if (exact_ground_hit[row]) {
+            continue;
+        }
+        const double absolute = std::abs(table_od[row] - exact_od[row]);
+        maximum_absolute = std::max(maximum_absolute, absolute);
+        if (std::abs(exact_od[row]) > 1.0e-10) {
+            maximum_relative =
+                std::max(maximum_relative, absolute / std::abs(exact_od[row]));
+        }
+        mean_absolute += absolute;
+        ++active;
+    }
+    mean_absolute /= active;
+    CAPTURE(active, maximum_absolute, maximum_relative, mean_absolute);
+    REQUIRE(maximum_relative < 0.06);
+    REQUIRE(mean_absolute < 0.006);
 }
 #endif
 

--- a/cpp/lib/tests/successive_orders/test_ray_transport.cpp
+++ b/cpp/lib/tests/successive_orders/test_ray_transport.cpp
@@ -2,7 +2,6 @@
 
 #include <sasktran2/test_helper.h>
 
-#include <array>
 #include <cmath>
 #include <vector>
 
@@ -22,30 +21,24 @@ namespace {
             atmosphere.storage().ssa.col(0) << 0.8, 0.6, 0.4;
             atmosphere.storage().ssa.col(1) << 0.35, 0.55, 0.75;
 
-            traced_rays.resize(2);
-            traced_rays[0].layers.resize(2);
-            traced_rays[0].ground_is_hit = true;
-            set_layer_weights(traced_rays[0], 0, {0, 1}, {0.7, 0.2});
-            set_layer_weights(traced_rays[0], 1, {1, 2}, {0.4, 1.1});
-
-            traced_rays[1].layers.resize(1);
-            set_layer_weights(traced_rays[1], 0, {0, 2}, {0.3, 0.5});
-
             interpolation.resize(2);
-            interpolation[0].traced_ray = &traced_rays[0];
-            interpolation[0].layers = {{0, 2, 0, 2}, {2, 2, 2, 2}};
+            interpolation[0].layers = {{0, 2, 0, 2, 0, 2}, {2, 2, 2, 2, 2, 2}};
             interpolation[0].atmosphere_weights = {
                 {0, 0.25}, {1, 0.75}, {1, 0.4}, {2, 0.6}};
             interpolation[0].source_weights = {
                 {0, 0.25, 0}, {2, 0.75, 2}, {1, 0.6, 1}, {2, 0.4, 2}};
+            interpolation[0].optical_depth_indices = {0, 1, 1, 2};
+            interpolation[0].optical_depth_weights = {0.7, 0.2, 0.4, 1.1};
             interpolation[0].ground_weights = {{0, 0.2, 0}, {3, 0.8, 3}};
+            interpolation[0].ground_hit = true;
             interpolation[0].transport_value_offset = 0;
             interpolation[0].transport_row_nnz = 4;
 
-            interpolation[1].traced_ray = &traced_rays[1];
-            interpolation[1].layers = {{0, 2, 0, 2}};
+            interpolation[1].layers = {{0, 2, 0, 2, 0, 2}};
             interpolation[1].atmosphere_weights = {{0, 0.5}, {2, 0.5}};
             interpolation[1].source_weights = {{1, 0.7, 0}, {3, 0.3, 1}};
+            interpolation[1].optical_depth_indices = {0, 2};
+            interpolation[1].optical_depth_weights = {0.3, 0.5};
             interpolation[1].transport_value_offset = 4;
             interpolation[1].transport_row_nnz = 2;
         }
@@ -67,23 +60,11 @@ namespace {
                             atmosphere.ssa_deriv_start_index(), num_locations);
         }
 
-        std::vector<sasktran2::raytracing::TracedRay> traced_rays;
         std::vector<sasktran2::successive_orders::RayInterpolation>
             interpolation;
         const std::vector<int> row_offsets{0, 4, 6};
         const std::vector<int> column_indices{0, 1, 2, 3, 1, 3};
         sasktran2::atmosphere::Atmosphere<1> atmosphere;
-
-      private:
-        static void
-        set_layer_weights(sasktran2::raytracing::TracedRay& ray,
-                          std::size_t layer, const std::array<int, 2>& indices,
-                          const std::array<double, 2>& optical_depth_weights) {
-            const std::array<double, 2> entrance{0.5, 0.5};
-            const std::array<double, 2> exit{0.5, 0.5};
-            ray.set_layer_weights(layer, indices, entrance, exit,
-                                  optical_depth_weights);
-        }
     };
 
     Eigen::VectorXd expected_values_at_wavelength_one() {

--- a/cpp/lib/tests/unitsphere/test_lebedev.cpp
+++ b/cpp/lib/tests/unitsphere/test_lebedev.cpp
@@ -21,35 +21,6 @@ TEST_CASE("Lebedev Initialization", "[sasktran2][unitsphere]") {
         */
 }
 
-TEST_CASE("Ground sphere interpolation always uses upward neighbors",
-          "[sasktran2][unitsphere][ground]") {
-    sasktran2::math::UnitSphereGround ground(
-        std::make_unique<sasktran2::math::LebedevSphere>(26),
-        Eigen::Vector3d::UnitZ());
-
-    const std::array<Eigen::Vector3d, 3> directions{Eigen::Vector3d::UnitZ(),
-                                                    Eigen::Vector3d::UnitX(),
-                                                    -Eigen::Vector3d::UnitZ()};
-    for (const auto& direction : directions) {
-        std::vector<std::pair<int, double>> weights;
-        int count = 0;
-        ground.interpolate(direction, weights, count);
-
-        REQUIRE(count == 3);
-        REQUIRE(weights.size() == 3);
-        double total_weight = 0.0;
-        for (const auto& [index, weight] : weights) {
-            REQUIRE(index >= 0);
-            REQUIRE(index < ground.num_points());
-            REQUIRE(std::isfinite(weight));
-            REQUIRE(weight >= 0.0);
-            REQUIRE(ground.get_quad_position(index).z() > 0.0);
-            total_weight += weight;
-        }
-        REQUIRE(total_weight == Catch::Approx(1.0).margin(1.0e-13));
-    }
-}
-
 /*
 TEST_CASE("Spherical Harmonics Integration",
 "[sasktran2][unitsphere][spherical_harmonics]") { const int max_order = 8; const

--- a/cpp/lib/tests/unitsphere/test_lebedev.cpp
+++ b/cpp/lib/tests/unitsphere/test_lebedev.cpp
@@ -21,6 +21,35 @@ TEST_CASE("Lebedev Initialization", "[sasktran2][unitsphere]") {
         */
 }
 
+TEST_CASE("Ground sphere interpolation always uses upward neighbors",
+          "[sasktran2][unitsphere][ground]") {
+    sasktran2::math::UnitSphereGround ground(
+        std::make_unique<sasktran2::math::LebedevSphere>(26),
+        Eigen::Vector3d::UnitZ());
+
+    const std::array<Eigen::Vector3d, 3> directions{Eigen::Vector3d::UnitZ(),
+                                                    Eigen::Vector3d::UnitX(),
+                                                    -Eigen::Vector3d::UnitZ()};
+    for (const auto& direction : directions) {
+        std::vector<std::pair<int, double>> weights;
+        int count = 0;
+        ground.interpolate(direction, weights, count);
+
+        REQUIRE(count == 3);
+        REQUIRE(weights.size() == 3);
+        double total_weight = 0.0;
+        for (const auto& [index, weight] : weights) {
+            REQUIRE(index >= 0);
+            REQUIRE(index < ground.num_points());
+            REQUIRE(std::isfinite(weight));
+            REQUIRE(weight >= 0.0);
+            REQUIRE(ground.get_quad_position(index).z() > 0.0);
+            total_weight += weight;
+        }
+        REQUIRE(total_weight == Catch::Approx(1.0).margin(1.0e-13));
+    }
+}
+
 /*
 TEST_CASE("Spherical Harmonics Integration",
 "[sasktran2][unitsphere][spherical_harmonics]") { const int max_order = 8; const

--- a/cpp/lib/unitsphere/unitsphere_ground.cpp
+++ b/cpp/lib/unitsphere/unitsphere_ground.cpp
@@ -1,5 +1,9 @@
 #include <sasktran2/math/unitsphere.h>
 
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
 namespace sasktran2::math {
     UnitSphereGround::UnitSphereGround(
         std::unique_ptr<const UnitSphere>&& sphere,
@@ -8,8 +12,6 @@ namespace sasktran2::math {
         Eigen::Vector3d quad;
 
         m_contributing_map.reserve(m_full_sphere->num_points() / 2);
-        m_reverse_contributing_map.resize(m_full_sphere->num_points());
-        m_is_full_sphere_looking_up.resize(m_full_sphere->num_points());
 
         m_quadrature_normalization = 0.0;
 
@@ -19,17 +21,10 @@ namespace sasktran2::math {
 
             if (quad.dot(location) > 0) {
                 // Looking up
-                m_is_full_sphere_looking_up[i] = true;
-
-                m_reverse_contributing_map[i] = m_contributing_map.size();
                 m_contributing_map.push_back(i);
 
                 m_quadrature_normalization +=
                     m_full_sphere->quadrature_weight(i);
-            } else {
-                m_is_full_sphere_looking_up[i] = false;
-                m_reverse_contributing_map[i] =
-                    -1; // Value should never be used
             }
         }
     }
@@ -51,36 +46,43 @@ namespace sasktran2::math {
         const Eigen::Vector3d& direction,
         std::vector<std::pair<int, double>>& index_weights,
         int& num_interp) const {
-        // Start by interpolating over the full sphere
-        m_full_sphere->interpolate(direction, index_weights, num_interp);
+        num_interp = std::min(3, num_points());
+        index_weights.assign(static_cast<std::size_t>(num_interp),
+                             {-1, std::numeric_limits<double>::infinity()});
 
-        // Now go through every interpolation index and see if they are outside
-        // the boundaries
-        double total_weight = 0;
-        for (int i = 0; i < index_weights.size(); ++i) {
-            if (!m_is_full_sphere_looking_up[index_weights[i].first]) {
-                // Have to remove this index from the interpolator
-                // Rather than removing it we just set the index to 0 and weight
-                // to 0
-                index_weights[i].first = 0;
-                index_weights[i].second = 0;
-            } else {
-                // remap the index
-                index_weights[i].first =
-                    m_reverse_contributing_map[index_weights[i].first];
+        // Select neighbors directly from the upward hemisphere. Filtering a
+        // full-sphere stencil after selection can discard every neighbor for
+        // near-horizon directions.
+        for (int local_index = 0; local_index < num_points(); ++local_index) {
+            double squared_distance =
+                (get_quad_position(local_index) - direction).squaredNorm();
+            for (int slot = 0; slot < num_interp; ++slot) {
+                if (squared_distance < index_weights[slot].second) {
+                    for (int shifted = num_interp - 1; shifted > slot;
+                         --shifted) {
+                        index_weights[shifted] = index_weights[shifted - 1];
+                    }
+                    index_weights[slot] = {local_index, squared_distance};
+                    break;
+                }
             }
-            total_weight += index_weights[i].second;
         }
 
-        // Renormalize the weights
-        // and remap the indicies
-        if (total_weight > 0) {
-            for (int i = 0; i < index_weights.size(); ++i) {
-                index_weights[i].second /= total_weight;
+        double total_inverse_distance = 0.0;
+        for (int slot = 0; slot < num_interp; ++slot) {
+            if (index_weights[slot].second < 1.0e-8) {
+                for (auto& weight : index_weights) {
+                    weight.second = 0.0;
+                }
+                index_weights[slot].second = 1.0;
+                return;
             }
-        } else {
-            // TODO: Why does this happen?
-            spdlog::warn("Ground Interpolation failed");
+            total_inverse_distance +=
+                1.0 / std::sqrt(index_weights[slot].second);
+        }
+        for (auto& weight : index_weights) {
+            weight.second =
+                (1.0 / std::sqrt(weight.second)) / total_inverse_distance;
         }
     }
 

--- a/cpp/lib/unitsphere/unitsphere_ground.cpp
+++ b/cpp/lib/unitsphere/unitsphere_ground.cpp
@@ -1,9 +1,5 @@
 #include <sasktran2/math/unitsphere.h>
 
-#include <algorithm>
-#include <cmath>
-#include <limits>
-
 namespace sasktran2::math {
     UnitSphereGround::UnitSphereGround(
         std::unique_ptr<const UnitSphere>&& sphere,
@@ -12,6 +8,8 @@ namespace sasktran2::math {
         Eigen::Vector3d quad;
 
         m_contributing_map.reserve(m_full_sphere->num_points() / 2);
+        m_reverse_contributing_map.resize(m_full_sphere->num_points());
+        m_is_full_sphere_looking_up.resize(m_full_sphere->num_points());
 
         m_quadrature_normalization = 0.0;
 
@@ -21,10 +19,17 @@ namespace sasktran2::math {
 
             if (quad.dot(location) > 0) {
                 // Looking up
+                m_is_full_sphere_looking_up[i] = true;
+
+                m_reverse_contributing_map[i] = m_contributing_map.size();
                 m_contributing_map.push_back(i);
 
                 m_quadrature_normalization +=
                     m_full_sphere->quadrature_weight(i);
+            } else {
+                m_is_full_sphere_looking_up[i] = false;
+                m_reverse_contributing_map[i] =
+                    -1; // Value should never be used
             }
         }
     }
@@ -46,43 +51,36 @@ namespace sasktran2::math {
         const Eigen::Vector3d& direction,
         std::vector<std::pair<int, double>>& index_weights,
         int& num_interp) const {
-        num_interp = std::min(3, num_points());
-        index_weights.assign(static_cast<std::size_t>(num_interp),
-                             {-1, std::numeric_limits<double>::infinity()});
+        // Start by interpolating over the full sphere
+        m_full_sphere->interpolate(direction, index_weights, num_interp);
 
-        // Select neighbors directly from the upward hemisphere. Filtering a
-        // full-sphere stencil after selection can discard every neighbor for
-        // near-horizon directions.
-        for (int local_index = 0; local_index < num_points(); ++local_index) {
-            double squared_distance =
-                (get_quad_position(local_index) - direction).squaredNorm();
-            for (int slot = 0; slot < num_interp; ++slot) {
-                if (squared_distance < index_weights[slot].second) {
-                    for (int shifted = num_interp - 1; shifted > slot;
-                         --shifted) {
-                        index_weights[shifted] = index_weights[shifted - 1];
-                    }
-                    index_weights[slot] = {local_index, squared_distance};
-                    break;
-                }
+        // Now go through every interpolation index and see if they are outside
+        // the boundaries
+        double total_weight = 0;
+        for (int i = 0; i < index_weights.size(); ++i) {
+            if (!m_is_full_sphere_looking_up[index_weights[i].first]) {
+                // Have to remove this index from the interpolator
+                // Rather than removing it we just set the index to 0 and weight
+                // to 0
+                index_weights[i].first = 0;
+                index_weights[i].second = 0;
+            } else {
+                // remap the index
+                index_weights[i].first =
+                    m_reverse_contributing_map[index_weights[i].first];
             }
+            total_weight += index_weights[i].second;
         }
 
-        double total_inverse_distance = 0.0;
-        for (int slot = 0; slot < num_interp; ++slot) {
-            if (index_weights[slot].second < 1.0e-8) {
-                for (auto& weight : index_weights) {
-                    weight.second = 0.0;
-                }
-                index_weights[slot].second = 1.0;
-                return;
+        // Renormalize the weights
+        // and remap the indicies
+        if (total_weight > 0) {
+            for (int i = 0; i < index_weights.size(); ++i) {
+                index_weights[i].second /= total_weight;
             }
-            total_inverse_distance +=
-                1.0 / std::sqrt(index_weights[slot].second);
-        }
-        for (auto& weight : index_weights) {
-            weight.second =
-                (1.0 / std::sqrt(weight.second)) / total_inverse_distance;
+        } else {
+            // TODO: Why does this happen?
+            spdlog::warn("Ground Interpolation failed");
         }
     }
 

--- a/docs/sphinx/source/api/model_geometry.rst
+++ b/docs/sphinx/source/api/model_geometry.rst
@@ -13,16 +13,18 @@ Geometry2D capabilities
 -----------------------
 
 The current :class:`sasktran2.Engine` integration for
-:class:`sasktran2.Geometry2D` supports occultation and transmission, exact
-single scattering, standard emission, and volume-emission-rate sources.
-Altitude-only constituents remain compatible and are applied across the
-horizontal grid, while the native 2D constituents can specify horizontally
-varying volume properties. Existing surface constituents may be used, but the
-surface itself is spatially uniform.
+:class:`sasktran2.Geometry2D` supports occultation and transmission, exact and
+table single scattering, successive-orders multiple scattering, standard
+emission, and volume-emission-rate sources. Altitude-only constituents remain
+compatible and are applied across the horizontal grid, while native 2D
+constituents can specify horizontally varying volume properties. Existing
+surface constituents may be used, but the surface itself is spatially uniform.
 
-Multiple scattering, flux observers, line-of-sight refraction, and
-horizontally varying surfaces are not yet supported with
-:class:`sasktran2.Geometry2D`.
+Solar-ray refraction is supported by the exact and table single-scatter
+sources and by the direct-beam calculation used by successive orders. Other
+multiple-scatter sources, flux observers, line-of-sight refraction,
+successive-orders diffuse-ray refraction, and horizontally varying surfaces
+are not yet supported with :class:`sasktran2.Geometry2D`.
 
 Geometry2D engine calculations use the Rust-backed 2D ray tracer and therefore
 require Rust component support. The ``SKTRAN_USE_RUST_RAYTRACER`` CMake option

--- a/docs/sphinx/source/components/source_terms/singlescatter.md
+++ b/docs/sphinx/source/components/source_terms/singlescatter.md
@@ -20,8 +20,9 @@ config.single_scatter_source = sk.SingleScatterSource.Exact
 ```
 
 here `Exact` refers to how the solar attenuation is calculated.  In the `Exact` mode, a ray is traced
-towards the sun everytime the single scatter source is required at a new point, i.e., the solar attenuation
-is calculated "exactly".
+towards the sun every time the single scatter source is required at a new point, i.e., the solar attenuation
+is calculated "exactly". With solar refraction in a 2D atmosphere, a shared characteristic table supplies
+the local bent direction and the optical depth along that characteristic is retraced at every point.
 
 The other available single scatter source,
 
@@ -30,10 +31,10 @@ config.single_scatter_source = sk.SingleScatterSource.Table
 ```
 
 differs in that the solar attenuation is pre-computed on an appropriate grid, and then interpolated whenever
-it is requested.  This can reduce accuracy in some cases, but also offer computational efficiency improvements.
-Generally the advantages of using `Table` over `Exact` are minimal, and we only recommended experimenting
-with the table option if you have a situation where many lines of sight are requested (>100) and the majority
-of the calculation time is suspected to be inside the single scatter source.
+it is requested. For a 2D atmosphere this is a three-dimensional table in altitude, solar zenith angle, and
+off-plane azimuth. It stores incremental characteristic stencils rather than a cumulative optical-depth row
+for every requested point. This can reduce accuracy in some cases, but substantially reduces setup time when
+many lines of sight are requested or when the table is shared with successive orders.
 
 Single scattering can be explicity disabled with
 
@@ -43,8 +44,9 @@ config.single_scatter_source = sk.SingleScatterSource.NoSource
 
 ## Additonal Notes
 
- - All available single scatter sources are perfectly linearized, capable of producing weighting functions to machine precision
- - The exact source has native JVP and VJP implementations; the table source currently uses the Jacobian-row contraction backend
+ - The exact source has native JVP and VJP implementations and can also materialize a complete Jacobian.
+ - The 2D table source has native JVP and VJP implementations. To retain its memory advantage it does not materialize a complete Jacobian; use {py:meth}`sasktran2.Engine.linearize` and its `jvp`/`vjp` methods.
+ - The 1D table source continues to use the materialized-Jacobian backend.
  - All single scatter sources support polarized calculations (`nstokes=3`)
 
 ## Relevant Configuration Options

--- a/docs/sphinx/source/components/source_terms/successive_orders.md
+++ b/docs/sphinx/source/components/source_terms/successive_orders.md
@@ -18,7 +18,7 @@ config.multiple_scatter_source = sk.MultipleScatterSource.SuccessiveOrders
 ## Advantages
 
  - Fully accounts for sphericity of the atmosphere
- - Supports full weighting-function calculations
+ - Supports full weighting-function calculations and memory-efficient native JVP/VJP products
 
 ## Disadvantages
 
@@ -41,6 +41,31 @@ iterations.
 The explicit {py:attr}`sasktran2.Config.successive_orders_altitude_grid_m`
 option decouples the source grid from the atmosphere altitude grid. When it is
 not set, the source uses the midpoints of the atmosphere layers.
+
+## Structured 2D Geometry
+
+The successive-orders source supports horizontally varying atmospheres defined
+with {py:class}`sasktran2.Geometry2D`. Its source grid is independent of the
+atmosphere grid:
+
+- {py:attr}`sasktran2.Config.num_sza` selects the number of evenly spaced
+  horizontal source columns spanning the atmosphere's horizontal-angle grid.
+- {py:attr}`sasktran2.Config.successive_orders_altitude_grid_m` selects the
+  vertical source locations. When it is not set, atmosphere-layer midpoints are
+  used.
+
+The incoming direct beam is obtained from a solar-characteristic table
+parameterized by altitude, solar zenith angle, and off-plane azimuth. Setting
+{py:attr}`sasktran2.Config.solar_refraction` bends these solar characteristics
+using the refractive-index profile stored on the geometry. When exact or table
+single scattering is also enabled, the sources share this table.
+
+Geometry2D successive orders provides native JVP and VJP calculations, which
+avoid allocating the complete structured radiance Jacobian. Refraction of the
+diffuse multiple-scatter rays is not yet supported, so
+{py:attr}`sasktran2.Config.multiple_scatter_refraction` must remain disabled.
+Line-of-sight refraction and flux observers are also not supported with
+Geometry2D.
 
 ## Relevant Configuration Options
 

--- a/docs/sphinx/source/users_guide/refraction.md
+++ b/docs/sphinx/source/users_guide/refraction.md
@@ -28,8 +28,10 @@ each option.
 
 ## Setting the Refractive Index
 Refractive effects in the atmosphere require knowledge of the refractive index of air.
-The refractive index is set through the {py:attr}`sasktran2.Geometry1D.refractive_index` property, which is
-the air refractive index on an altitude grid.
+The refractive index is set through the {py:attr}`sasktran2.Geometry1D.refractive_index` or
+{py:attr}`sasktran2.Geometry2D.refractive_index` property, which is the air refractive index on an altitude grid.
+For a 2D atmosphere the extinction and scattering fields may vary horizontally, but the refractive index is currently
+required to be altitude-only.
 In SASKTRAN2 refraction is considered a geometry (wavelength independent effect) for computational efficiency reasons.
 If wavelength dependent refractive index calculations are important for your application, the model can be reset and executed
 for a single wavelength at a time.
@@ -110,6 +112,14 @@ plt.plot((refracted["radiance"] / unrefracted["radiance"]).to_numpy().flatten(),
 ## Solar Refraction
 Solar refraction refers to refraction of the incoming solar beam, it is most important for twilight conditions where the sun is low in the sky.
 Typically solar refraction is unimportant until the solar zenith angle is above 85 degrees.  The option is controlled by
-{py:attr}`sasktran2.Config.solar_refraction`.  Note that currently this option is considered experimental, and only works when
-both the single scatter source and multiple scatter source are set to DiscreteOrdinates, and thus only works for nadir viewing
-applications.
+{py:attr}`sasktran2.Config.solar_refraction`.
+
+For a {py:class}`sasktran2.Geometry2D` calculation, solar refraction is supported by both the exact and table single-scatter
+sources and by the successive-orders multiple-scatter source. The direct beam is represented by a three-dimensional
+solar-characteristic table parameterized by altitude, solar zenith angle, and off-plane azimuth. The exact single-scatter
+source uses the table to obtain the local bent direction and retraces the optical depth from every line-of-sight integration
+point; the table source interpolates both quantities. When exact/table single scattering and successive orders are enabled
+together, they share the same characteristic table.
+
+This setting bends the direct solar beam only. Refraction of the diffuse rays used by successive orders is controlled by
+{py:attr}`sasktran2.Config.multiple_scatter_refraction` and is not currently supported with `Geometry2D`.

--- a/rust/sasktran2-core/src/raytracer/cxx.rs
+++ b/rust/sasktran2-core/src/raytracer/cxx.rs
@@ -70,6 +70,7 @@ pub mod ffi {
             result: Pin<&mut CppTraceResult2D>,
             index: usize,
             layer: &RustTraceLayer,
+            optical_depth_only: bool,
         );
     }
 
@@ -171,6 +172,7 @@ pub mod ffi {
             look_y: f64,
             look_z: f64,
             refractive_index: &[f64],
+            optical_depth_only: bool,
             result: Pin<&mut CppTraceResult2D>,
         ) -> Result<RustTraceSummary>;
     }
@@ -311,6 +313,7 @@ fn trace_structured_ray_2d_into_cpp_result(
     look_y: f64,
     look_z: f64,
     refractive_index: &[f64],
+    optical_depth_only: bool,
     mut result: Pin<&mut ffi::CppTraceResult2D>,
 ) -> Result<ffi::RustTraceSummary> {
     let profile = if refractive_index.is_empty() {
@@ -336,12 +339,12 @@ fn trace_structured_ray_2d_into_cpp_result(
                 tracer.tracer.primitives().len(),
             )
         });
-        tracer.tracer.trace_into(
+        tracer.tracer.trace_into_for_cpp(
             ray,
             &mut storage.result,
             &mut storage.scratch,
             TraceOptions2D {
-                solar: Some(tracer.solar),
+                solar: (!optical_depth_only).then_some(tracer.solar),
                 refraction: profile.as_ref(),
             },
         );
@@ -349,7 +352,12 @@ fn trace_structured_ray_2d_into_cpp_result(
         let summary = summary_to_ffi(&storage.result);
         ffi::prepare_trace_result_2d(result.as_mut(), &summary);
         for (index, layer) in storage.result.layers.iter().enumerate() {
-            ffi::set_trace_layer_2d(result.as_mut(), index, &layer_to_ffi(layer));
+            ffi::set_trace_layer_2d(
+                result.as_mut(),
+                index,
+                &layer_to_ffi(layer),
+                optical_depth_only,
+            );
         }
         summary
     }))

--- a/rust/sasktran2-core/src/raytracer/grid2d.rs
+++ b/rust/sasktran2-core/src/raytracer/grid2d.rs
@@ -83,13 +83,6 @@ impl AngularBasis {
     pub fn angular_normal(self, angle: f64) -> Vec3 {
         angle.cos() * self.reference_x - angle.sin() * self.reference_z
     }
-
-    #[inline(always)]
-    fn raw_angle(self, point: Vec3) -> f64 {
-        point
-            .dot(self.reference_x)
-            .atan2(point.dot(self.reference_z))
-    }
 }
 
 /// Spherical grid that is finite in altitude and non-periodic in one
@@ -205,29 +198,55 @@ impl StructuredGrid2D {
         point.norm() - self.earth_radius
     }
 
-    pub fn horizontal_angle_at(&self, point: Vec3) -> f64 {
-        let raw = self.basis.raw_angle(point);
+    #[inline(always)]
+    pub(crate) fn horizontal_angle_from_projections(
+        &self,
+        reference_x: f64,
+        reference_z: f64,
+    ) -> f64 {
+        let raw = reference_x.atan2(reference_z);
         let center = (self.horizontal_angles[0]
             + self.horizontal_angles[self.horizontal_angles.len() - 1])
             / 2.0;
         unwrap_angle_near(raw, center)
     }
 
-    pub fn locate_indices(&self, point: Vec3, epsilon: f64) -> Option<(usize, usize)> {
-        let altitude_index = locate_axis_cell(&self.altitudes, self.altitude_at(point), epsilon)?;
-        let horizontal_index = locate_extended_axis_cell(
-            &self.horizontal_angles,
-            self.horizontal_angle_at(point),
-            epsilon,
-        );
+    #[inline(always)]
+    pub fn horizontal_angle_at(&self, point: Vec3) -> f64 {
+        self.horizontal_angle_from_projections(
+            point.dot(self.basis.reference_x()),
+            point.dot(self.basis.reference_z()),
+        )
+    }
+
+    #[inline(always)]
+    pub(crate) fn locate_indices_at_coordinates(
+        &self,
+        altitude: f64,
+        horizontal_angle: f64,
+        epsilon: f64,
+    ) -> Option<(usize, usize)> {
+        let altitude_index = locate_axis_cell(&self.altitudes, altitude, epsilon)?;
+        let horizontal_index =
+            locate_extended_axis_cell(&self.horizontal_angles, horizontal_angle, epsilon);
         Some((altitude_index, horizontal_index))
     }
 
-    pub fn interpolation_weights_at(&self, point: Vec3) -> InterpolationStencil {
+    pub fn locate_indices(&self, point: Vec3, epsilon: f64) -> Option<(usize, usize)> {
+        self.locate_indices_at_coordinates(
+            self.altitude_at(point),
+            self.horizontal_angle_at(point),
+            epsilon,
+        )
+    }
+
+    pub(crate) fn interpolation_weights_at_coordinates(
+        &self,
+        altitude: f64,
+        horizontal_angle: f64,
+    ) -> InterpolationStencil {
         const LOCATION_EPSILON: f64 = 1e-8;
 
-        let altitude = self.altitude_at(point);
-        let horizontal_angle = self.horizontal_angle_at(point);
         let altitude_weights = axis_interpolation_weights(
             &self.altitudes,
             altitude,
@@ -251,6 +270,13 @@ impl StructuredGrid2D {
             }
         }
         result
+    }
+
+    pub fn interpolation_weights_at(&self, point: Vec3) -> InterpolationStencil {
+        self.interpolation_weights_at_coordinates(
+            self.altitude_at(point),
+            self.horizontal_angle_at(point),
+        )
     }
 
     /// Bilinear basis weights for a point interpreted from one specified

--- a/rust/sasktran2-core/src/raytracer/trace2d.rs
+++ b/rust/sasktran2-core/src/raytracer/trace2d.rs
@@ -3,7 +3,9 @@
 //! This remains a standalone API: the CXX adapter exposes its geometry output,
 //! but it is not connected to Python, atmosphere storage, or engine selection.
 
-use super::grid::{BoundarySet, BoundaryTag, CellId, GeometryKind, MediumGrid, VerticalGrid1D};
+use super::grid::{
+    BoundarySet, BoundaryTag, CellId, GeometryKind, InterpolationMethod, MediumGrid, VerticalGrid1D,
+};
 use super::grid2d::StructuredGrid2D;
 use super::layer::{Layer, TraceEvent, TraceEventKind, TracePoint, TracedRay};
 use super::od_quadrature::add_od_quadrature;
@@ -137,6 +139,29 @@ impl StructuredRayTracer2D {
         scratch: &mut TraceScratch2D,
         options: TraceOptions2D<'_>,
     ) {
+        self.trace_into_impl(ray, result, scratch, options, true);
+    }
+
+    /// Trace for the C++ adapter, which reconstructs endpoint interpolation
+    /// metadata from the returned positions and cell indices.
+    pub(crate) fn trace_into_for_cpp(
+        &self,
+        ray: Ray,
+        result: &mut TracedRay,
+        scratch: &mut TraceScratch2D,
+        options: TraceOptions2D<'_>,
+    ) {
+        self.trace_into_impl(ray, result, scratch, options, false);
+    }
+
+    fn trace_into_impl(
+        &self,
+        ray: Ray,
+        result: &mut TracedRay,
+        scratch: &mut TraceScratch2D,
+        options: TraceOptions2D<'_>,
+        populate_point_metadata: bool,
+    ) {
         scratch.clear();
         result.reset(
             ray,
@@ -156,13 +181,19 @@ impl StructuredRayTracer2D {
                 // Preserve the 1D/C++ convention that a supplied profile marks
                 // the result as refracted, but avoid quadrature dither for the
                 // exactly straight unity-index path.
-                self.trace_straight_geometry(ray, result, scratch);
+                self.trace_straight_geometry(ray, result, scratch, populate_point_metadata);
                 result.is_straight = false;
             } else {
-                self.trace_refracted_geometry(ray, result, scratch, profile);
+                self.trace_refracted_geometry(
+                    ray,
+                    result,
+                    scratch,
+                    profile,
+                    populate_point_metadata,
+                );
             }
         } else {
-            self.trace_straight_geometry(ray, result, scratch);
+            self.trace_straight_geometry(ray, result, scratch, populate_point_metadata);
         }
 
         let reuse_shared_boundary_solar = result.is_straight;
@@ -193,6 +224,7 @@ impl StructuredRayTracer2D {
         ray: Ray,
         result: &mut TracedRay,
         scratch: &mut TraceScratch2D,
+        populate_point_metadata: bool,
     ) {
         result.is_straight = true;
         result.tangent_radius = ray.spherical_tangent_radius();
@@ -242,6 +274,7 @@ impl StructuredRayTracer2D {
 
         let mut atmospheric_segment_started = false;
         let mut far_boundaries = BoundarySet::new();
+        let mut current_cell = None;
         for window in scratch.events.windows(2) {
             let near = window[0];
             let far = window[1];
@@ -252,8 +285,11 @@ impl StructuredRayTracer2D {
                 continue;
             }
 
-            let midpoint = ray.point_at((near.distance + far.distance) / 2.0);
-            let Some(cell) = self.grid.locate_cell(midpoint) else {
+            let cell = current_cell.or_else(|| {
+                let midpoint = ray.point_at((near.distance + far.distance) / 2.0);
+                self.grid.locate_cell(midpoint)
+            });
+            let Some(cell) = cell else {
                 if atmospheric_segment_started {
                     break;
                 }
@@ -261,10 +297,11 @@ impl StructuredRayTracer2D {
             };
 
             atmospheric_segment_started = true;
-            let entrance = self.trace_point(ray, near);
-            let exit = self.trace_point(ray, far);
+            let entrance = self.trace_point(ray, near, populate_point_metadata);
+            let exit = self.trace_point(ray, far, populate_point_metadata);
             result.layers.push(Layer::new(entrance, exit, Some(cell)));
             far_boundaries = far.boundaries;
+            current_cell = self.cell_after_straight_event(cell, far, exit.position, ray.direction);
 
             if surface_limit.is_some_and(|limit| far.distance >= limit - self.epsilon) {
                 break;
@@ -275,12 +312,79 @@ impl StructuredRayTracer2D {
         result.layers.reverse();
     }
 
+    fn cell_after_straight_event(
+        &self,
+        cell: CellId,
+        event: Event2D,
+        position: Vec3,
+        direction: Vec3,
+    ) -> Option<CellId> {
+        let CellId::Structured2D {
+            mut altitude_index,
+            mut horizontal_index,
+        } = cell
+        else {
+            return None;
+        };
+
+        for boundary in event.boundaries.iter() {
+            if let Some(index) = boundary.altitude_index() {
+                if event.is_tangent {
+                    continue;
+                }
+                if position.dot(direction) > 0.0 {
+                    if index + 1 >= self.grid.altitudes().len() {
+                        return None;
+                    }
+                    altitude_index = index;
+                } else {
+                    if index == 0 {
+                        return None;
+                    }
+                    altitude_index = index - 1;
+                }
+                continue;
+            }
+
+            match boundary {
+                BoundaryTag::Horizontal { index } => {
+                    let normal = self
+                        .grid
+                        .basis()
+                        .angular_normal(self.grid.horizontal_angles()[index]);
+                    horizontal_index = if direction.dot(normal) > 0.0 {
+                        index
+                    } else {
+                        index - 1
+                    };
+                }
+                BoundaryTag::HorizontalSeam => {
+                    horizontal_index = if horizontal_index == 0 {
+                        self.grid.horizontal_angles().len() - 2
+                    } else {
+                        0
+                    };
+                }
+                BoundaryTag::Surface { .. }
+                | BoundaryTag::TopOfAtmosphere { .. }
+                | BoundaryTag::Altitude { .. }
+                | BoundaryTag::Custom { .. } => {}
+            }
+        }
+
+        Some(CellId::Structured2D {
+            altitude_index,
+            horizontal_index,
+        })
+    }
+
     fn trace_refracted_geometry(
         &self,
         ray: Ray,
         result: &mut TracedRay,
         scratch: &mut TraceScratch2D,
         profile: &RefractiveProfile,
+        populate_point_metadata: bool,
     ) {
         const ANGULAR_EVENT_EPSILON: f64 = 1e-8;
 
@@ -311,7 +415,7 @@ impl StructuredRayTracer2D {
         if ray_plane_normal.norm_squared() == 0.0 {
             // Near-radial rays are normally routed through the straight path by
             // the viewing cutoff. Keep a defensive fallback for degenerate input.
-            self.trace_straight_geometry(ray, result, scratch);
+            self.trace_straight_geometry(ray, result, scratch, populate_point_metadata);
             return;
         }
 
@@ -323,9 +427,17 @@ impl StructuredRayTracer2D {
         'radial_layers: for radial_layer in radial_result.layers.iter().rev() {
             scratch.curved_events.clear();
 
-            let start = self.structured_point(radial_layer.entrance, cumulative_path);
+            let start = self.structured_point(
+                radial_layer.entrance,
+                cumulative_path,
+                populate_point_metadata,
+            );
             let layer_path = radial_layer.effective_distance();
-            let end = self.structured_point(radial_layer.exit, cumulative_path + layer_path);
+            let end = self.structured_point(
+                radial_layer.exit,
+                cumulative_path + layer_path,
+                populate_point_metadata,
+            );
             let start_direction = start.position.normalized();
             let end_direction = end.position.normalized();
             let total_angle = forward_angle(
@@ -389,8 +501,16 @@ impl StructuredRayTracer2D {
                             position,
                             altitude: self.grid.altitude_at(position),
                             event: TraceEvent::boundary(boundaries),
-                            interpolation: self.grid.interpolation_weights_at(position),
-                            cell: self.grid.locate_cell(position),
+                            interpolation: if populate_point_metadata {
+                                self.grid.interpolation_weights_at(position)
+                            } else {
+                                Default::default()
+                            },
+                            cell: if populate_point_metadata {
+                                self.grid.locate_cell(position)
+                            } else {
+                                None
+                            },
                             on_exact_vertical_boundary: false,
                         },
                     });
@@ -447,7 +567,12 @@ impl StructuredRayTracer2D {
         result.layers.reverse();
     }
 
-    fn structured_point(&self, point: TracePoint, distance: f64) -> TracePoint {
+    fn structured_point(
+        &self,
+        point: TracePoint,
+        distance: f64,
+        populate_point_metadata: bool,
+    ) -> TracePoint {
         let mut boundaries = point.event.boundaries;
         let angle = self.grid.horizontal_angle_at(point.position);
         for (index, boundary) in self.grid.horizontal_topology_boundaries() {
@@ -471,14 +596,29 @@ impl StructuredRayTracer2D {
             position: point.position,
             altitude: point.altitude,
             event,
-            interpolation: self.grid.interpolation_weights_at(point.position),
-            cell: self.grid.locate_cell(point.position),
+            interpolation: if populate_point_metadata {
+                self.grid
+                    .interpolation_weights_at_coordinates(point.altitude, angle)
+            } else {
+                Default::default()
+            },
+            cell: if populate_point_metadata {
+                self.grid
+                    .locate_indices_at_coordinates(point.altitude, angle, 1e-8)
+                    .map(|(altitude_index, horizontal_index)| CellId::Structured2D {
+                        altitude_index,
+                        horizontal_index,
+                    })
+            } else {
+                None
+            },
             on_exact_vertical_boundary: point.on_exact_vertical_boundary,
         }
     }
 
-    fn trace_point(&self, ray: Ray, event: Event2D) -> TracePoint {
+    fn trace_point(&self, ray: Ray, event: Event2D, populate_point_metadata: bool) -> TracePoint {
         let position = ray.point_at(event.distance);
+        let altitude = self.grid.altitude_at(position);
         let trace_event = TraceEvent {
             kind: if event.is_tangent {
                 TraceEventKind::Tangent
@@ -490,21 +630,53 @@ impl StructuredRayTracer2D {
             boundaries: event.boundaries,
         };
 
+        let (interpolation, cell) = if populate_point_metadata {
+            let horizontal_angle = self.grid.horizontal_angle_at(position);
+            (
+                self.grid
+                    .interpolation_weights_at_coordinates(altitude, horizontal_angle),
+                self.grid
+                    .locate_indices_at_coordinates(altitude, horizontal_angle, 1e-8)
+                    .map(|(altitude_index, horizontal_index)| CellId::Structured2D {
+                        altitude_index,
+                        horizontal_index,
+                    }),
+            )
+        } else {
+            (Default::default(), None)
+        };
+
         TracePoint {
             distance: event.distance,
             position,
-            altitude: self.grid.altitude_at(position),
+            altitude,
             event: trace_event,
-            interpolation: self.grid.interpolation_weights_at(position),
-            cell: self.grid.locate_cell(position),
+            interpolation,
+            cell,
             on_exact_vertical_boundary: event.boundaries.contains_vertical(),
         }
     }
 }
 
-// Positive half of the 16-point Gauss-Legendre rule. Four panels keep angular
-// interpolation accurate near a spherical tangent while all work remains a
-// one-time geometry cost shared by every wavelength.
+// Positive half of the 8-point Gauss-Legendre rule. Straight structured
+// layers are smooth within a cell except where an extended horizontal edge
+// transitions into the sampled domain; that point is split explicitly below.
+const GQ8_NODES: [f64; 4] = [
+    0.183_434_642_495_649_8,
+    0.525_532_409_916_329,
+    0.796_666_477_413_626_7,
+    0.960_289_856_497_536_3,
+];
+const GQ8_WEIGHTS: [f64; 4] = [
+    0.362_683_783_378_362,
+    0.313_706_645_877_887_3,
+    0.222_381_034_453_374_5,
+    0.101_228_536_290_376_3,
+];
+
+// Positive half of the 16-point Gauss-Legendre rule. Curved refracted layers
+// retain the conservative four-panel rule because their path parameterization
+// is more complex and they are not part of exact-solar setup.
 const GQ16_NODES: [f64; 8] = [
     0.095_012_509_837_637_44,
     0.281_603_550_779_258_9,
@@ -541,6 +713,11 @@ fn add_structured_od_quadrature(layer: &mut Layer, grid: &StructuredGrid2D) {
         return;
     }
 
+    if layer.curvature_factor == 1.0 {
+        add_straight_structured_od_quadrature(layer, grid, altitude_index, horizontal_index);
+        return;
+    }
+
     // Integrate each of the four cell-local bilinear basis functions along the
     // ray. This produces geometry-only coefficients Q_j such that, for every
     // wavelength, tau_layer = sum_j Q_j * extinction_j. Each panel applies a
@@ -562,6 +739,110 @@ fn add_structured_od_quadrature(layer: &mut Layer, grid: &StructuredGrid2D) {
             }
         }
     }
+}
+
+fn add_straight_structured_od_quadrature(
+    layer: &mut Layer,
+    grid: &StructuredGrid2D,
+    altitude_index: usize,
+    horizontal_index: usize,
+) {
+    let entrance = layer.entrance.position;
+    let delta = layer.exit.position - entrance;
+    let radius_constant = entrance.norm_squared();
+    let radius_linear = 2.0 * entrance.dot(delta);
+    let radius_quadratic = delta.norm_squared();
+    let basis = grid.basis();
+    let projected_x_constant = entrance.dot(basis.reference_x());
+    let projected_x_linear = delta.dot(basis.reference_x());
+    let projected_z_constant = entrance.dot(basis.reference_z());
+    let projected_z_linear = delta.dot(basis.reference_z());
+    let altitude_lower = grid.altitudes()[altitude_index];
+    let inverse_altitude_width = 1.0 / (grid.altitudes()[altitude_index + 1] - altitude_lower);
+    let horizontal_lower = grid.horizontal_angles()[horizontal_index];
+    let inverse_horizontal_width =
+        1.0 / (grid.horizontal_angles()[horizontal_index + 1] - horizontal_lower);
+
+    let mut integrated = [0.0; 4];
+    let mut integrate_interval = |lower_fraction: f64, upper_fraction: f64| {
+        let center = (lower_fraction + upper_fraction) / 2.0;
+        let half_width = (upper_fraction - lower_fraction) / 2.0;
+        for (&node, &weight) in GQ8_NODES.iter().zip(GQ8_WEIGHTS.iter()) {
+            for signed_node in [-node, node] {
+                let fraction = center + half_width * signed_node;
+                let radius = (radius_constant
+                    + fraction * (radius_linear + fraction * radius_quadratic))
+                    .max(0.0)
+                    .sqrt();
+                let altitude_upper = match grid.altitude_interpolation() {
+                    InterpolationMethod::Lower => 0.0,
+                    InterpolationMethod::Shell => 0.5,
+                    InterpolationMethod::Linear => {
+                        ((radius - grid.earth_radius() - altitude_lower) * inverse_altitude_width)
+                            .clamp(0.0, 1.0)
+                    }
+                };
+                let horizontal_angle = grid.horizontal_angle_from_projections(
+                    projected_x_constant + fraction * projected_x_linear,
+                    projected_z_constant + fraction * projected_z_linear,
+                );
+                let horizontal_upper = ((horizontal_angle - horizontal_lower)
+                    * inverse_horizontal_width)
+                    .clamp(0.0, 1.0);
+                let altitude_lower_weight = 1.0 - altitude_upper;
+                let horizontal_lower_weight = 1.0 - horizontal_upper;
+                let scale = half_width * weight;
+                integrated[0] += scale * horizontal_lower_weight * altitude_lower_weight;
+                integrated[1] += scale * horizontal_lower_weight * altitude_upper;
+                integrated[2] += scale * horizontal_upper * altitude_lower_weight;
+                integrated[3] += scale * horizontal_upper * altitude_upper;
+            }
+        }
+    };
+
+    if let Some(split) = straight_horizontal_clamp_split(layer, grid, horizontal_index) {
+        integrate_interval(0.0, split);
+        integrate_interval(split, 1.0);
+    } else {
+        integrate_interval(0.0, 1.0);
+    }
+
+    let effective_distance = layer.effective_distance();
+    for (output, normalized) in layer.integrated_cell_weights.iter_mut().zip(integrated) {
+        *output = effective_distance * normalized;
+    }
+}
+
+fn straight_horizontal_clamp_split(
+    layer: &Layer,
+    grid: &StructuredGrid2D,
+    horizontal_index: usize,
+) -> Option<f64> {
+    let horizontal_angle = if horizontal_index == 0 {
+        grid.horizontal_angles()[0]
+    } else if horizontal_index + 2 == grid.horizontal_angles().len() {
+        grid.horizontal_angles()[grid.horizontal_angles().len() - 1]
+    } else {
+        return None;
+    };
+
+    let basis = grid.basis();
+    let normal = basis.angular_normal(horizontal_angle);
+    let radial_direction = basis.radial_direction(horizontal_angle);
+    let entrance = layer.entrance.position;
+    let delta = layer.exit.position - entrance;
+    let denominator = delta.dot(normal);
+    if denominator.abs() <= f64::EPSILON * delta.norm().max(1.0) {
+        return None;
+    }
+
+    let fraction = -entrance.dot(normal) / denominator;
+    const FRACTION_EPSILON: f64 = 1e-12;
+    if fraction <= FRACTION_EPSILON || fraction >= 1.0 - FRACTION_EPSILON {
+        return None;
+    }
+    let crossing = entrance + fraction * delta;
+    (crossing.dot(radial_direction) >= 0.0).then_some(fraction)
 }
 
 fn layer_position_at_fraction(layer: &Layer, fraction: f64) -> Vec3 {
@@ -1137,6 +1418,59 @@ mod tests {
             endpoint_gap_found |= (endpoint_approximation - quadrature).abs() > 1e-6;
         }
         assert!(endpoint_gap_found);
+    }
+
+    #[test]
+    fn straight_integrated_weights_split_extended_edge_clamp() {
+        let tracer = StructuredRayTracer2D::new(grid());
+        let origin = 15.0 * radial_direction(-0.75);
+        let traced = tracer.trace(Ray::new(origin, Vec3::UNIT_X), TraceOptions2D::default());
+        let layer = traced
+            .layers
+            .iter()
+            .find(|layer| {
+                let Some(CellId::Structured2D {
+                    horizontal_index: 0,
+                    ..
+                }) = layer.cell
+                else {
+                    return false;
+                };
+                let entrance_angle = tracer.grid.horizontal_angle_at(layer.entrance.position);
+                let exit_angle = tracer.grid.horizontal_angle_at(layer.exit.position);
+                (entrance_angle + 0.5) * (exit_angle + 0.5) < 0.0
+            })
+            .expect("the ray should cross the first sampled horizontal node");
+        let Some(CellId::Structured2D {
+            altitude_index,
+            horizontal_index,
+        }) = layer.cell
+        else {
+            unreachable!();
+        };
+        assert!(straight_horizontal_clamp_split(layer, &tracer.grid, horizontal_index).is_some());
+
+        const NUM_REFERENCE_POINTS: usize = 100_000;
+        let mut reference = [0.0; 4];
+        for index in 0..NUM_REFERENCE_POINTS {
+            let fraction = (index as f64 + 0.5) / NUM_REFERENCE_POINTS as f64;
+            let point = layer_position_at_fraction(layer, fraction);
+            let basis = tracer
+                .grid
+                .cell_basis_weights(point, altitude_index, horizontal_index);
+            for (integrated, local) in reference.iter_mut().zip(basis) {
+                *integrated += local;
+            }
+        }
+        for weight in &mut reference {
+            *weight *= layer.effective_distance() / NUM_REFERENCE_POINTS as f64;
+        }
+        for (actual, expected) in layer.integrated_cell_weights.iter().zip(reference) {
+            assert!(
+                (actual - expected).abs() <= 5e-8 * layer.effective_distance().max(1.0),
+                "actual={actual}, expected={expected}"
+            );
+        }
     }
 
     #[test]

--- a/rust/sasktran2-py-ext/src/geometry.rs
+++ b/rust/sasktran2-py-ext/src/geometry.rs
@@ -136,6 +136,20 @@ impl PyGeometry2D {
         Ok(horizontal_angles.to_pyarray(py).to_owned())
     }
 
+    #[getter]
+    fn get_refractive_index<'py>(this: Bound<'py, Self>) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let binding = &this.borrow().geometry;
+        let array = binding.refractive_index_mut().into_pyresult()?;
+        unsafe { Ok(PyArray1::borrow_from_array(&array, this.into_any())) }
+    }
+
+    #[setter]
+    fn set_refractive_index(&mut self, refractive_index: PyReadonlyArray1<f64>) -> PyResult<()> {
+        let mut view = self.geometry.refractive_index_mut().into_pyresult()?;
+        view.assign(&refractive_index.as_array());
+        Ok(())
+    }
+
     fn location_shape(&self) -> PyResult<(usize, usize)> {
         self.geometry.location_shape().into_pyresult()
     }

--- a/rust/sasktran2-py-ext/src/geometry.rs
+++ b/rust/sasktran2-py-ext/src/geometry.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 use numpy::PyArray1;
 use numpy::{PyReadonlyArray1, ToPyArray};
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use sasktran2_rs::bindings::geometry;
 
@@ -139,14 +140,30 @@ impl PyGeometry2D {
     #[getter]
     fn get_refractive_index<'py>(this: Bound<'py, Self>) -> PyResult<Bound<'py, PyArray1<f64>>> {
         let binding = &this.borrow().geometry;
-        let array = binding.refractive_index_mut().into_pyresult()?;
+        let array = binding.refractive_index().into_pyresult()?;
         unsafe { Ok(PyArray1::borrow_from_array(&array, this.into_any())) }
     }
 
     #[setter]
     fn set_refractive_index(&mut self, refractive_index: PyReadonlyArray1<f64>) -> PyResult<()> {
+        let values = refractive_index.as_array();
+        let (_, num_altitudes) = self.geometry.location_shape().into_pyresult()?;
+        if values.len() != num_altitudes {
+            return Err(PyValueError::new_err(format!(
+                "Geometry2D refractive_index requires {num_altitudes} values, received {}",
+                values.len()
+            )));
+        }
+        if values
+            .iter()
+            .any(|value| !value.is_finite() || *value <= 0.0)
+        {
+            return Err(PyValueError::new_err(
+                "Geometry2D refractive_index values must be finite and positive",
+            ));
+        }
         let mut view = self.geometry.refractive_index_mut().into_pyresult()?;
-        view.assign(&refractive_index.as_array());
+        view.assign(&values);
         Ok(())
     }
 

--- a/rust/sasktran2-rs/src/bindings/engine.rs
+++ b/rust/sasktran2-rs/src/bindings/engine.rs
@@ -196,7 +196,7 @@ impl<'a> Engine<'a> {
         })
     }
 
-    /// Creates a transmission-only engine on a structured 2D geometry.
+    /// Creates an engine on a structured 2D geometry.
     pub fn new_2d(
         config: &'a Config,
         geometry: &'a Geometry2D,
@@ -213,9 +213,7 @@ impl<'a> Engine<'a> {
         };
 
         if engine.is_null() {
-            return Err(anyhow::anyhow!(
-                "Failed to create transmission-only Geometry2D Engine"
-            ));
+            return Err(anyhow::anyhow!("Failed to create Geometry2D Engine"));
         }
 
         Ok(Engine {
@@ -875,6 +873,20 @@ mod tests {
 
         config
             .with_single_scatter_source(SingleScatterSource::SolarTable)
+            .unwrap();
+        let engine = Engine::new_2d(&config, &geometry, &viewing_geometry).unwrap();
+        assert!(!engine.engine.is_null());
+        drop(engine);
+
+        config
+            .with_multiple_scatter_source(MultipleScatterSource::SuccessiveOrders)
+            .unwrap();
+        let engine = Engine::new_2d(&config, &geometry, &viewing_geometry).unwrap();
+        assert!(!engine.engine.is_null());
+        drop(engine);
+
+        config
+            .with_multiple_scatter_source(MultipleScatterSource::SuccessiveOrdersLegacy)
             .unwrap();
         assert!(Engine::new_2d(&config, &geometry, &viewing_geometry).is_err());
 

--- a/rust/sasktran2-rs/src/bindings/geometry.rs
+++ b/rust/sasktran2-rs/src/bindings/geometry.rs
@@ -155,6 +155,23 @@ impl Geometry2D {
         Ok(Array1::from(horizontal_angles))
     }
 
+    pub fn refractive_index_mut(&self) -> Result<ArrayViewMut1<'_, f64>> {
+        let (_, num_altitudes) = self.location_shape()?;
+        let mut refractive_index_ptr = std::ptr::null_mut();
+        let result = unsafe {
+            ffi::sk_geometry2d_get_refractive_index_ptr(self.geometry, &mut refractive_index_ptr)
+        };
+        if result != 0 || refractive_index_ptr.is_null() {
+            return Err(anyhow!("Failed to get Geometry2D refractive index"));
+        }
+        unsafe {
+            Ok(ArrayViewMut1::from_shape_ptr(
+                num_altitudes,
+                refractive_index_ptr,
+            ))
+        }
+    }
+
     pub fn location_index(&self, altitude_index: usize, horizontal_index: usize) -> Result<usize> {
         let altitude_index =
             i32::try_from(altitude_index).map_err(|_| anyhow!("Altitude index is too large"))?;

--- a/rust/sasktran2-rs/src/bindings/geometry.rs
+++ b/rust/sasktran2-rs/src/bindings/geometry.rs
@@ -356,6 +356,31 @@ mod tests {
     }
 
     #[test]
+    fn test_geometry2d_refractive_index() {
+        let geometry = Geometry2D::new(
+            0.5,
+            0.1,
+            6_371_000.0,
+            vec![0.0, 10_000.0, 20_000.0],
+            vec![-0.2, 0.2],
+            InterpolationMethod::Linear,
+        )
+        .unwrap();
+
+        {
+            let mut refractive_index = geometry.refractive_index_mut().unwrap();
+            assert_eq!(refractive_index.to_vec(), vec![1.0, 1.0, 1.0]);
+            refractive_index[0] = 1.0003;
+            refractive_index[1] = 1.0001;
+        }
+
+        assert_eq!(
+            geometry.refractive_index_mut().unwrap().to_vec(),
+            vec![1.0003, 1.0001, 1.0]
+        );
+    }
+
+    #[test]
     fn test_geometry2d_rejects_invalid_grids() {
         assert!(
             Geometry2D::new(

--- a/rust/sasktran2-rs/src/bindings/geometry.rs
+++ b/rust/sasktran2-rs/src/bindings/geometry.rs
@@ -155,11 +155,31 @@ impl Geometry2D {
         Ok(Array1::from(horizontal_angles))
     }
 
-    pub fn refractive_index_mut(&self) -> Result<ArrayViewMut1<'_, f64>> {
+    pub fn refractive_index(&self) -> Result<ArrayView1<'_, f64>> {
+        let (_, num_altitudes) = self.location_shape()?;
+        let mut refractive_index_ptr = std::ptr::null();
+        let result = unsafe {
+            ffi::sk_geometry2d_get_refractive_index_ptr(self.geometry, &mut refractive_index_ptr)
+        };
+        if result != 0 || refractive_index_ptr.is_null() {
+            return Err(anyhow!("Failed to get Geometry2D refractive index"));
+        }
+        unsafe {
+            Ok(ArrayView1::from_shape_ptr(
+                num_altitudes,
+                refractive_index_ptr,
+            ))
+        }
+    }
+
+    pub fn refractive_index_mut(&mut self) -> Result<ArrayViewMut1<'_, f64>> {
         let (_, num_altitudes) = self.location_shape()?;
         let mut refractive_index_ptr = std::ptr::null_mut();
         let result = unsafe {
-            ffi::sk_geometry2d_get_refractive_index_ptr(self.geometry, &mut refractive_index_ptr)
+            ffi::sk_geometry2d_get_refractive_index_mut_ptr(
+                self.geometry,
+                &mut refractive_index_ptr,
+            )
         };
         if result != 0 || refractive_index_ptr.is_null() {
             return Err(anyhow!("Failed to get Geometry2D refractive index"));
@@ -357,7 +377,7 @@ mod tests {
 
     #[test]
     fn test_geometry2d_refractive_index() {
-        let geometry = Geometry2D::new(
+        let mut geometry = Geometry2D::new(
             0.5,
             0.1,
             6_371_000.0,
@@ -375,7 +395,7 @@ mod tests {
         }
 
         assert_eq!(
-            geometry.refractive_index_mut().unwrap().to_vec(),
+            geometry.refractive_index().unwrap().to_vec(),
             vec![1.0003, 1.0001, 1.0]
         );
     }

--- a/rust/sasktran2-sys/src/bindings.rs
+++ b/rust/sasktran2-sys/src/bindings.rs
@@ -74,6 +74,12 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    pub fn sk_geometry2d_get_refractive_index_ptr(
+        geometry: *const Geometry2D,
+        refractive_index: *mut *mut f64,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
     pub fn sk_geometry2d_get_location_index(
         geometry: *const Geometry2D,
         altitude_index: ::std::os::raw::c_int,

--- a/rust/sasktran2-sys/src/bindings.rs
+++ b/rust/sasktran2-sys/src/bindings.rs
@@ -76,6 +76,12 @@ unsafe extern "C" {
 unsafe extern "C" {
     pub fn sk_geometry2d_get_refractive_index_ptr(
         geometry: *const Geometry2D,
+        refractive_index: *mut *const f64,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn sk_geometry2d_get_refractive_index_mut_ptr(
+        geometry: *mut Geometry2D,
         refractive_index: *mut *mut f64,
     ) -> ::std::os::raw::c_int;
 }

--- a/src/sasktran2/config.py
+++ b/src/sasktran2/config.py
@@ -387,7 +387,8 @@ class Config:
         """
         The number of solar zenith angle discretizations to use when calculating the multiple scatter source.
         For the discrete ordinates source, this determines the number of independent discrete ordinates calculations to perform.
-        In the successive orders of scattering source, this is directly the number of discretizations.
+        For the successive-orders source with Geometry1D, this is the number of solar-zenith-angle discretizations.
+        With Geometry2D, it is the number of evenly spaced horizontal source columns spanning the atmosphere grid.
         Defaults to 1, indicating that the multiple scatter source is estimated only at the reference point.
         """
         return self._config.num_sza
@@ -397,7 +398,8 @@ class Config:
         """
         The number of solar zenith angle discretizations to use when calculating the multiple scatter source.
         For the discrete ordinates source, this determines the number of independent discrete ordinates calculations to perform.
-        In the successive orders of scattering source, this is directly the number of discretizations.
+        For the successive-orders source with Geometry1D, this is the number of solar-zenith-angle discretizations.
+        With Geometry2D, it is the number of evenly spaced horizontal source columns spanning the atmosphere grid.
         Defaults to 1, indicating that the multiple scatter source is estimated only at the reference point.
         """
         self._config.num_sza = value

--- a/src/sasktran2/config.py
+++ b/src/sasktran2/config.py
@@ -367,18 +367,20 @@ class Config:
     @property
     def multiple_scatter_refraction(self) -> bool:
         """
-        Controls whether or not refraction is enabled for the solar line of sight rays. Requires
-        the refractive index to be set in the Geometry object for refraction to work.  Only has an effect
-        when the single scatter source term is set to Table.  Defaults to False.
+        Controls whether refraction is enabled for diffuse rays used by the multiple scatter source.
+        Requires the refractive index to be set in the Geometry object. Geometry2D successive orders
+        does not currently support diffuse-ray refraction; ``solar_refraction`` independently controls
+        refraction of its incoming direct solar beam. Defaults to False.
         """
         return self._config.multiple_scatter_refraction
 
     @multiple_scatter_refraction.setter
     def multiple_scatter_refraction(self, value: bool):
         """
-        Controls whether or not refraction is enabled for the solar line of sight rays. Requires
-        the refractive index to be set in the Geometry object for refraction to work.  Only has an effect
-        when the single scatter source term is set to Table.  Defaults to False.
+        Controls whether refraction is enabled for diffuse rays used by the multiple scatter source.
+        Requires the refractive index to be set in the Geometry object. Geometry2D successive orders
+        does not currently support diffuse-ray refraction; ``solar_refraction`` independently controls
+        refraction of its incoming direct solar beam. Defaults to False.
         """
         self._config.multiple_scatter_refraction = value
 

--- a/src/sasktran2/engine.py
+++ b/src/sasktran2/engine.py
@@ -103,7 +103,11 @@ class Engine:
                     sk.SingleScatterSource.NoSource,
                     sk.SingleScatterSource.Exact,
                 )
-                or config.multiple_scatter_source != sk.MultipleScatterSource.NoSource
+                or config.multiple_scatter_source
+                not in (
+                    sk.MultipleScatterSource.NoSource,
+                    sk.MultipleScatterSource.SuccessiveOrders,
+                )
                 or config.emission_source
                 not in (
                     sk.EmissionSource.NoSource,
@@ -113,8 +117,8 @@ class Engine:
             ):
                 msg = (
                     "Geometry2D Engine currently supports exact single scattering, "
-                    "occultation, standard emission, and volume emission rate "
-                    "sources with multiple scattering disabled"
+                    "successive-orders multiple scattering, occultation, standard "
+                    "emission, and volume emission rate sources"
                 )
                 raise NotImplementedError(msg)
             if viewing_geometry.flux_observers:
@@ -124,6 +128,16 @@ class Engine:
                 msg = (
                     "Geometry2D Engine does not yet accept per-ray refractive-index "
                     "profiles"
+                )
+                raise NotImplementedError(msg)
+            if (
+                config.multiple_scatter_source
+                == sk.MultipleScatterSource.SuccessiveOrders
+                and config.multiple_scatter_refraction
+            ):
+                msg = (
+                    "Geometry2D successive orders does not support diffuse-ray "
+                    "refraction"
                 )
                 raise NotImplementedError(msg)
 

--- a/src/sasktran2/engine.py
+++ b/src/sasktran2/engine.py
@@ -102,6 +102,7 @@ class Engine:
                 not in (
                     sk.SingleScatterSource.NoSource,
                     sk.SingleScatterSource.Exact,
+                    sk.SingleScatterSource.Table,
                 )
                 or config.multiple_scatter_source
                 not in (
@@ -116,9 +117,10 @@ class Engine:
                 )
             ):
                 msg = (
-                    "Geometry2D Engine currently supports exact single scattering, "
-                    "successive-orders multiple scattering, occultation, standard "
-                    "emission, and volume emission rate sources"
+                    "Geometry2D Engine currently supports exact and table single "
+                    "scattering, successive-orders multiple scattering, "
+                    "occultation, standard emission, and volume emission rate "
+                    "sources"
                 )
                 raise NotImplementedError(msg)
             if viewing_geometry.flux_observers:
@@ -191,9 +193,14 @@ class Engine:
                 "calculate_derivatives=True"
             )
             raise ValueError(msg)
-        if not self._engine._supports_linearization(0):
-            msg = "The configured engine does not support full-Jacobian linearization"
+        derivative_backends = {
+            mode: self._engine._linearization_backend(mode_index)
+            for mode, mode_index in (("jvp", 1), ("vjp", 2))
+        }
+        if any(backend == 0 for backend in derivative_backends.values()):
+            msg = "The configured engine does not support JVP/VJP linearization"
             raise NotImplementedError(msg)
+        jacobian_supported = self._engine._supports_linearization(0)
 
         native_atmosphere = atmosphere.internal_object()
         revision = atmosphere.revision
@@ -205,11 +212,17 @@ class Engine:
             2: LinearizationBackend.Native,
         }
         backends = {
-            mode: backend_names[self._engine._linearization_backend(mode_index)]
-            for mode, mode_index in (("jvp", 1), ("vjp", 2))
+            mode: backend_names[backend]
+            for mode, backend in derivative_backends.items()
         }
 
         def load_jacobian() -> xr.Dataset:
+            if not jacobian_supported:
+                msg = (
+                    "The configured engine supports derivative products but "
+                    "cannot materialize the full Jacobian"
+                )
+                raise NotImplementedError(msg)
             result, _ = self._calculate_radiance(
                 atmosphere, internal_atmosphere=native_atmosphere
             )

--- a/src/sasktran2/geometry.py
+++ b/src/sasktran2/geometry.py
@@ -123,6 +123,15 @@ class Geometry2D:
         return self._geometry.horizontal_angles()
 
     @property
+    def refractive_index(self) -> np.ndarray:
+        """Altitude-only refractive-index profile used by solar rays."""
+        return self._geometry.refractive_index
+
+    @refractive_index.setter
+    def refractive_index(self, value: np.ndarray) -> None:
+        self._geometry.refractive_index = value
+
+    @property
     def shape(self) -> tuple[int, int]:
         """Location shape ordered as ``(horizontal, altitude)``."""
         return self._geometry.location_shape()

--- a/tests/engine/test_geometry2d_emission.py
+++ b/tests/engine/test_geometry2d_emission.py
@@ -350,5 +350,7 @@ def test_ground_surface_emission_is_attenuated_and_matches_1d():
 
 def test_geometry2d_engine_rejects_unimplemented_emission_sources():
     config = emission_config(sk.EmissionSource.TwoStream)
-    with pytest.raises(NotImplementedError, match="supports exact single scattering"):
+    with pytest.raises(
+        NotImplementedError, match="supports exact and table single scattering"
+    ):
         sk.Engine(config, geometry2d(), tangent_viewing_geometry())

--- a/tests/engine/test_geometry2d_single_scatter.py
+++ b/tests/engine/test_geometry2d_single_scatter.py
@@ -732,20 +732,11 @@ def test_single_scatter_occultation_and_emission_sources_add_linearly():
     np.testing.assert_allclose(results["combined"].radiance, expected, rtol=1.0e-14)
 
 
-@pytest.mark.parametrize(
-    "single_scatter_source",
-    [
-        sk.SingleScatterSource.Table,
-        sk.SingleScatterSource.DiscreteOrdinates,
-    ],
-)
-def test_geometry2d_rejects_nonexact_single_scatter_sources(
-    single_scatter_source: sk.SingleScatterSource,
-):
+def test_geometry2d_rejects_unsupported_single_scatter_sources():
     config = single_scatter_config()
-    config.single_scatter_source = single_scatter_source
+    config.single_scatter_source = sk.SingleScatterSource.DiscreteOrdinates
 
-    with pytest.raises(NotImplementedError, match="exact single scattering"):
+    with pytest.raises(NotImplementedError, match="exact and table single scattering"):
         sk.Engine(config, geometry2d(), parity_viewing())
 
 

--- a/tests/engine/test_geometry2d_transmission.py
+++ b/tests/engine/test_geometry2d_transmission.py
@@ -338,8 +338,10 @@ def test_geometry2d_engine_rejects_unsupported_sources_and_mismatched_geometry()
     viewing = sk.ViewingGeometry()
     viewing.add_ray(tangent_ray())
     unsupported = sk.Config()
-    unsupported.single_scatter_source = sk.SingleScatterSource.Table
-    with pytest.raises(NotImplementedError, match="supports exact single scattering"):
+    unsupported.single_scatter_source = sk.SingleScatterSource.DiscreteOrdinates
+    with pytest.raises(
+        NotImplementedError, match="supports exact and table single scattering"
+    ):
         sk.Engine(unsupported, geometry, viewing)
 
     config = transmission_config()

--- a/tests/engine/test_successive_orders_2d.py
+++ b/tests/engine/test_successive_orders_2d.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import sasktran2 as sk
+import xarray as xr
+
+EARTH_RADIUS_M = 6_372_000.0
+ALTITUDES_M = np.array([0.0, 10_000.0, 30_000.0])
+HORIZONTAL_ANGLES_RAD = np.array([-0.6, 0.0, 0.6])
+
+
+def successive_orders_config(
+    *,
+    num_stokes: int = 1,
+    single_scatter_source: sk.SingleScatterSource = sk.SingleScatterSource.Exact,
+    multiple_scatter_source: sk.MultipleScatterSource = (
+        sk.MultipleScatterSource.SuccessiveOrders
+    ),
+) -> sk.Config:
+    config = sk.Config()
+    config.num_threads = 1
+    config.num_stokes = num_stokes
+    config.num_streams = 4
+    config.num_singlescatter_moments = 4
+    config.single_scatter_source = single_scatter_source
+    config.multiple_scatter_source = multiple_scatter_source
+    config.occultation_source = sk.OccultationSource.NoSource
+    config.emission_source = sk.EmissionSource.NoSource
+    config.num_successive_orders_incoming = 6
+    config.num_successive_orders_outgoing = 6
+    config.num_successive_orders_iterations = 2
+    config.successive_orders_relative_tolerance = 0.0
+    config.successive_orders_absolute_tolerance = 0.0
+    config.delta_m_scaling = False
+    return config
+
+
+def geometry2d() -> sk.Geometry2D:
+    return sk.Geometry2D(
+        cos_sza=0.6,
+        solar_azimuth=0.0,
+        earth_radius_m=EARTH_RADIUS_M,
+        altitude_grid_m=ALTITUDES_M,
+        horizontal_angle_grid_radians=HORIZONTAL_ANGLES_RAD,
+    )
+
+
+def viewing_geometry() -> sk.ViewingGeometry:
+    viewing = sk.ViewingGeometry()
+    viewing.add_ray(
+        sk.GroundViewingSolar(
+            cos_sza=0.6,
+            relative_azimuth=0.2,
+            cos_viewing_zenith=0.7,
+            observer_altitude_m=100_000.0,
+        )
+    )
+    return viewing
+
+
+def atmosphere(
+    geometry: sk.Geometry2D,
+    config: sk.Config,
+    *,
+    horizontal_slope: float = 0.0,
+    calculate_derivatives: bool = False,
+) -> sk.Atmosphere:
+    result = sk.Atmosphere(
+        geometry,
+        config,
+        wavelengths_nm=np.array([500.0]),
+        calculate_derivatives=calculate_derivatives,
+    )
+    horizontal, altitude = np.meshgrid(
+        HORIZONTAL_ANGLES_RAD, ALTITUDES_M, indexing="ij"
+    )
+    result.storage.total_extinction[:, 0] = (
+        1.5e-5 * np.exp(-altitude / 15_000.0) * (1.0 + horizontal_slope * horizontal)
+    ).ravel()
+    result.storage.ssa[:, 0] = (0.88 - 0.08 * altitude / ALTITUDES_M[-1]).ravel()
+    result.leg_coeff.a1[0] = 1.0
+    result.leg_coeff.a1[2] = 0.3
+    if config.num_stokes == 3:
+        result.leg_coeff.a2[2] = 3.0
+        result.leg_coeff.b1[2] = -np.sqrt(6.0) / 2.0
+    result.surface.albedo[:] = 0.1
+    return result
+
+
+def calculate(
+    geometry: sk.Geometry2D,
+    *,
+    num_stokes: int = 1,
+    horizontal_slope: float = 0.0,
+    single_source: sk.SingleScatterSource = sk.SingleScatterSource.Exact,
+    source: sk.MultipleScatterSource = sk.MultipleScatterSource.SuccessiveOrders,
+) -> np.ndarray:
+    config = successive_orders_config(
+        num_stokes=num_stokes,
+        single_scatter_source=single_source,
+        multiple_scatter_source=source,
+    )
+    result = sk.Engine(config, geometry, viewing_geometry()).calculate_radiance(
+        atmosphere(geometry, config, horizontal_slope=horizontal_slope)
+    )
+    return result.radiance.values
+
+
+@pytest.mark.parametrize("num_stokes", [1, 3])
+def test_2d_successive_orders_is_finite_and_adds_multiple_scatter(num_stokes: int):
+    geometry = geometry2d()
+    multiple = calculate(
+        geometry,
+        num_stokes=num_stokes,
+        single_source=sk.SingleScatterSource.NoSource,
+    )
+
+    assert multiple.shape == (1, 1, num_stokes)
+    assert np.all(np.isfinite(multiple))
+    assert multiple[0, 0, 0] > 0.0
+    if num_stokes == 1:
+        combined = calculate(geometry, num_stokes=num_stokes)
+        assert np.all(np.isfinite(combined))
+        assert combined[0, 0, 0] > multiple[0, 0, 0]
+
+
+def test_2d_successive_orders_uses_horizontal_atmospheric_structure():
+    geometry = geometry2d()
+    config = successive_orders_config(
+        single_scatter_source=sk.SingleScatterSource.NoSource
+    )
+    engine = sk.Engine(config, geometry, viewing_geometry())
+    uniform_multiple = engine.calculate_radiance(
+        atmosphere(geometry, config)
+    ).radiance.values
+    varying_multiple = engine.calculate_radiance(
+        atmosphere(geometry, config, horizontal_slope=0.8)
+    ).radiance.values
+
+    assert not np.isclose(
+        varying_multiple.item(), uniform_multiple.item(), rtol=1.0e-4, atol=0.0
+    )
+
+
+def test_2d_successive_orders_native_products_are_adjoint():
+    geometry = geometry2d()
+    config = successive_orders_config(
+        single_scatter_source=sk.SingleScatterSource.NoSource
+    )
+    config.num_successive_orders_iterations = 60
+    config.successive_orders_relative_tolerance = 1.0e-11
+    config.successive_orders_absolute_tolerance = 1.0e-13
+    config.successive_orders_anderson_depth = 3
+    linearization = sk.Engine(config, geometry, viewing_geometry()).linearize(
+        atmosphere(geometry, config, horizontal_slope=0.4, calculate_derivatives=True)
+    )
+
+    assert linearization.backends == {
+        "jvp": sk.LinearizationBackend.Native,
+        "vjp": sk.LinearizationBackend.Native,
+    }
+    tangent = linearization.tangent_template[["extinction", "ssa"]]
+    tangent["extinction"].data[:] = np.linspace(
+        -2.0e-7, 3.0e-7, tangent["extinction"].size
+    ).reshape(tangent["extinction"].shape)
+    tangent["ssa"].data[:] = np.linspace(-0.015, 0.02, tangent["ssa"].size).reshape(
+        tangent["ssa"].shape
+    )
+    jvp = linearization.jvp(tangent)
+
+    cotangent = xr.ones_like(linearization.value)
+    gradient = linearization.vjp(cotangent, parameters=("extinction", "ssa"))
+    lhs = float((jvp * cotangent).sum())
+    rhs = float(
+        (tangent["extinction"] * gradient["extinction"]).sum()
+        + (tangent["ssa"] * gradient["ssa"]).sum()
+    )
+
+    assert np.all(np.isfinite(jvp))
+    assert np.all(np.isfinite(gradient["extinction"]))
+    assert np.all(np.isfinite(gradient["ssa"]))
+    np.testing.assert_allclose(lhs, rhs, rtol=3.0e-8, atol=3.0e-11)
+
+
+def test_2d_successive_orders_rejects_diffuse_refraction():
+    config = successive_orders_config()
+    config.multiple_scatter_refraction = True
+
+    with pytest.raises(NotImplementedError, match="diffuse-ray refraction"):
+        sk.Engine(config, geometry2d(), viewing_geometry())
+
+
+def test_2d_rejects_legacy_successive_orders_source():
+    config = successive_orders_config(
+        multiple_scatter_source=sk.MultipleScatterSource.SuccessiveOrdersLegacy
+    )
+
+    with pytest.raises(NotImplementedError, match="successive-orders"):
+        sk.Engine(config, geometry2d(), viewing_geometry())

--- a/tests/engine/test_successive_orders_2d.py
+++ b/tests/engine/test_successive_orders_2d.py
@@ -191,6 +191,244 @@ def test_2d_successive_orders_rejects_diffuse_refraction():
         sk.Engine(config, geometry2d(), viewing_geometry())
 
 
+def test_2d_successive_orders_supports_solar_refraction():
+    geometry = geometry2d()
+    geometry.refractive_index = np.array([1.001, 1.0004, 1.0])
+
+    straight_config = successive_orders_config(
+        single_scatter_source=sk.SingleScatterSource.NoSource
+    )
+    refracted_config = successive_orders_config(
+        single_scatter_source=sk.SingleScatterSource.NoSource
+    )
+    refracted_config.solar_refraction = True
+
+    straight = (
+        sk.Engine(straight_config, geometry, viewing_geometry())
+        .calculate_radiance(atmosphere(geometry, straight_config))
+        .radiance.values
+    )
+    refracted = (
+        sk.Engine(refracted_config, geometry, viewing_geometry())
+        .calculate_radiance(atmosphere(geometry, refracted_config))
+        .radiance.values
+    )
+
+    assert np.all(np.isfinite(refracted))
+    assert not np.allclose(refracted, straight, rtol=1.0e-8, atol=0.0)
+
+    refracted_config.num_successive_orders_iterations = 60
+    refracted_config.successive_orders_relative_tolerance = 1.0e-11
+    refracted_config.successive_orders_absolute_tolerance = 1.0e-13
+    refracted_config.successive_orders_anderson_depth = 3
+    linearization = sk.Engine(refracted_config, geometry, viewing_geometry()).linearize(
+        atmosphere(
+            geometry,
+            refracted_config,
+            horizontal_slope=0.3,
+            calculate_derivatives=True,
+        )
+    )
+    tangent = linearization.tangent_template[["extinction"]]
+    tangent["extinction"].data[:] = np.linspace(
+        -2.0e-7, 3.0e-7, tangent["extinction"].size
+    ).reshape(tangent["extinction"].shape)
+    cotangent = xr.ones_like(linearization.value)
+    jvp = linearization.jvp(tangent)
+    gradient = linearization.vjp(cotangent, parameters=("extinction",))
+    np.testing.assert_allclose(
+        float((jvp * cotangent).sum()),
+        float((tangent["extinction"] * gradient["extinction"]).sum()),
+        rtol=3.0e-8,
+        atol=3.0e-11,
+    )
+
+
+def test_2d_successive_orders_unity_solar_refraction_matches_straight_paths():
+    geometry = geometry2d()
+    straight_config = successive_orders_config(
+        single_scatter_source=sk.SingleScatterSource.NoSource
+    )
+    refracted_config = successive_orders_config(
+        single_scatter_source=sk.SingleScatterSource.NoSource
+    )
+    refracted_config.solar_refraction = True
+
+    straight = (
+        sk.Engine(straight_config, geometry, viewing_geometry())
+        .calculate_radiance(atmosphere(geometry, straight_config))
+        .radiance.values
+    )
+    refracted = (
+        sk.Engine(refracted_config, geometry, viewing_geometry())
+        .calculate_radiance(atmosphere(geometry, refracted_config))
+        .radiance.values
+    )
+
+    np.testing.assert_allclose(refracted, straight, rtol=2.0e-12, atol=1.0e-14)
+
+
+@pytest.mark.parametrize(
+    "single_source",
+    [sk.SingleScatterSource.Exact, sk.SingleScatterSource.Table],
+)
+@pytest.mark.parametrize("num_stokes", [1, 3])
+def test_2d_single_scatter_supports_solar_refraction(single_source, num_stokes):
+    geometry = geometry2d()
+    geometry.refractive_index = np.array([1.001, 1.0004, 1.0])
+    straight_config = successive_orders_config(
+        num_stokes=num_stokes,
+        single_scatter_source=single_source,
+        multiple_scatter_source=sk.MultipleScatterSource.NoSource,
+    )
+    refracted_config = successive_orders_config(
+        num_stokes=num_stokes,
+        single_scatter_source=single_source,
+        multiple_scatter_source=sk.MultipleScatterSource.NoSource,
+    )
+    refracted_config.solar_refraction = True
+
+    straight = (
+        sk.Engine(straight_config, geometry, viewing_geometry())
+        .calculate_radiance(atmosphere(geometry, straight_config))
+        .radiance.values
+    )
+    refracted = (
+        sk.Engine(refracted_config, geometry, viewing_geometry())
+        .calculate_radiance(atmosphere(geometry, refracted_config))
+        .radiance.values
+    )
+
+    assert np.all(np.isfinite(refracted))
+    assert refracted[0, 0, 0] > 0.0
+    assert not np.allclose(refracted, straight, rtol=1.0e-8, atol=0.0)
+
+
+@pytest.mark.parametrize(
+    "single_source",
+    [sk.SingleScatterSource.Exact, sk.SingleScatterSource.Table],
+)
+@pytest.mark.parametrize("num_stokes", [1, 3])
+def test_2d_single_scatter_unity_solar_refraction_matches_straight(
+    single_source, num_stokes
+):
+    geometry = geometry2d()
+    straight_config = successive_orders_config(
+        num_stokes=num_stokes,
+        single_scatter_source=single_source,
+        multiple_scatter_source=sk.MultipleScatterSource.NoSource,
+    )
+    refracted_config = successive_orders_config(
+        num_stokes=num_stokes,
+        single_scatter_source=single_source,
+        multiple_scatter_source=sk.MultipleScatterSource.NoSource,
+    )
+    refracted_config.solar_refraction = True
+
+    straight = (
+        sk.Engine(straight_config, geometry, viewing_geometry())
+        .calculate_radiance(atmosphere(geometry, straight_config))
+        .radiance.values
+    )
+    refracted = (
+        sk.Engine(refracted_config, geometry, viewing_geometry())
+        .calculate_radiance(atmosphere(geometry, refracted_config))
+        .radiance.values
+    )
+
+    np.testing.assert_allclose(refracted, straight, rtol=2.0e-12, atol=1.0e-14)
+
+
+@pytest.mark.parametrize("num_stokes", [1, 3])
+def test_2d_table_single_scatter_native_products_are_adjoint(num_stokes):
+    geometry = geometry2d()
+    geometry.refractive_index = np.array([1.001, 1.0004, 1.0])
+    config = successive_orders_config(
+        num_stokes=num_stokes,
+        single_scatter_source=sk.SingleScatterSource.Table,
+        multiple_scatter_source=sk.MultipleScatterSource.NoSource,
+    )
+    config.solar_refraction = True
+    linearization = sk.Engine(config, geometry, viewing_geometry()).linearize(
+        atmosphere(
+            geometry,
+            config,
+            horizontal_slope=0.35,
+            calculate_derivatives=True,
+        )
+    )
+
+    assert linearization.backends == {
+        "jvp": sk.LinearizationBackend.Native,
+        "vjp": sk.LinearizationBackend.Native,
+    }
+    with pytest.raises(NotImplementedError, match="cannot materialize"):
+        _ = linearization.jacobian
+    tangent = linearization.tangent_template[["extinction", "ssa"]]
+    tangent["extinction"].data[:] = np.linspace(
+        -2.0e-7, 3.0e-7, tangent["extinction"].size
+    ).reshape(tangent["extinction"].shape)
+    tangent["ssa"].data[:] = np.linspace(-0.015, 0.02, tangent["ssa"].size).reshape(
+        tangent["ssa"].shape
+    )
+    cotangent = xr.ones_like(linearization.value)
+    jvp = linearization.jvp(tangent)
+
+    finite_difference_engine = sk.Engine(config, geometry, viewing_geometry())
+    epsilon = 1.0e-3
+
+    def perturbed_radiance(sign: float) -> xr.DataArray:
+        perturbed = atmosphere(
+            geometry,
+            config,
+            horizontal_slope=0.35,
+            calculate_derivatives=False,
+        )
+        perturbed.storage.total_extinction[:] += (
+            sign
+            * epsilon
+            * tangent["extinction"].values.reshape(
+                perturbed.storage.total_extinction.shape
+            )
+        )
+        perturbed.storage.ssa[:] += (
+            sign * epsilon * tangent["ssa"].values.reshape(perturbed.storage.ssa.shape)
+        )
+        return finite_difference_engine.calculate_radiance(perturbed).radiance
+
+    finite_difference = (perturbed_radiance(1.0) - perturbed_radiance(-1.0)) / (
+        2.0 * epsilon
+    )
+    xr.testing.assert_allclose(jvp, finite_difference, rtol=2.0e-7, atol=1.0e-12)
+
+    gradient = linearization.vjp(cotangent, parameters=("extinction", "ssa"))
+
+    np.testing.assert_allclose(
+        float((jvp * cotangent).sum()),
+        float(
+            (tangent["extinction"] * gradient["extinction"]).sum()
+            + (tangent["ssa"] * gradient["ssa"]).sum()
+        ),
+        rtol=3.0e-8,
+        atol=3.0e-11,
+    )
+
+
+def test_2d_table_single_scatter_can_share_solar_table_with_successive_orders():
+    geometry = geometry2d()
+    geometry.refractive_index = np.array([1.001, 1.0004, 1.0])
+    config = successive_orders_config(
+        single_scatter_source=sk.SingleScatterSource.Table
+    )
+    config.solar_refraction = True
+    result = sk.Engine(config, geometry, viewing_geometry()).calculate_radiance(
+        atmosphere(geometry, config, horizontal_slope=0.2)
+    )
+
+    assert np.all(np.isfinite(result.radiance.values))
+    assert result.radiance.values.item() > 0.0
+
+
 def test_2d_rejects_legacy_successive_orders_source():
     config = successive_orders_config(
         multiple_scatter_source=sk.MultipleScatterSource.SuccessiveOrdersLegacy

--- a/tests/engine/test_successive_orders_2d.py
+++ b/tests/engine/test_successive_orders_2d.py
@@ -429,6 +429,45 @@ def test_2d_table_single_scatter_can_share_solar_table_with_successive_orders():
     assert result.radiance.values.item() > 0.0
 
 
+@pytest.mark.parametrize(
+    ("single_source", "multiple_source"),
+    [
+        (sk.SingleScatterSource.Table, sk.MultipleScatterSource.NoSource),
+        (
+            sk.SingleScatterSource.NoSource,
+            sk.MultipleScatterSource.SuccessiveOrders,
+        ),
+    ],
+)
+def test_2d_solar_table_has_stable_tangent_topology(single_source, multiple_source):
+    altitude_grid_m = np.linspace(0.0, 80_000.0, 80)
+    horizontal_grid = np.linspace(-0.4, 0.4, 40)
+    geometry = sk.Geometry2D(
+        cos_sza=0.15,
+        solar_azimuth=0.25,
+        earth_radius_m=EARTH_RADIUS_M,
+        altitude_grid_m=altitude_grid_m,
+        horizontal_angle_grid_radians=horizontal_grid,
+    )
+    viewing = sk.ViewingGeometry()
+    viewing.add_ray(
+        sk.TangentAltitude(
+            tangent_altitude_m=20_000.0,
+            observer_altitude_m=150_000.0,
+            horizontal_angle_radians=-0.3,
+            viewing_azimuth_radians=0.0,
+        )
+    )
+    config = successive_orders_config(
+        single_scatter_source=single_source,
+        multiple_scatter_source=multiple_source,
+    )
+    config.num_sza = 5
+    config.successive_orders_altitude_grid_m = np.linspace(1_000.0, 79_000.0, 25)
+
+    sk.Engine(config, geometry, viewing)
+
+
 def test_2d_rejects_legacy_successive_orders_source():
     config = successive_orders_config(
         multiple_scatter_source=sk.MultipleScatterSource.SuccessiveOrdersLegacy

--- a/tests/geometry/test_geometry2d.py
+++ b/tests/geometry/test_geometry2d.py
@@ -54,6 +54,24 @@ def test_geometry2d_refractive_index_is_mutable_and_assignable():
 
 
 @pytest.mark.parametrize(
+    ("profile", "message"),
+    [
+        (np.ones(2), "requires 3 values"),
+        (np.array([1.0, np.nan, 1.0]), "finite and positive"),
+        (np.array([1.0, 0.0, 1.0]), "finite and positive"),
+        (np.array([1.0, -1.0, 1.0]), "finite and positive"),
+    ],
+)
+def test_geometry2d_refractive_index_assignment_is_validated(profile, message):
+    geometry = geometry2d()
+
+    with pytest.raises(ValueError, match=message):
+        geometry.refractive_index = profile
+
+    np.testing.assert_array_equal(geometry.refractive_index, np.ones(3))
+
+
+@pytest.mark.parametrize(
     "interpolation_method",
     [
         sk.InterpolationMethod.LinearInterpolation,

--- a/tests/geometry/test_geometry2d.py
+++ b/tests/geometry/test_geometry2d.py
@@ -28,6 +28,7 @@ def test_geometry2d_constructor_grids_shape_and_indexing():
         geometry.horizontal_angles(), np.array([-0.3, 0.0, 0.4, 0.7])
     )
     assert geometry.shape == (4, 3)
+    np.testing.assert_array_equal(geometry.refractive_index, np.ones(3))
 
     for horizontal_index in range(4):
         for altitude_index in range(3):
@@ -39,6 +40,17 @@ def test_geometry2d_constructor_grids_shape_and_indexing():
         geometry.location_index(3, 0)
     with pytest.raises(RuntimeError):
         geometry.location_index(0, 4)
+
+
+def test_geometry2d_refractive_index_is_mutable_and_assignable():
+    geometry = geometry2d()
+    profile = np.array([1.0003, 1.0001, 1.0])
+
+    geometry.refractive_index = profile
+    np.testing.assert_array_equal(geometry.refractive_index, profile)
+
+    geometry.refractive_index[:] = profile[::-1]
+    np.testing.assert_array_equal(geometry.refractive_index, profile[::-1])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Enable the modern `SuccessiveOrders` source for `Geometry2D` with independent horizontal and vertical source grids.
- Add compact successive-orders ray geometry, transport, interpolation, and native JVP/VJP paths to reduce retained memory and make repeated atmosphere updates fast.
- Add a shared 3D solar characteristic table over altitude, solar zenith angle, and off-plane azimuth. The table traces top-of-atmosphere chords inward, supports solar refraction, and can be used by both exact/table single scatter and successive orders.
- Keep the new 2D behavior isolated in the successive-orders source where practical, with focused Python, C++, Rust, documentation, and benchmark coverage.

## Implementation notes

- Geometry-only transport and interpolation are prepared during setup and reused when the atmosphere changes.
- Solar optical depth is accumulated along inward characteristics, including refracted solar rays.
- Exact shell tangencies are normalized across azimuth planes to avoid side-label topology failures from Cartesian roundoff.
- The `Geometry2D` refractive-index FFI now has const-correct immutable and mutable access, with Python validation for length and finite positive values.

## Benchmark

Measured locally with one wavelength and one thread:

| Item | Value |
| --- | ---: |
| Atmosphere grid | 40 horizontal × 80 vertical |
| Source grid | 5 horizontal × 25 vertical |
| Lines of sight | 40 × 60 = 2400 |
| Incoming/outgoing angular points | 110 |
| Setup | 2.281 s |
| Changed-atmosphere linearize median | 0.03682 s |
| Repeated same-atmosphere VJP median | 0.04491 s |
| Changed-atmosphere linearize + VJP median | 0.07506 s |
| Baseline process RSS | 192.3 MiB |
| Retained process RSS | 859.4 MiB |
| Retained RSS delta | 667.1 MiB |
| Peak process RSS | 867.8 MiB |

The ASV workload is included in `asv_bench/benchmarks/successive_orders_2d.py` and is marked as a slow benchmark.

## Validation

- `pixi run build`
- `pixi run pre-commit`
- Full Python suite: 528 passed, 15 skipped
- Full C++ suite: 231 test cases and 296,128 assertions passed
- Full Rust workspace suite: core, bindings, and integration suites passed; performance-only cases remain ignored
- `RUSTFLAGS=-Dwarnings cargo clippy --all-targets --all-features`
- Documentation build passed with 13 pre-existing warnings

## Current limitations

- Diffuse source rays in `Geometry2D` remain straight; solar refraction is supported separately.
- Refracted viewing LOS and flux observers are not supported for this source geometry.
- The compact 2D source table uses native JVP/VJP products instead of materializing a dense full Jacobian.