### PR TITLE
Add a pure-Rust, fully linearized MT_CKD continuum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "core_rust"
-version = "2026.8.0"
+version = "2026.8.1"
 dependencies = [
  "anyhow",
  "nalgebra",

--- a/docs/sphinx/source/api/constituents.rst
+++ b/docs/sphinx/source/api/constituents.rst
@@ -17,6 +17,7 @@ Constituents
     sasktran2.constituent.GaussianHeightExtinction
     sasktran2.constituent.MonochromaticVolumeEmissionRate
     sasktran2.constituent.Manual
+    sasktran2.continuum.MTCKDContinuum
 
 .. _constituents_api_brdf:
 

--- a/rust/sasktran2-py-ext/src/continuum.rs
+++ b/rust/sasktran2-py-ext/src/continuum.rs
@@ -4,7 +4,8 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use rayon::prelude::*;
 use sasktran2_rs::continuum::mt_ckd::{
-    calculate, calculate_linearized, AtmosphericState, LinearizedSpectrum, MtCkd, OUTPUT_POINTS,
+    AtmosphericState, LinearizedSpectrum, MtCkd, OUTPUT_POINTS, calculate, calculate_absorption,
+    calculate_absorption_linearized, calculate_linearized,
 };
 use std::sync::OnceLock;
 
@@ -78,6 +79,7 @@ pub fn mt_ckd_py<'py>(
     vmr_co2: PyReadonlyArray1<'py, f64>,
     vmr_o3: PyReadonlyArray1<'py, f64>,
     data_file: &str,
+    include_rayleigh: bool,
 ) -> PyResult<Bound<'py, PyArray2<f64>>> {
     let model = model(data_file)?;
     let states = states(pressure_pa, temperature_k, vmr_h2o, vmr_co2, vmr_o3)?;
@@ -85,7 +87,13 @@ pub fn mt_ckd_py<'py>(
     let spectra: Vec<_> = py.detach(|| {
         states
             .into_par_iter()
-            .map(|state| calculate(model, state))
+            .map(|state| {
+                if include_rayleigh {
+                    calculate(model, state)
+                } else {
+                    calculate_absorption(model, state)
+                }
+            })
             .collect()
     });
     Ok(array_from_rows(spectra, row_count).into_pyarray(py))
@@ -111,6 +119,7 @@ pub fn mt_ckd_linearized_py<'py>(
     vmr_co2: PyReadonlyArray1<'py, f64>,
     vmr_o3: PyReadonlyArray1<'py, f64>,
     data_file: &str,
+    include_rayleigh: bool,
 ) -> PyResult<LinearizedArrays<'py>> {
     let model = model(data_file)?;
     let states = states(pressure_pa, temperature_k, vmr_h2o, vmr_co2, vmr_o3)?;
@@ -118,7 +127,13 @@ pub fn mt_ckd_linearized_py<'py>(
     let spectra: Vec<LinearizedSpectrum> = py.detach(|| {
         states
             .into_par_iter()
-            .map(|state| calculate_linearized(model, state))
+            .map(|state| {
+                if include_rayleigh {
+                    calculate_linearized(model, state)
+                } else {
+                    calculate_absorption_linearized(model, state)
+                }
+            })
             .collect()
     });
 

--- a/rust/sasktran2-py-ext/src/continuum.rs
+++ b/rust/sasktran2-py-ext/src/continuum.rs
@@ -1,0 +1,144 @@
+use ndarray::Array2;
+use numpy::{IntoPyArray, PyArray2, PyReadonlyArray1};
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use rayon::prelude::*;
+use sasktran2_rs::continuum::mt_ckd::{
+    calculate, calculate_linearized, AtmosphericState, LinearizedSpectrum, MtCkd, OUTPUT_POINTS,
+};
+use std::sync::OnceLock;
+
+fn model(data_file: &str) -> PyResult<&'static MtCkd> {
+    static MODEL: OnceLock<MtCkd> = OnceLock::new();
+
+    if MODEL.get().is_none() {
+        let loaded = MtCkd::from_file(data_file).map_err(|error| {
+            PyValueError::new_err(format!("failed to load MT_CKD coefficient data: {error}"))
+        })?;
+        let _ = MODEL.set(loaded);
+    }
+
+    Ok(MODEL.get().expect("MT_CKD model must be initialized"))
+}
+
+fn states(
+    pressure_pa: PyReadonlyArray1<'_, f64>,
+    temperature_k: PyReadonlyArray1<'_, f64>,
+    vmr_h2o: PyReadonlyArray1<'_, f64>,
+    vmr_co2: PyReadonlyArray1<'_, f64>,
+    vmr_o3: PyReadonlyArray1<'_, f64>,
+) -> PyResult<Vec<AtmosphericState>> {
+    let pressure_pa = pressure_pa.as_array().to_vec();
+    let temperature_k = temperature_k.as_array().to_vec();
+    let vmr_h2o = vmr_h2o.as_array().to_vec();
+    let vmr_co2 = vmr_co2.as_array().to_vec();
+    let vmr_o3 = vmr_o3.as_array().to_vec();
+    let length = pressure_pa.len();
+    if [
+        temperature_k.len(),
+        vmr_h2o.len(),
+        vmr_co2.len(),
+        vmr_o3.len(),
+    ]
+    .into_iter()
+    .any(|candidate| candidate != length)
+    {
+        return Err(PyValueError::new_err(
+            "pressure_pa, temperature_k, vmr_h2o, vmr_co2, and vmr_o3 must have the same length",
+        ));
+    }
+
+    Ok((0..length)
+        .map(|index| AtmosphericState {
+            pressure_pa: pressure_pa[index],
+            temperature_k: temperature_k[index],
+            h2o_vmr: vmr_h2o[index],
+            co2_vmr: vmr_co2[index],
+            o3_vmr: vmr_o3[index],
+        })
+        .collect())
+}
+
+fn array_from_values(values: Vec<f64>, row_count: usize) -> Array2<f64> {
+    Array2::from_shape_vec((row_count, OUTPUT_POINTS), values).unwrap()
+}
+
+fn array_from_rows(rows: impl IntoIterator<Item = Vec<f64>>, row_count: usize) -> Array2<f64> {
+    array_from_values(rows.into_iter().flatten().collect(), row_count)
+}
+
+/// MT_CKD 4.3 extinction coefficient on the fixed 1,991-point grid.
+#[pyfunction(name = "_mt_ckd")]
+#[allow(clippy::too_many_arguments)]
+pub fn mt_ckd_py<'py>(
+    py: Python<'py>,
+    pressure_pa: PyReadonlyArray1<'py, f64>,
+    temperature_k: PyReadonlyArray1<'py, f64>,
+    vmr_h2o: PyReadonlyArray1<'py, f64>,
+    vmr_co2: PyReadonlyArray1<'py, f64>,
+    vmr_o3: PyReadonlyArray1<'py, f64>,
+    data_file: &str,
+) -> PyResult<Bound<'py, PyArray2<f64>>> {
+    let model = model(data_file)?;
+    let states = states(pressure_pa, temperature_k, vmr_h2o, vmr_co2, vmr_o3)?;
+    let row_count = states.len();
+    let spectra: Vec<_> = py.detach(|| {
+        states
+            .into_par_iter()
+            .map(|state| calculate(model, state))
+            .collect()
+    });
+    Ok(array_from_rows(spectra, row_count).into_pyarray(py))
+}
+
+type LinearizedArrays<'py> = (
+    Bound<'py, PyArray2<f64>>,
+    Bound<'py, PyArray2<f64>>,
+    Bound<'py, PyArray2<f64>>,
+    Bound<'py, PyArray2<f64>>,
+    Bound<'py, PyArray2<f64>>,
+    Bound<'py, PyArray2<f64>>,
+);
+
+/// Extinction coefficient followed by analytic Jacobians for P, T, H2O, CO2, and O3.
+#[pyfunction(name = "_mt_ckd_linearized")]
+#[allow(clippy::too_many_arguments)]
+pub fn mt_ckd_linearized_py<'py>(
+    py: Python<'py>,
+    pressure_pa: PyReadonlyArray1<'py, f64>,
+    temperature_k: PyReadonlyArray1<'py, f64>,
+    vmr_h2o: PyReadonlyArray1<'py, f64>,
+    vmr_co2: PyReadonlyArray1<'py, f64>,
+    vmr_o3: PyReadonlyArray1<'py, f64>,
+    data_file: &str,
+) -> PyResult<LinearizedArrays<'py>> {
+    let model = model(data_file)?;
+    let states = states(pressure_pa, temperature_k, vmr_h2o, vmr_co2, vmr_o3)?;
+    let row_count = states.len();
+    let spectra: Vec<LinearizedSpectrum> = py.detach(|| {
+        states
+            .into_par_iter()
+            .map(|state| calculate_linearized(model, state))
+            .collect()
+    });
+
+    let mut fields: [Vec<f64>; 6] =
+        std::array::from_fn(|_| Vec::with_capacity(row_count * OUTPUT_POINTS));
+    for spectrum in spectra {
+        fields[0].extend(spectrum.extinction);
+        fields[1].extend(spectrum.d_pressure_pa);
+        fields[2].extend(spectrum.d_temperature_k);
+        fields[3].extend(spectrum.d_h2o_vmr);
+        fields[4].extend(spectrum.d_co2_vmr);
+        fields[5].extend(spectrum.d_o3_vmr);
+    }
+    let [extinction, d_pressure, d_temperature, d_h2o, d_co2, d_o3] = fields;
+    Ok((
+        array_from_values(extinction, row_count).into_pyarray(py),
+        array_from_values(d_pressure, row_count).into_pyarray(py),
+        array_from_values(d_temperature, row_count).into_pyarray(py),
+        array_from_values(d_h2o, row_count).into_pyarray(py),
+        array_from_values(d_co2, row_count).into_pyarray(py),
+        array_from_values(d_o3, row_count).into_pyarray(py),
+    ))
+}

--- a/rust/sasktran2-py-ext/src/lib.rs
+++ b/rust/sasktran2-py-ext/src/lib.rs
@@ -6,6 +6,7 @@ mod brdf;
 mod common;
 mod config;
 mod constituent;
+mod continuum;
 mod derivative_mapping;
 mod engine;
 mod geodetic;
@@ -113,6 +114,8 @@ fn _core_rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Information functions
     m.add_function(wrap_pyfunction!(common::openmp_support_enabled, m)?)?;
     m.add_function(wrap_pyfunction!(common::lto_test, m)?)?;
+    m.add_function(wrap_pyfunction!(continuum::mt_ckd_py, m)?)?;
+    m.add_function(wrap_pyfunction!(continuum::mt_ckd_linearized_py, m)?)?;
 
     // rebasis
     m.add_class::<pyrebasis::basis::PyBasis>()?;

--- a/rust/sasktran2-rs/src/continuum/MT_CKD_LICENSE.txt
+++ b/rust/sasktran2-rs/src/continuum/MT_CKD_LICENSE.txt
@@ -1,0 +1,18 @@
+Copyright ©, Atmospheric and Environmental Research, Inc., 2022
+
+All rights reserved. This source code was developed as part of the LBLRTM
+software and is designed for scientific and research purposes. Atmospheric
+and Environmental Research Inc. (AER) grants USER the right to download,
+install, use and copy this software and data for scientific and research
+purposes only. This software and data may be redistributed as long as this
+copyright notice is reproduced on any copy made and appropriate acknowledgment
+is given to AER. This software and data or any modified version of this
+software and data may not be incorporated into proprietary software or data or
+commercial software or data offered for sale without the express written
+consent of AER. This software and data are provided as is without any expressed
+or implied warranties.
+
+Address questions to: aer_contnm@aer.com
+
+General reference: Mlawer et al. (2012),
+https://doi.org/10.1098/rsta.2011.0295

--- a/rust/sasktran2-rs/src/continuum/README.md
+++ b/rust/sasktran2-rs/src/continuum/README.md
@@ -15,6 +15,12 @@ Its SHA-256 is:
 
 `06b5600ecb0f5a3417c46d226555bc516f5a55ae93b19b6e7b5431e50f8f0459`
 
+The reproducible extraction and validation recipe is maintained in
+`tools/databases/mt-ckd/`. It requires a separately obtained, licensed MT_CKD
+checkout and an externally built compatible probe library; no upstream wrapper
+source is redistributed in this repository. The tool writes the artifacts
+directly to a caller-selected directory.
+
 The upstream double-precision validation spectra are stored only on the data
 server as `continuum/mt_ckd_4_3_reference.bin`, with SHA-256:
 
@@ -31,6 +37,10 @@ on the native 0 to 19,900 cm^-1 grid at 10 cm^-1 spacing. Internally MT_CKD is
 evaluated for a fixed one-metre column, making its optical depth numerically
 equal to extinction in m^-1. Geometric path length is therefore deliberately
 not part of the continuum API.
+
+The low-level compatibility functions include MT_CKD's historical Rayleigh
+term by default. `MTCKDContinuum` requests absorption only so SASKTRAN2's
+dedicated Rayleigh constituent can supply scattering without double counting.
 
 The scalar evaluator uses ordinary `f64` arithmetic. The linearized evaluator
 uses the same generic kernel with forward-mode dual numbers for pressure,

--- a/rust/sasktran2-rs/src/continuum/README.md
+++ b/rust/sasktran2-rs/src/continuum/README.md
@@ -1,0 +1,37 @@
+# MT_CKD 4.3 spectral data
+
+The pure-Rust evaluator intentionally contains no AER coefficient data. On
+first use, the Python interface downloads the separately licensed table through
+`StandardDatabase` using this key:
+
+`continuum/mt_ckd_4_3.bin`
+
+The server copy is staged at
+`/Volumes/SasktranFiles/sasktran2_db/v_latest/continuum/mt_ckd_4_3.bin` and is
+served from the corresponding `arg.usask.ca/sasktranfiles` URL. It contains 22
+little-endian `f64` coefficient fields generated from AER-RC/MT_CKD tag `4.3`
+(commit `1dad6e29363a2dc75d0eb642b7321b5db51079cc`) and its pinned LBLRTM source.
+Its SHA-256 is:
+
+`06b5600ecb0f5a3417c46d226555bc516f5a55ae93b19b6e7b5431e50f8f0459`
+
+The upstream double-precision validation spectra are stored only on the data
+server as `continuum/mt_ckd_4_3_reference.bin`, with SHA-256:
+
+`0fdc39229ae020f2979511acfc81600ddfaa0b9bc0bbb03bb86a5ce3d01a9760`
+
+The AER terms are reproduced in `MT_CKD_LICENSE.txt`, printed before the first
+coefficient download, and downloaded beside the cached table. The coefficient
+and validation data are not covered by SASKTRAN2's MIT license.
+
+## Evaluator convention
+
+The Rust and Python APIs return 1,991 extinction-coefficient samples in m^-1
+on the native 0 to 19,900 cm^-1 grid at 10 cm^-1 spacing. Internally MT_CKD is
+evaluated for a fixed one-metre column, making its optical depth numerically
+equal to extinction in m^-1. Geometric path length is therefore deliberately
+not part of the continuum API.
+
+The scalar evaluator uses ordinary `f64` arithmetic. The linearized evaluator
+uses the same generic kernel with forward-mode dual numbers for pressure,
+temperature, H2O VMR, CO2 VMR, and O3 VMR.

--- a/rust/sasktran2-rs/src/continuum/mod.rs
+++ b/rust/sasktran2-rs/src/continuum/mod.rs
@@ -1,0 +1,7 @@
+//! Molecular continuum absorption models.
+//!
+//! This module is intentionally independent of the SASKTRAN2 engine and FFI
+//! layers. Continuum models operate on scalar atmospheric states and return
+//! spectra together with their atmospheric Jacobians.
+
+pub mod mt_ckd;

--- a/rust/sasktran2-rs/src/continuum/mt_ckd.rs
+++ b/rust/sasktran2-rs/src/continuum/mt_ckd.rs
@@ -1,0 +1,740 @@
+//! Pure-Rust implementation of the MT_CKD 4.3 continuum.
+//!
+//! Pressure is in Pa, temperature in K, and volume mixing ratios are unitless.
+//! The result is an extinction coefficient in m^-1 on the 1,991-point MT_CKD
+//! grid from 0 through 19,900 cm^-1. All five atmospheric derivatives are
+//! propagated analytically in the same evaluation when requested.
+
+use std::fmt;
+use std::fs;
+use std::io;
+use std::ops::{Add, Div, Mul, Neg, Sub};
+use std::path::Path;
+
+/// Number of useful MT_CKD samples from 0 through 19,900 cm^-1.
+pub const SPECTRAL_POINTS: usize = 1991;
+/// Number of values returned by the `mt_ckd` interface.
+pub const OUTPUT_POINTS: usize = SPECTRAL_POINTS;
+/// Wavenumber represented by output index zero.
+pub const OUTPUT_WAVENUMBER_START: f64 = 0.0;
+/// Fixed-grid spacing in cm^-1.
+pub const WAVENUMBER_SPACING: f64 = 10.0;
+
+const N_INPUTS: usize = 5;
+const N_FIELDS: usize = 22;
+const HEADER_BYTES: usize = 16;
+const RADCN2: f64 = 1.438_775_2;
+const ALOSMT: f64 = 2.686_777_5e19;
+const XLOSMT: f64 = 2.686_75e19;
+// MT_CKD computes optical depth from a column amount. A one-metre column makes
+// that optical depth numerically equal to the extinction coefficient in m^-1.
+const REFERENCE_PATH_LENGTH_CM: f64 = 100.0;
+const N2_FUNDAMENTAL_POINTS: usize = 228;
+const N2_FUNDAMENTAL_V1: f64 = 1_997.784_896;
+const N2_FUNDAMENTAL_DV: f64 = 3.981_461_525;
+const TABLE_MAGIC: &[u8; 8] = b"MTCKD43\0";
+
+#[derive(Clone, Copy, Debug)]
+#[repr(usize)]
+enum Input {
+    Pressure = 0,
+    Temperature = 1,
+    H2O = 2,
+    CO2 = 3,
+    O3 = 4,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct Dual {
+    value: f64,
+    derivative: [f64; N_INPUTS],
+}
+
+trait Scalar:
+    Copy
+    + Add<Output = Self>
+    + Add<f64, Output = Self>
+    + Sub<Output = Self>
+    + Sub<f64, Output = Self>
+    + Mul<Output = Self>
+    + Mul<f64, Output = Self>
+    + Div<Output = Self>
+    + Div<f64, Output = Self>
+    + Neg<Output = Self>
+{
+    fn constant(value: f64) -> Self;
+    fn value(self) -> f64;
+    fn exp(self) -> Self;
+    fn powf(self, exponent: f64) -> Self;
+}
+
+impl Scalar for f64 {
+    fn constant(value: f64) -> Self {
+        value
+    }
+
+    fn value(self) -> f64 {
+        self
+    }
+
+    fn exp(self) -> Self {
+        f64::exp(self)
+    }
+
+    fn powf(self, exponent: f64) -> Self {
+        f64::powf(self, exponent)
+    }
+}
+
+impl Dual {
+    fn constant(value: f64) -> Self {
+        Self {
+            value,
+            derivative: [0.0; N_INPUTS],
+        }
+    }
+
+    fn variable(value: f64, input: Input) -> Self {
+        let mut derivative = [0.0; N_INPUTS];
+        derivative[input as usize] = 1.0;
+        Self { value, derivative }
+    }
+
+    fn exp(self) -> Self {
+        let value = self.value.exp();
+        Self {
+            value,
+            derivative: self.derivative.map(|d| d * value),
+        }
+    }
+
+    fn powf(self, exponent: f64) -> Self {
+        let value = self.value.powf(exponent);
+        let scale = exponent * self.value.powf(exponent - 1.0);
+        Self {
+            value,
+            derivative: self.derivative.map(|d| d * scale),
+        }
+    }
+}
+
+impl Scalar for Dual {
+    fn constant(value: f64) -> Self {
+        Self::constant(value)
+    }
+
+    fn value(self) -> f64 {
+        self.value
+    }
+
+    fn exp(self) -> Self {
+        self.exp()
+    }
+
+    fn powf(self, exponent: f64) -> Self {
+        self.powf(exponent)
+    }
+}
+
+impl Add for Dual {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self {
+            value: self.value + rhs.value,
+            derivative: std::array::from_fn(|i| self.derivative[i] + rhs.derivative[i]),
+        }
+    }
+}
+
+impl Add<f64> for Dual {
+    type Output = Self;
+
+    fn add(self, rhs: f64) -> Self::Output {
+        self + Self::constant(rhs)
+    }
+}
+
+impl Sub for Dual {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self {
+            value: self.value - rhs.value,
+            derivative: std::array::from_fn(|i| self.derivative[i] - rhs.derivative[i]),
+        }
+    }
+}
+
+impl Sub<f64> for Dual {
+    type Output = Self;
+
+    fn sub(self, rhs: f64) -> Self::Output {
+        self - Self::constant(rhs)
+    }
+}
+
+#[allow(clippy::suspicious_arithmetic_impl)]
+impl Mul for Dual {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        Self {
+            value: self.value * rhs.value,
+            derivative: std::array::from_fn(|i| {
+                self.derivative[i] * rhs.value + self.value * rhs.derivative[i]
+            }),
+        }
+    }
+}
+
+impl Mul<f64> for Dual {
+    type Output = Self;
+
+    fn mul(self, rhs: f64) -> Self::Output {
+        Self {
+            value: self.value * rhs,
+            derivative: self.derivative.map(|d| d * rhs),
+        }
+    }
+}
+
+impl Div for Dual {
+    type Output = Self;
+
+    fn div(self, rhs: Self) -> Self::Output {
+        let denominator = rhs.value * rhs.value;
+        Self {
+            value: self.value / rhs.value,
+            derivative: std::array::from_fn(|i| {
+                (self.derivative[i] * rhs.value - self.value * rhs.derivative[i]) / denominator
+            }),
+        }
+    }
+}
+
+impl Div<f64> for Dual {
+    type Output = Self;
+
+    fn div(self, rhs: f64) -> Self::Output {
+        self * (1.0 / rhs)
+    }
+}
+
+impl Neg for Dual {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        Self {
+            value: -self.value,
+            derivative: self.derivative.map(|d| -d),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct AtmosphericState {
+    pub pressure_pa: f64,
+    pub temperature_k: f64,
+    pub h2o_vmr: f64,
+    pub co2_vmr: f64,
+    pub o3_vmr: f64,
+}
+
+/// MT_CKD extinction coefficient and analytic Jacobians on the fixed grid.
+#[derive(Debug, Clone)]
+pub struct LinearizedSpectrum {
+    pub extinction: Vec<f64>,
+    pub d_pressure_pa: Vec<f64>,
+    pub d_temperature_k: Vec<f64>,
+    pub d_h2o_vmr: Vec<f64>,
+    pub d_co2_vmr: Vec<f64>,
+    pub d_o3_vmr: Vec<f64>,
+}
+
+#[derive(Clone, Copy)]
+#[repr(usize)]
+enum Field {
+    H2OSelf = 0,
+    H2OSelfTemperatureExponent = 1,
+    H2OForeign = 2,
+    CO2 = 3,
+    CO2TemperatureExponent = 4,
+    O3Constant = 5,
+    O3Linear = 6,
+    O3Quadratic = 7,
+    O2Fundamental = 8,
+    O2FundamentalEnergy = 9,
+    O2Infrared1 = 10,
+    O2Infrared2 = 11,
+    O2Infrared3 = 12,
+    O2Visible = 13,
+    N2Rotation296 = 14,
+    N2RotationScale296 = 15,
+    N2Rotation220 = 16,
+    N2RotationScale220 = 17,
+    N2Fundamental272 = 18,
+    N2Fundamental228 = 19,
+    N2H2OEfficiency = 20,
+    N2Overtone = 21,
+}
+
+/// Errors raised while loading the separately distributed MT_CKD data table.
+#[derive(Debug)]
+pub enum MtCkdDataError {
+    Io(io::Error),
+    InvalidFormat(String),
+}
+
+impl fmt::Display for MtCkdDataError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(error) => write!(formatter, "failed to read MT_CKD data: {error}"),
+            Self::InvalidFormat(message) => write!(formatter, "invalid MT_CKD data: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for MtCkdDataError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(error) => Some(error),
+            Self::InvalidFormat(_) => None,
+        }
+    }
+}
+
+impl From<io::Error> for MtCkdDataError {
+    fn from(error: io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+/// An MT_CKD 4.3 evaluator loaded from the separately licensed coefficient data.
+pub struct MtCkd {
+    coefficients: Box<[f64]>,
+}
+
+impl MtCkd {
+    /// Load and validate an MT_CKD 4.3 coefficient table from memory.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, MtCkdDataError> {
+        if bytes.len() < HEADER_BYTES {
+            return Err(MtCkdDataError::InvalidFormat(format!(
+                "header is truncated: expected at least {HEADER_BYTES} bytes, found {}",
+                bytes.len()
+            )));
+        }
+        if &bytes[..TABLE_MAGIC.len()] != TABLE_MAGIC {
+            return Err(MtCkdDataError::InvalidFormat(
+                "unexpected magic or model version".to_owned(),
+            ));
+        }
+
+        let spectral_points = u32::from_le_bytes(bytes[8..12].try_into().unwrap()) as usize;
+        let fields = u32::from_le_bytes(bytes[12..16].try_into().unwrap()) as usize;
+        if spectral_points != SPECTRAL_POINTS || fields != N_FIELDS {
+            return Err(MtCkdDataError::InvalidFormat(format!(
+                "expected {SPECTRAL_POINTS} spectral points and {N_FIELDS} fields, found {spectral_points} and {fields}"
+            )));
+        }
+
+        let expected_length = HEADER_BYTES + SPECTRAL_POINTS * N_FIELDS * size_of::<f64>();
+        if bytes.len() != expected_length {
+            return Err(MtCkdDataError::InvalidFormat(format!(
+                "expected {expected_length} bytes, found {}",
+                bytes.len()
+            )));
+        }
+
+        let coefficients: Box<[f64]> = bytes[HEADER_BYTES..]
+            .chunks_exact(size_of::<f64>())
+            .map(|value| f64::from_le_bytes(value.try_into().unwrap()))
+            .collect();
+        if let Some(index) = coefficients.iter().position(|value| !value.is_finite()) {
+            return Err(MtCkdDataError::InvalidFormat(format!(
+                "coefficient {index} is not finite"
+            )));
+        }
+
+        Ok(Self { coefficients })
+    }
+
+    /// Load and validate an MT_CKD 4.3 coefficient table from a file.
+    pub fn from_file(path: impl AsRef<Path>) -> Result<Self, MtCkdDataError> {
+        Self::from_bytes(&fs::read(path)?)
+    }
+
+    fn coefficient(&self, field: Field, spectral_index: usize) -> f64 {
+        self.coefficients[field as usize * SPECTRAL_POINTS + spectral_index]
+    }
+}
+
+fn radiation_term<S: Scalar>(wavenumber: f64, temperature: S) -> S {
+    let ratio = S::constant(wavenumber * RADCN2) / temperature;
+    if ratio.value() <= 0.01 {
+        ratio * (0.5 * wavenumber)
+    } else if ratio.value() <= 10.0 {
+        let exponential = (-ratio).exp();
+        S::constant(wavenumber) * (S::constant(1.0) - exponential)
+            / (S::constant(1.0) + exponential)
+    } else {
+        S::constant(wavenumber)
+    }
+}
+
+fn interpolate_logarithmically<S: Scalar>(
+    at_first_temperature: f64,
+    at_second_temperature: f64,
+    fraction: S,
+) -> S {
+    if at_first_temperature > 0.0 && at_second_temperature > 0.0 {
+        S::constant(at_first_temperature)
+            * (fraction * (at_second_temperature / at_first_temperature).ln()).exp()
+    } else {
+        S::constant(at_first_temperature)
+            + fraction * (at_second_temperature - at_first_temperature)
+    }
+}
+
+fn n2_fundamental_source<S: Scalar>(model: &MtCkd, position: isize, temperature: S) -> [S; 3] {
+    // n2_ver_1 pads two zero samples before and after its stored grid.
+    let raw_index = position - 3;
+    if raw_index < 0 || raw_index >= N2_FUNDAMENTAL_POINTS as isize {
+        return [S::constant(0.0); 3];
+    }
+    let raw_index = raw_index as usize;
+    let at_272 = model.coefficient(Field::N2Fundamental272, raw_index);
+    let at_228 = model.coefficient(Field::N2Fundamental228, raw_index);
+    let reciprocal_temperature_fraction =
+        (S::constant(1.0) / temperature - 1.0 / 272.0) / ((1.0 / 228.0) - (1.0 / 272.0));
+    let linear_temperature_fraction = (temperature - 272.0) / (228.0 - 272.0);
+    let spectral_coefficient = if at_272 > 0.0 && at_228 > 0.0 {
+        interpolate_logarithmically(at_272, at_228, reciprocal_temperature_fraction)
+    } else {
+        S::constant(at_272) + linear_temperature_fraction * (at_228 - at_272)
+    };
+    let source_wavenumber = N2_FUNDAMENTAL_V1 + raw_index as f64 * N2_FUNDAMENTAL_DV;
+    let spectral_coefficient = spectral_coefficient / source_wavenumber;
+    let o2_efficiency = S::constant(1.294) - temperature * (0.4545 / 296.0);
+    let h2o_efficiency = model.coefficient(Field::N2H2OEfficiency, raw_index);
+    [
+        spectral_coefficient,
+        spectral_coefficient * o2_efficiency,
+        spectral_coefficient * (9.0 / 7.0 * h2o_efficiency),
+    ]
+}
+
+fn n2_fundamental_coefficients<S: Scalar>(
+    model: &MtCkd,
+    wavenumber: f64,
+    temperature: S,
+) -> [S; 3] {
+    if !(2000.0..=2900.0).contains(&wavenumber) {
+        return [S::constant(0.0); 3];
+    }
+
+    let padded_v1 = N2_FUNDAMENTAL_V1 - 2.0 * N2_FUNDAMENTAL_DV;
+    let position = ((wavenumber - padded_v1) / N2_FUNDAMENTAL_DV + 1.001).trunc() as isize;
+    let position_wavenumber = padded_v1 + (position - 1) as f64 * N2_FUNDAMENTAL_DV;
+    let p = (wavenumber - position_wavenumber) / N2_FUNDAMENTAL_DV;
+    let c = (3.0 - 2.0 * p) * p * p;
+    let b = 0.5 * p * (1.0 - p);
+    let b1 = b * (1.0 - p);
+    let b2 = b * p;
+    let weights = [-b1, 1.0 - c + b2, c + b1, -b2];
+    let mut result = [S::constant(0.0); 3];
+    for (offset, weight) in weights.into_iter().enumerate() {
+        let source = n2_fundamental_source(model, position - 1 + offset as isize, temperature);
+        for component in 0..3 {
+            result[component] = result[component] + source[component] * weight;
+        }
+    }
+    result
+}
+
+fn evaluate<S: Scalar>(
+    model: &MtCkd,
+    pressure_pa: S,
+    temperature: S,
+    h2o_vmr: S,
+    co2_vmr: S,
+    o3_vmr: S,
+) -> Vec<S> {
+    let pressure_mb = pressure_pa / 100.0;
+    let initial_total = pressure_mb / 1013.0
+        * (S::constant(273.0) / temperature)
+        * (ALOSMT * REFERENCE_PATH_LENGTH_CM);
+    let dry_amount = initial_total * (S::constant(1.0) - h2o_vmr);
+    let h2o_amount = h2o_vmr * dry_amount;
+    let co2_amount = co2_vmr * dry_amount;
+    let o3_amount = o3_vmr * dry_amount;
+    let o2_amount = dry_amount * 0.21;
+    let broadening_amount = dry_amount * (0.78 + 0.009);
+    let total_amount = broadening_amount + h2o_amount + co2_amount + o3_amount + o2_amount;
+    let x_h2o = h2o_amount / total_amount;
+    let x_o2 = o2_amount / total_amount;
+    let x_n2 = S::constant(1.0) - x_h2o - x_o2;
+    let n2_amount = x_n2 * total_amount;
+    let rho = pressure_mb / 1013.0 * (S::constant(296.0) / temperature);
+    let amagat = pressure_mb / 1013.0 * (S::constant(273.0) / temperature);
+
+    let mut extinction = Vec::with_capacity(OUTPUT_POINTS);
+
+    for spectral_index in 0..SPECTRAL_POINTS {
+        let wavenumber = spectral_index as f64 * WAVENUMBER_SPACING;
+        let radiation = radiation_term(wavenumber, temperature);
+
+        let self_coefficient = S::constant(model.coefficient(Field::H2OSelf, spectral_index))
+            * (S::constant(296.0) / temperature)
+                .powf(model.coefficient(Field::H2OSelfTemperatureExponent, spectral_index))
+            * x_h2o
+            * rho;
+        let foreign_coefficient = S::constant(model.coefficient(Field::H2OForeign, spectral_index))
+            * (S::constant(1.0) - x_h2o)
+            * rho;
+        let h2o = h2o_amount * (self_coefficient + foreign_coefficient);
+
+        let co2 = co2_amount
+            * rho
+            * 1.0e-20
+            * model.coefficient(Field::CO2, spectral_index)
+            * (temperature / 246.0)
+                .powf(model.coefficient(Field::CO2TemperatureExponent, spectral_index));
+
+        let delta_temperature = temperature - 273.15;
+        let o3_coefficient = S::constant(model.coefficient(Field::O3Constant, spectral_index))
+            + delta_temperature * model.coefficient(Field::O3Linear, spectral_index)
+            + delta_temperature
+                * delta_temperature
+                * model.coefficient(Field::O3Quadratic, spectral_index);
+        let o3 = o3_amount * 1.0e-20 * o3_coefficient;
+
+        let o2_fundamental = o2_amount
+            * 1.0e-20
+            * amagat
+            * model.coefficient(Field::O2Fundamental, spectral_index)
+            * (S::constant(model.coefficient(Field::O2FundamentalEnergy, spectral_index))
+                * (S::constant(1.0 / 296.0) - S::constant(1.0) / temperature))
+                .exp();
+        let o2_infrared1 = o2_amount / XLOSMT
+            * amagat
+            * (x_o2 / 0.446 + x_n2 * (0.3 / 0.446) + x_h2o)
+            * model.coefficient(Field::O2Infrared1, spectral_index);
+        let o2_infrared2 = o2_amount / total_amount
+            * (1.0 / 0.209)
+            * o2_amount
+            * 1.0e-20
+            * rho
+            * model.coefficient(Field::O2Infrared2, spectral_index);
+        let o2_infrared3 =
+            o2_amount / XLOSMT * amagat * model.coefficient(Field::O2Infrared3, spectral_index);
+        let o2_visible = o2_amount / total_amount
+            * o2_amount
+            * 1.0e-20
+            * amagat
+            * model.coefficient(Field::O2Visible, spectral_index);
+
+        let rotation_fraction = (temperature - 296.0) / (220.0 - 296.0);
+        let n2_rotation_coefficient = interpolate_logarithmically(
+            model.coefficient(Field::N2Rotation296, spectral_index),
+            model.coefficient(Field::N2Rotation220, spectral_index),
+            rotation_fraction,
+        );
+        let n2_rotation_scale = interpolate_logarithmically(
+            model.coefficient(Field::N2RotationScale296, spectral_index),
+            model.coefficient(Field::N2RotationScale220, spectral_index),
+            rotation_fraction,
+        );
+        let n2_o2_efficiency = (n2_rotation_scale - 1.0) * (0.79 / 0.21);
+        let n2_rotation = n2_amount / XLOSMT
+            * amagat
+            * n2_rotation_coefficient
+            * (x_n2 + n2_o2_efficiency * x_o2 + x_h2o);
+
+        let n2_fundamental_coefficients =
+            n2_fundamental_coefficients(model, wavenumber, temperature);
+        let n2_fundamental = n2_amount / XLOSMT
+            * amagat
+            * (x_n2 * n2_fundamental_coefficients[0]
+                + x_o2 * n2_fundamental_coefficients[1]
+                + x_h2o * n2_fundamental_coefficients[2]);
+        let n2_overtone = n2_amount / XLOSMT
+            * amagat
+            * (x_n2 + x_o2 + x_h2o)
+            * model.coefficient(Field::N2Overtone, spectral_index);
+
+        let absorption = (h2o
+            + co2
+            + o3
+            + o2_fundamental
+            + o2_infrared1
+            + o2_infrared2
+            + o2_infrared3
+            + o2_visible
+            + n2_rotation
+            + n2_fundamental
+            + n2_overtone)
+            * radiation;
+
+        // MT_CKD's standalone wrapper also enables its historical Rayleigh
+        // term. With the radiation term restored this simplifies exactly to
+        // the expression below.
+        let scaled_wavenumber = wavenumber / 1.0e4;
+        let rayleigh = total_amount
+            * (1.0e-20 / (2.686_75e-1 * 1.0e5))
+            * (scaled_wavenumber.powi(4) / (9.380_76e2 - 10.8426 * scaled_wavenumber.powi(2)));
+
+        let result = absorption + rayleigh;
+        extinction.push(result);
+    }
+
+    extinction
+}
+
+/// Evaluate MT_CKD 4.3 and all atmospheric Jacobians.
+pub fn calculate_linearized(model: &MtCkd, state: AtmosphericState) -> LinearizedSpectrum {
+    let spectrum = evaluate(
+        model,
+        Dual::variable(state.pressure_pa, Input::Pressure),
+        Dual::variable(state.temperature_k, Input::Temperature),
+        Dual::variable(state.h2o_vmr, Input::H2O),
+        Dual::variable(state.co2_vmr, Input::CO2),
+        Dual::variable(state.o3_vmr, Input::O3),
+    );
+
+    let mut extinction = Vec::with_capacity(OUTPUT_POINTS);
+    let mut derivatives =
+        std::array::from_fn::<_, N_INPUTS, _>(|_| Vec::with_capacity(OUTPUT_POINTS));
+    for result in spectrum {
+        extinction.push(result.value);
+        for (input, output) in derivatives.iter_mut().enumerate() {
+            output.push(result.derivative[input]);
+        }
+    }
+
+    LinearizedSpectrum {
+        extinction,
+        d_pressure_pa: std::mem::take(&mut derivatives[Input::Pressure as usize]),
+        d_temperature_k: std::mem::take(&mut derivatives[Input::Temperature as usize]),
+        d_h2o_vmr: std::mem::take(&mut derivatives[Input::H2O as usize]),
+        d_co2_vmr: std::mem::take(&mut derivatives[Input::CO2 as usize]),
+        d_o3_vmr: std::mem::take(&mut derivatives[Input::O3 as usize]),
+    }
+}
+
+/// Evaluate only the extinction coefficient without derivative propagation.
+pub fn calculate(model: &MtCkd, state: AtmosphericState) -> Vec<f64> {
+    evaluate(
+        model,
+        state.pressure_pa,
+        state.temperature_k,
+        state.h2o_vmr,
+        state.co2_vmr,
+        state.o3_vmr,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn state() -> AtmosphericState {
+        AtmosphericState {
+            pressure_pa: 101_325.0,
+            temperature_k: 288.15,
+            h2o_vmr: 0.01,
+            co2_vmr: 400.0e-6,
+            o3_vmr: 2.0e-6,
+        }
+    }
+
+    fn zero_coefficient_model() -> MtCkd {
+        let mut bytes =
+            Vec::with_capacity(HEADER_BYTES + SPECTRAL_POINTS * N_FIELDS * size_of::<f64>());
+        bytes.extend_from_slice(TABLE_MAGIC);
+        bytes.extend_from_slice(&(SPECTRAL_POINTS as u32).to_le_bytes());
+        bytes.extend_from_slice(&(N_FIELDS as u32).to_le_bytes());
+        bytes.resize(
+            HEADER_BYTES + SPECTRAL_POINTS * N_FIELDS * size_of::<f64>(),
+            0,
+        );
+        MtCkd::from_bytes(&bytes).unwrap()
+    }
+
+    #[test]
+    fn coefficient_table_parser_validates_the_data_contract() {
+        let model = zero_coefficient_model();
+        assert_eq!(model.coefficients.len(), N_FIELDS * SPECTRAL_POINTS);
+
+        let error = match MtCkd::from_bytes(b"not an MT_CKD table") {
+            Ok(_) => panic!("invalid MT_CKD data was accepted"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("unexpected magic"));
+    }
+
+    #[test]
+    fn analytic_derivatives_match_central_differences() {
+        let model = zero_coefficient_model();
+        let reference = calculate_linearized(&model, state());
+        let perturbations = [1.0, 1.0e-3, 1.0e-7, 1.0e-8, 1.0e-8];
+        let analytic = [
+            &reference.d_pressure_pa,
+            &reference.d_temperature_k,
+            &reference.d_h2o_vmr,
+            &reference.d_co2_vmr,
+            &reference.d_o3_vmr,
+        ];
+
+        for input in 0..N_INPUTS {
+            let mut above = state();
+            let mut below = state();
+            let delta = perturbations[input];
+            match input {
+                0 => {
+                    above.pressure_pa += delta;
+                    below.pressure_pa -= delta;
+                }
+                1 => {
+                    above.temperature_k += delta;
+                    below.temperature_k -= delta;
+                }
+                2 => {
+                    above.h2o_vmr += delta;
+                    below.h2o_vmr -= delta;
+                }
+                3 => {
+                    above.co2_vmr += delta;
+                    below.co2_vmr -= delta;
+                }
+                4 => {
+                    above.o3_vmr += delta;
+                    below.o3_vmr -= delta;
+                }
+                _ => unreachable!(),
+            }
+            let above = calculate(&model, above);
+            let below = calculate(&model, below);
+            for spectral_index in 1..SPECTRAL_POINTS {
+                let numeric = (above[spectral_index] - below[spectral_index]) / (2.0 * delta);
+                let scale = numeric.abs().max(analytic[input][spectral_index].abs());
+                if scale > 1.0e-18 {
+                    assert!(
+                        (numeric - analytic[input][spectral_index]).abs() <= 2.0e-5 * scale,
+                        "input={input}, index={spectral_index}, numeric={numeric:e}, analytic={:e}",
+                        analytic[input][spectral_index]
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn value_only_evaluation_matches_linearized_values() {
+        let model = zero_coefficient_model();
+        assert_eq!(
+            calculate(&model, state()),
+            calculate_linearized(&model, state()).extinction
+        );
+    }
+}

--- a/rust/sasktran2-rs/src/continuum/mt_ckd.rs
+++ b/rust/sasktran2-rs/src/continuum/mt_ckd.rs
@@ -452,7 +452,7 @@ fn n2_fundamental_coefficients<S: Scalar>(
     result
 }
 
-fn evaluate<S: Scalar>(
+fn evaluate<S: Scalar, const INCLUDE_RAYLEIGH: bool>(
     model: &MtCkd,
     pressure_pa: S,
     temperature: S,
@@ -465,7 +465,14 @@ fn evaluate<S: Scalar>(
         * (S::constant(273.0) / temperature)
         * (ALOSMT * REFERENCE_PATH_LENGTH_CM);
     let dry_amount = initial_total * (S::constant(1.0) - h2o_vmr);
-    let h2o_amount = h2o_vmr * dry_amount;
+    // Preserve MT_CKD's special pure-water convention. The selected branch is
+    // differentiated analytically; as in the upstream piecewise model, the
+    // derivative is undefined exactly at either threshold.
+    let h2o_amount = if (h2o_vmr.value() - 1.0).abs() < 1.0e-5 {
+        initial_total
+    } else {
+        h2o_vmr * dry_amount
+    };
     let co2_amount = co2_vmr * dry_amount;
     let o3_amount = o3_vmr * dry_amount;
     let o2_amount = dry_amount * 0.21;
@@ -584,16 +591,22 @@ fn evaluate<S: Scalar>(
             * (1.0e-20 / (2.686_75e-1 * 1.0e5))
             * (scaled_wavenumber.powi(4) / (9.380_76e2 - 10.8426 * scaled_wavenumber.powi(2)));
 
-        let result = absorption + rayleigh;
+        let result = if INCLUDE_RAYLEIGH {
+            absorption + rayleigh
+        } else {
+            absorption
+        };
         extinction.push(result);
     }
 
     extinction
 }
 
-/// Evaluate MT_CKD 4.3 and all atmospheric Jacobians.
-pub fn calculate_linearized(model: &MtCkd, state: AtmosphericState) -> LinearizedSpectrum {
-    let spectrum = evaluate(
+fn calculate_linearized_impl<const INCLUDE_RAYLEIGH: bool>(
+    model: &MtCkd,
+    state: AtmosphericState,
+) -> LinearizedSpectrum {
+    let spectrum = evaluate::<Dual, INCLUDE_RAYLEIGH>(
         model,
         Dual::variable(state.pressure_pa, Input::Pressure),
         Dual::variable(state.temperature_k, Input::Temperature),
@@ -622,9 +635,38 @@ pub fn calculate_linearized(model: &MtCkd, state: AtmosphericState) -> Linearize
     }
 }
 
-/// Evaluate only the extinction coefficient without derivative propagation.
+/// Evaluate the complete MT_CKD 4.3 standalone spectrum, including its
+/// historical Rayleigh-scattering term, and all atmospheric Jacobians.
+pub fn calculate_linearized(model: &MtCkd, state: AtmosphericState) -> LinearizedSpectrum {
+    calculate_linearized_impl::<true>(model, state)
+}
+
+/// Evaluate MT_CKD 4.3 continuum absorption and all atmospheric Jacobians,
+/// excluding the historical Rayleigh-scattering term.
+pub fn calculate_absorption_linearized(
+    model: &MtCkd,
+    state: AtmosphericState,
+) -> LinearizedSpectrum {
+    calculate_linearized_impl::<false>(model, state)
+}
+
+/// Evaluate the complete MT_CKD 4.3 standalone spectrum, including its
+/// historical Rayleigh-scattering term, without derivative propagation.
 pub fn calculate(model: &MtCkd, state: AtmosphericState) -> Vec<f64> {
-    evaluate(
+    evaluate::<f64, true>(
+        model,
+        state.pressure_pa,
+        state.temperature_k,
+        state.h2o_vmr,
+        state.co2_vmr,
+        state.o3_vmr,
+    )
+}
+
+/// Evaluate only MT_CKD 4.3 continuum absorption, excluding the historical
+/// Rayleigh-scattering term, without derivative propagation.
+pub fn calculate_absorption(model: &MtCkd, state: AtmosphericState) -> Vec<f64> {
+    evaluate::<f64, false>(
         model,
         state.pressure_pa,
         state.temperature_k,
@@ -736,5 +778,39 @@ mod tests {
             calculate(&model, state()),
             calculate_linearized(&model, state()).extinction
         );
+        assert_eq!(
+            calculate_absorption(&model, state()),
+            calculate_absorption_linearized(&model, state()).extinction
+        );
+    }
+
+    #[test]
+    fn pure_water_branch_is_finite_and_linearized() {
+        let model = zero_coefficient_model();
+        let mut pure_water = state();
+        pure_water.h2o_vmr = 1.0;
+
+        let reference = calculate_linearized(&model, pure_water);
+        assert!(reference.extinction.iter().all(|value| value.is_finite()));
+        assert!(reference.d_h2o_vmr.iter().all(|value| value.is_finite()));
+
+        let delta = 1.0e-7;
+        let mut above = pure_water;
+        let mut below = pure_water;
+        above.h2o_vmr += delta;
+        below.h2o_vmr -= delta;
+        let above = calculate(&model, above);
+        let below = calculate(&model, below);
+        for spectral_index in 1..SPECTRAL_POINTS {
+            let numeric = (above[spectral_index] - below[spectral_index]) / (2.0 * delta);
+            let analytic = reference.d_h2o_vmr[spectral_index];
+            let scale = numeric.abs().max(analytic.abs());
+            if scale > 1.0e-18 {
+                assert!(
+                    (numeric - analytic).abs() <= 2.0e-7 * scale,
+                    "index={spectral_index}, numeric={numeric:e}, analytic={analytic:e}"
+                );
+            }
+        }
     }
 }

--- a/rust/sasktran2-rs/src/lib.rs
+++ b/rust/sasktran2-rs/src/lib.rs
@@ -7,6 +7,7 @@ pub mod threading;
 pub mod atmosphere;
 pub mod bindings;
 pub mod constituent;
+pub mod continuum;
 pub mod interpolation;
 pub mod mie;
 pub mod optical;

--- a/src/sasktran2/__init__.py
+++ b/src/sasktran2/__init__.py
@@ -13,6 +13,7 @@ from . import (
     basis,
     climatology,
     constituent,
+    continuum,
     database,
     mie,
     optical,
@@ -39,6 +40,12 @@ from ._core_rust import (
 )
 from .atmosphere import Atmosphere
 from .config import Config
+from .continuum import (
+    MT_CKD_WAVENUMBERS_CM_INV,
+    MTCKDContinuum,
+    mt_ckd,
+    mt_ckd_linearized,
+)
 from .engine import Engine
 from .geodetic import WGS84, Geodetic, SphericalGeoid
 from .geometry import Geometry1D, Geometry2D

--- a/src/sasktran2/atmosphere.py
+++ b/src/sasktran2/atmosphere.py
@@ -154,6 +154,9 @@ class _ExpandedProfileAtmosphere:
     def _native_state_equation(self) -> EquationOfState:
         return self._native_inputs.state_equation
 
+    def __getitem__(self, name: str):
+        return self._atmosphere[name]
+
     def __getattr__(self, name):
         return getattr(self._atmosphere, name)
 

--- a/src/sasktran2/continuum.py
+++ b/src/sasktran2/continuum.py
@@ -12,18 +12,16 @@ from sasktran2.constituent.base import Constituent
 from sasktran2.util.interpolation import linear_interpolating_matrix
 
 __all__ = [
-    "MTCKDContinuum",
     "MT_CKD_AER_LICENSE",
     "MT_CKD_WAVENUMBERS_CM_INV",
+    "MTCKDContinuum",
     "mt_ckd",
     "mt_ckd_linearized",
 ]
 
 _MT_CKD_DATA_KEY = "continuum/mt_ckd_4_3.bin"
 _MT_CKD_LICENSE_KEY = "continuum/MT_CKD_LICENSE.txt"
-_MT_CKD_DATA_SHA256 = (
-    "06b5600ecb0f5a3417c46d226555bc516f5a55ae93b19b6e7b5431e50f8f0459"
-)
+_MT_CKD_DATA_SHA256 = "06b5600ecb0f5a3417c46d226555bc516f5a55ae93b19b6e7b5431e50f8f0459"
 _MT_CKD_LICENSE_SHA256 = (
     "3648e3e8a231da514f923409b9b5e41be5e1746e92692af3ce3ac89bc6803b69"
 )
@@ -104,12 +102,21 @@ def mt_ckd(
     vmr_h2o: np.ndarray,
     vmr_co2: np.ndarray,
     vmr_o3: np.ndarray,
+    *,
+    include_rayleigh: bool = True,
 ) -> np.ndarray:
     """Calculate the MT_CKD 4.3 extinction coefficient in m^-1.
 
     The returned columns correspond to
     :data:`MT_CKD_WAVENUMBERS_CM_INV`. The calculation uses a fixed one-metre
     reference column internally, so no geometric path length is an input.
+
+    By default the result includes the historical Rayleigh-scattering term
+    returned by the standalone MT_CKD wrapper, preserving low-level
+    compatibility with :mod:`sasktran2_ext`. Set ``include_rayleigh=False``
+    when only continuum absorption is required. :class:`MTCKDContinuum` always
+    excludes Rayleigh so it can be combined safely with SASKTRAN2's Rayleigh
+    constituent.
 
     The separately licensed AER coefficient data is downloaded from the
     SASKTRAN2 database on first use. Its scientific/research-only license is
@@ -123,6 +130,7 @@ def mt_ckd(
         vmr_co2,
         vmr_o3,
         str(_mt_ckd_data_file()),
+        include_rayleigh,
     )
 
 
@@ -132,6 +140,8 @@ def mt_ckd_linearized(
     vmr_h2o: np.ndarray,
     vmr_co2: np.ndarray,
     vmr_o3: np.ndarray,
+    *,
+    include_rayleigh: bool = True,
 ) -> tuple[np.ndarray, ...]:
     """Calculate MT_CKD extinction and its five analytic Jacobians.
 
@@ -141,6 +151,9 @@ def mt_ckd_linearized(
     :data:`MT_CKD_WAVENUMBERS_CM_INV`. On first use, the separately licensed
     AER coefficient data is downloaded as described in :func:`mt_ckd`; it is
     not covered by SASKTRAN2's MIT license.
+
+    ``include_rayleigh`` has the same compatibility behavior as in
+    :func:`mt_ckd`.
     """
     return _mt_ckd_linearized(
         pressure_pa,
@@ -149,6 +162,7 @@ def mt_ckd_linearized(
         vmr_co2,
         vmr_o3,
         str(_mt_ckd_data_file()),
+        include_rayleigh,
     )
 
 
@@ -160,6 +174,10 @@ class MTCKDContinuum(Constituent):
     options are retained for source compatibility but are no longer used;
     pressure, temperature, H2O, CO2, and O3 derivatives are evaluated
     analytically by the Rust implementation.
+
+    This constituent adds continuum absorption only. MT_CKD's historical
+    Rayleigh term is excluded so scattering can be supplied by SASKTRAN2's
+    dedicated Rayleigh constituent without double counting.
 
     MT_CKD's AER coefficient data is not covered by SASKTRAN2's MIT license.
     On first use it is downloaded from the SASKTRAN2 database after its
@@ -246,11 +264,11 @@ class MTCKDContinuum(Constituent):
             np.ascontiguousarray(o3_vmr, dtype=np.float64),
         )
         if atmo.calculate_derivatives:
-            self._linearized_cache = mt_ckd_linearized(*inputs)
+            self._linearized_cache = mt_ckd_linearized(*inputs, include_rayleigh=False)
             extinction = self._linearized_cache[0]
         else:
             self._linearized_cache = None
-            extinction = mt_ckd(*inputs)
+            extinction = mt_ckd(*inputs, include_rayleigh=False)
         atmo.storage.total_extinction[:] += (
             np.nan_to_num(extinction) @ self._wavenumber_interpolator.T
         )
@@ -303,7 +321,10 @@ class MTCKDContinuum(Constituent):
             self._linearized_cache[1:],
             strict=True,
         ):
-            if derivative_name == "pressure_pa" and not atmo.calculate_pressure_derivative:
+            if (
+                derivative_name == "pressure_pa"
+                and not atmo.calculate_pressure_derivative
+            ):
                 continue
             if (
                 derivative_name == "temperature_k"

--- a/src/sasktran2/continuum.py
+++ b/src/sasktran2/continuum.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import hashlib
+from functools import cache
+from pathlib import Path
+
+import numpy as np
+
+import sasktran2 as sk
+from sasktran2._core_rust import _mt_ckd, _mt_ckd_linearized
+from sasktran2.constituent.base import Constituent
+from sasktran2.util.interpolation import linear_interpolating_matrix
+
+__all__ = [
+    "MTCKDContinuum",
+    "MT_CKD_AER_LICENSE",
+    "MT_CKD_WAVENUMBERS_CM_INV",
+    "mt_ckd",
+    "mt_ckd_linearized",
+]
+
+_MT_CKD_DATA_KEY = "continuum/mt_ckd_4_3.bin"
+_MT_CKD_LICENSE_KEY = "continuum/MT_CKD_LICENSE.txt"
+_MT_CKD_DATA_SHA256 = (
+    "06b5600ecb0f5a3417c46d226555bc516f5a55ae93b19b6e7b5431e50f8f0459"
+)
+_MT_CKD_LICENSE_SHA256 = (
+    "3648e3e8a231da514f923409b9b5e41be5e1746e92692af3ce3ac89bc6803b69"
+)
+
+MT_CKD_WAVENUMBERS_CM_INV = np.arange(0.0, 19_901.0, 10.0)
+"""The native 1,991-point MT_CKD wavenumber grid in cm^-1."""
+MT_CKD_WAVENUMBERS_CM_INV.setflags(write=False)
+
+MT_CKD_AER_LICENSE = """Copyright ©, Atmospheric and Environmental Research, Inc., 2022
+
+All rights reserved. This source code was developed as part of the LBLRTM
+software and is designed for scientific and research purposes. Atmospheric
+and Environmental Research Inc. (AER) grants USER the right to download,
+install, use and copy this software and data for scientific and research
+purposes only. This software and data may be redistributed as long as this
+copyright notice is reproduced on any copy made and appropriate acknowledgment
+is given to AER. This software and data or any modified version of this
+software and data may not be incorporated into proprietary software or data or
+commercial software or data offered for sale without the express written
+consent of AER. This software and data are provided as is without any expressed
+or implied warranties.
+
+Address questions to: aer_contnm@aer.com
+
+General reference: Mlawer et al. (2012),
+https://doi.org/10.1098/rsta.2011.0295"""
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _verified_standard_database_file(key: str, expected_sha256: str) -> Path:
+    path = sk.database.StandardDatabase().path(key)
+    if path is None or not path.exists():
+        msg = f"Failed to download the required MT_CKD file {key!r}"
+        raise OSError(msg)
+
+    actual_sha256 = _sha256(path)
+    if actual_sha256 != expected_sha256:
+        path.unlink()
+        msg = (
+            f"The downloaded MT_CKD file {key!r} failed checksum validation; "
+            f"expected {expected_sha256}, found {actual_sha256}. The invalid "
+            "cached file has been removed."
+        )
+        raise OSError(msg)
+    return path
+
+
+@cache
+def _mt_ckd_data_file() -> Path:
+    local_data_file = sk.appconfig.database_root().joinpath(_MT_CKD_DATA_KEY)
+    if not local_data_file.exists():
+        print(  # noqa: T201
+            "MT_CKD 4.3 coefficient data is licensed separately from "
+            "SASKTRAN2 under the following AER terms:\n\n"
+            f"{MT_CKD_AER_LICENSE}\n"
+        )
+
+    _verified_standard_database_file(
+        _MT_CKD_LICENSE_KEY,
+        _MT_CKD_LICENSE_SHA256,
+    )
+    return _verified_standard_database_file(
+        _MT_CKD_DATA_KEY,
+        _MT_CKD_DATA_SHA256,
+    )
+
+
+def mt_ckd(
+    pressure_pa: np.ndarray,
+    temperature_k: np.ndarray,
+    vmr_h2o: np.ndarray,
+    vmr_co2: np.ndarray,
+    vmr_o3: np.ndarray,
+) -> np.ndarray:
+    """Calculate the MT_CKD 4.3 extinction coefficient in m^-1.
+
+    The returned columns correspond to
+    :data:`MT_CKD_WAVENUMBERS_CM_INV`. The calculation uses a fixed one-metre
+    reference column internally, so no geometric path length is an input.
+
+    The separately licensed AER coefficient data is downloaded from the
+    SASKTRAN2 database on first use. Its scientific/research-only license is
+    printed before that download, stored beside the cached data, and reproduced
+    in :data:`MT_CKD_AER_LICENSE`. It is not covered by SASKTRAN2's MIT license.
+    """
+    return _mt_ckd(
+        pressure_pa,
+        temperature_k,
+        vmr_h2o,
+        vmr_co2,
+        vmr_o3,
+        str(_mt_ckd_data_file()),
+    )
+
+
+def mt_ckd_linearized(
+    pressure_pa: np.ndarray,
+    temperature_k: np.ndarray,
+    vmr_h2o: np.ndarray,
+    vmr_co2: np.ndarray,
+    vmr_o3: np.ndarray,
+) -> tuple[np.ndarray, ...]:
+    """Calculate MT_CKD extinction and its five analytic Jacobians.
+
+    The return values are extinction coefficient in m^-1 followed by
+    derivatives with respect to pressure, temperature, H2O VMR, CO2 VMR, and
+    O3 VMR. Their columns correspond to
+    :data:`MT_CKD_WAVENUMBERS_CM_INV`. On first use, the separately licensed
+    AER coefficient data is downloaded as described in :func:`mt_ckd`; it is
+    not covered by SASKTRAN2's MIT license.
+    """
+    return _mt_ckd_linearized(
+        pressure_pa,
+        temperature_k,
+        vmr_h2o,
+        vmr_co2,
+        vmr_o3,
+        str(_mt_ckd_data_file()),
+    )
+
+
+class MTCKDContinuum(Constituent):
+    """MT_CKD 4.3 continuum absorption with analytic linearization.
+
+    The constructor and atmosphere requirements match
+    ``sasktran2_ext.continuum.MTCKDContinuum``. The numerical-difference
+    options are retained for source compatibility but are no longer used;
+    pressure, temperature, H2O, CO2, and O3 derivatives are evaluated
+    analytically by the Rust implementation.
+
+    MT_CKD's AER coefficient data is not covered by SASKTRAN2's MIT license.
+    On first use it is downloaded from the SASKTRAN2 database after its
+    scientific/research-only terms are printed, and the AER notice is stored
+    beside the cached data. See :data:`MT_CKD_AER_LICENSE` for the full terms.
+
+    Parameters
+    ----------
+    h2o_name : str, optional
+        Name of the atmosphere's H2O constituent.
+    co2_name : str, optional
+        Name of the atmosphere's CO2 constituent.
+    o3_name : str, optional
+        Name of the atmosphere's O3 constituent.
+    numeric_wf_fractional_change : float, optional
+        Retained for compatibility with ``sasktran2_ext``.
+    numeric_wf_central_difference : bool, optional
+        Retained for compatibility with ``sasktran2_ext``.
+    """
+
+    def __init__(
+        self,
+        h2o_name: str = "H2O",
+        co2_name: str = "CO2",
+        o3_name: str = "O3",
+        numeric_wf_fractional_change: float = 1e-2,
+        numeric_wf_central_difference: bool = True,
+    ) -> None:
+        self._h2o_name = h2o_name
+        self._co2_name = co2_name
+        self._o3_name = o3_name
+        self._mtckd_wavenumbers = MT_CKD_WAVENUMBERS_CM_INV
+        self._fractional_change = numeric_wf_fractional_change
+        self._central_difference = numeric_wf_central_difference
+        self._linearized_cache: tuple[np.ndarray, ...] | None = None
+        self._wavenumber_interpolator: np.ndarray | None = None
+        self._vmr_interpolators: tuple[np.ndarray, ...] | None = None
+
+    def _inputs(
+        self, atmo: sk.Atmosphere
+    ) -> tuple[tuple[np.ndarray, ...], tuple[np.ndarray, ...]]:
+        if atmo.wavelengths_nm is None:
+            msg = "It is required to give the Atmosphere object wavelengths to use the continuum constituent"
+            raise ValueError(msg)
+        if atmo.pressure_pa is None:
+            msg = "It is required to set the pressure_pa property in the Atmosphere object to use the continuum constituent"
+            raise ValueError(msg)
+        if atmo.temperature_k is None:
+            msg = "It is required to set the temperature_k property in the Atmosphere object to use the continuum constituent"
+            raise ValueError(msg)
+
+        constituents = []
+        for species_name in (self._h2o_name, self._co2_name, self._o3_name):
+            if atmo[species_name] is None:
+                msg = f"It is required to add an {species_name} constituent to the Atmosphere object to use the continuum constituent"
+                raise ValueError(msg)
+            constituents.append(atmo[species_name])
+
+        altitude_grid = atmo.model_geometry.altitudes()
+        vmrs = []
+        interpolators = []
+        for constituent in constituents:
+            interpolator = linear_interpolating_matrix(
+                constituent.altitudes_m,
+                altitude_grid,
+                "zero",
+            )
+            interpolators.append(interpolator)
+            vmrs.append(interpolator @ constituent.vmr)
+        return tuple(vmrs), tuple(interpolators)
+
+    def add_to_atmosphere(self, atmo: sk.Atmosphere) -> None:
+        (h2o_vmr, co2_vmr, o3_vmr), self._vmr_interpolators = self._inputs(atmo)
+        self._wavenumber_interpolator = linear_interpolating_matrix(
+            self._mtckd_wavenumbers,
+            atmo.wavenumbers_cminv,
+            "zero",
+        )
+        inputs = (
+            np.ascontiguousarray(atmo.pressure_pa, dtype=np.float64),
+            np.ascontiguousarray(atmo.temperature_k, dtype=np.float64),
+            np.ascontiguousarray(h2o_vmr, dtype=np.float64),
+            np.ascontiguousarray(co2_vmr, dtype=np.float64),
+            np.ascontiguousarray(o3_vmr, dtype=np.float64),
+        )
+        if atmo.calculate_derivatives:
+            self._linearized_cache = mt_ckd_linearized(*inputs)
+            extinction = self._linearized_cache[0]
+        else:
+            self._linearized_cache = None
+            extinction = mt_ckd(*inputs)
+        atmo.storage.total_extinction[:] += (
+            np.nan_to_num(extinction) @ self._wavenumber_interpolator.T
+        )
+
+    def register_derivative(self, atmo: sk.Atmosphere, name: str) -> None:
+        if (
+            self._linearized_cache is None
+            or self._wavenumber_interpolator is None
+            or self._vmr_interpolators is None
+        ):
+            msg = "MTCKDContinuum.add_to_atmosphere must be called before register_derivative"
+            raise RuntimeError(msg)
+
+        altitude_count = len(atmo.model_geometry.altitudes())
+        native_grid_interpolator = np.eye(altitude_count)
+        derivative_specs = (
+            (
+                "pressure_pa",
+                "altitude",
+                native_grid_interpolator,
+                "wf_pressure_pa",
+            ),
+            (
+                "temperature_k",
+                "altitude",
+                native_grid_interpolator,
+                "wf_temperature_k",
+            ),
+            (
+                f"{self._h2o_name}_vmr",
+                f"{self._h2o_name}_altitude",
+                self._vmr_interpolators[0],
+                f"wf_{self._h2o_name}_vmr",
+            ),
+            (
+                f"{self._co2_name}_vmr",
+                f"{self._co2_name}_altitude",
+                self._vmr_interpolators[1],
+                f"wf_{self._co2_name}_vmr",
+            ),
+            (
+                f"{self._o3_name}_vmr",
+                f"{self._o3_name}_altitude",
+                self._vmr_interpolators[2],
+                f"wf_{self._o3_name}_vmr",
+            ),
+        )
+        for (derivative_name, interp_dim, interpolator, assign_name), derivative in zip(
+            derivative_specs,
+            self._linearized_cache[1:],
+            strict=True,
+        ):
+            if derivative_name == "pressure_pa" and not atmo.calculate_pressure_derivative:
+                continue
+            if (
+                derivative_name == "temperature_k"
+                and not atmo.calculate_temperature_derivative
+            ):
+                continue
+
+            extinction_derivative = (
+                np.nan_to_num(derivative) @ self._wavenumber_interpolator.T
+            )
+            mapping = atmo.storage.get_derivative_mapping(
+                f"wf_{name}_{derivative_name}"
+            )
+            mapping.d_extinction[:] += extinction_derivative
+            ssa_derivative = np.zeros_like(extinction_derivative)
+            np.divide(
+                -extinction_derivative * atmo.storage.ssa,
+                atmo.storage.total_extinction,
+                out=ssa_derivative,
+                where=atmo.storage.total_extinction != 0.0,
+            )
+            mapping.d_ssa[:] += ssa_derivative
+            mapping.interp_dim = interp_dim
+            mapping.interpolator = interpolator
+            mapping.assign_name = assign_name

--- a/tests/continuum/test_mt_ckd.py
+++ b/tests/continuum/test_mt_ckd.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import hashlib
 
 import numpy as np
-
 import sasktran2 as sk
 from sasktran2.constituent.base import Constituent
 
@@ -13,10 +12,10 @@ class _VMRProfile(Constituent):
         self.altitudes_m = altitudes_m
         self.vmr = vmr
 
-    def add_to_atmosphere(self, atmo: sk.Atmosphere):  # noqa: ARG002
+    def add_to_atmosphere(self, atmo: sk.Atmosphere):
         pass
 
-    def register_derivative(self, atmo: sk.Atmosphere, name: str):  # noqa: ARG002
+    def register_derivative(self, atmo: sk.Atmosphere, name: str):
         pass
 
 
@@ -120,6 +119,42 @@ def test_mt_ckd_analytic_jacobians():
         )
 
 
+def test_mt_ckd_pure_water_branch_matches_upstream_and_is_linearized():
+    inputs = list(_inputs())
+    inputs[1] = np.array([296.0])
+    inputs[2] = np.array([1.0])
+    result = sk.mt_ckd_linearized(*inputs)
+
+    assert all(np.all(np.isfinite(field)) for field in result)
+    np.testing.assert_allclose(
+        result[0][0, [1, 100, 240, 800, 1000, 1300, 1990]],
+        [
+            1.7199222942376495,
+            0.3249611845717048,
+            0.02554401487894435,
+            0.000733663141266962,
+            9.614781340354584e-05,
+            5.429603526351588e-06,
+            3.431332907137031e-05,
+        ],
+        rtol=5e-14,
+        atol=1e-16,
+    )
+
+    delta = 1e-7
+    above = [value.copy() for value in inputs]
+    below = [value.copy() for value in inputs]
+    above[2] += delta
+    below[2] -= delta
+    numeric = (sk.mt_ckd(*above) - sk.mt_ckd(*below)) / (2.0 * delta)
+    np.testing.assert_allclose(
+        result[3][:, 1:],
+        numeric[:, 1:],
+        rtol=3e-6,
+        atol=1e-12,
+    )
+
+
 def test_full_spectra_match_mt_ckd_4_3_double_precision_reference():
     reference_path = sk.database.StandardDatabase().path(
         "continuum/mt_ckd_4_3_reference.bin"
@@ -183,9 +218,7 @@ def test_constituent_adds_extinction_and_analytic_mappings():
     atmosphere.pressure_pa = np.array([101_325.0, 50_000.0, 8_000.0])
     atmosphere.temperature_k = np.array([288.15, 250.0, 220.0])
     atmosphere["H2O"] = _VMRProfile(altitudes, np.array([0.01, 0.002, 5e-5]))
-    atmosphere["CO2"] = _VMRProfile(
-        altitudes, np.array([400e-6, 420e-6, 380e-6])
-    )
+    atmosphere["CO2"] = _VMRProfile(altitudes, np.array([400e-6, 420e-6, 380e-6]))
     atmosphere["O3"] = _VMRProfile(altitudes, np.array([2e-6, 1e-6, 5e-6]))
     atmosphere["continuum"] = sk.continuum.MTCKDContinuum()
 
@@ -197,6 +230,7 @@ def test_constituent_adds_extinction_and_analytic_mappings():
         atmosphere["H2O"].vmr,
         atmosphere["CO2"].vmr,
         atmosphere["O3"].vmr,
+        include_rayleigh=False,
     )
     indices = (wavenumbers / 10.0).astype(int)
     np.testing.assert_allclose(
@@ -250,12 +284,12 @@ def test_constituent_without_derivatives_uses_value_only_path(monkeypatch):
     value_calls = 0
     value_function = sk.continuum.mt_ckd
 
-    def tracked_value(*args):
+    def tracked_value(*args, **kwargs):
         nonlocal value_calls
         value_calls += 1
-        return value_function(*args)
+        return value_function(*args, **kwargs)
 
-    def unexpected_linearized(*args):  # noqa: ARG001
+    def unexpected_linearized(*args, **kwargs):
         msg = "the linearized MT_CKD path should not be evaluated"
         raise AssertionError(msg)
 
@@ -322,6 +356,7 @@ def test_species_derivative_mapping_chains_to_profile_grid():
                 expected_interpolator @ above,
                 atmosphere["CO2"].vmr,
                 atmosphere["O3"].vmr,
+                include_rayleigh=False,
             )[:, spectral_indices]
             - sk.mt_ckd(
                 atmosphere.pressure_pa,
@@ -329,10 +364,109 @@ def test_species_derivative_mapping_chains_to_profile_grid():
                 expected_interpolator @ below,
                 atmosphere["CO2"].vmr,
                 atmosphere["O3"].vmr,
+                include_rayleigh=False,
             )[:, spectral_indices]
         ) / (2.0 * delta)
         analytic = (
-            mapping.d_extinction
-            * expected_interpolator[:, parameter_index, np.newaxis]
+            mapping.d_extinction * expected_interpolator[:, parameter_index, np.newaxis]
         )
         np.testing.assert_allclose(analytic, numeric, rtol=3e-5, atol=1e-12)
+
+
+def test_constituent_excludes_legacy_rayleigh_term():
+    altitudes = np.array([0.0, 10_000.0])
+    wavenumber = np.array([10_000.0])
+    geometry = sk.Geometry1D(
+        cos_sza=0.6,
+        solar_azimuth=0.0,
+        earth_radius_m=6_372_000.0,
+        altitude_grid_m=altitudes,
+        interpolation_method=sk.InterpolationMethod.LinearInterpolation,
+        geometry_type=sk.GeometryType.Spherical,
+    )
+    atmosphere = sk.Atmosphere(
+        geometry,
+        sk.Config(),
+        wavenumber_cminv=wavenumber,
+        calculate_derivatives=False,
+    )
+    atmosphere.pressure_pa = np.array([101_325.0, 50_000.0])
+    atmosphere.temperature_k = np.array([288.15, 250.0])
+    atmosphere["H2O"] = _VMRProfile(altitudes, np.array([0.01, 0.002]))
+    atmosphere["CO2"] = _VMRProfile(altitudes, np.array([400e-6, 420e-6]))
+    atmosphere["O3"] = _VMRProfile(altitudes, np.array([2e-6, 1e-6]))
+    atmosphere["continuum"] = sk.continuum.MTCKDContinuum()
+
+    atmosphere.internal_object()
+
+    inputs = _inputs()
+    full = sk.mt_ckd(*inputs)[0, 1000]
+    absorption = sk.mt_ckd(*inputs, include_rayleigh=False)[0, 1000]
+    assert full > 5.0 * absorption
+    np.testing.assert_allclose(
+        atmosphere.storage.total_extinction[0, 0],
+        absorption,
+        rtol=2e-14,
+    )
+
+
+def test_constituent_supports_expanded_profiles_in_2d_atmosphere():
+    altitudes = np.array([0.0, 10_000.0, 30_000.0])
+    horizontal_angles = np.array([-0.2, 0.3])
+    wavenumbers = np.array([1000.0, 10_000.0])
+    geometry = sk.Geometry2D(
+        cos_sza=0.6,
+        solar_azimuth=0.0,
+        earth_radius_m=6_372_000.0,
+        altitude_grid_m=altitudes,
+        horizontal_angle_grid_radians=horizontal_angles,
+    )
+    config = sk.Config()
+    config.num_streams = 2
+    atmosphere = sk.Atmosphere(
+        geometry,
+        config,
+        wavenumber_cminv=wavenumbers,
+        calculate_derivatives=True,
+    )
+    pressure = np.array([101_325.0, 50_000.0, 8_000.0])
+    temperature = np.array([288.15, 250.0, 220.0])
+    h2o = np.array([0.01, 0.002, 5e-5])
+    co2 = np.array([400e-6, 420e-6, 380e-6])
+    o3 = np.array([2e-6, 1e-6, 5e-6])
+    atmosphere.pressure_pa = pressure
+    atmosphere.temperature_k = temperature
+    atmosphere["H2O"] = _VMRProfile(altitudes, h2o)
+    atmosphere["CO2"] = _VMRProfile(altitudes, co2)
+    atmosphere["O3"] = _VMRProfile(altitudes, o3)
+    atmosphere["continuum"] = sk.continuum.MTCKDContinuum()
+
+    atmosphere.internal_object()
+
+    repeats = len(horizontal_angles)
+    low_level = sk.mt_ckd_linearized(
+        np.tile(pressure, repeats),
+        np.tile(temperature, repeats),
+        np.tile(h2o, repeats),
+        np.tile(co2, repeats),
+        np.tile(o3, repeats),
+        include_rayleigh=False,
+    )
+    spectral_indices = (wavenumbers / 10.0).astype(int)
+    np.testing.assert_allclose(
+        atmosphere.storage.total_extinction,
+        low_level[0][:, spectral_indices],
+        rtol=2e-14,
+    )
+
+    mapping = atmosphere.storage.get_derivative_mapping("wf_continuum_H2O_vmr")
+    np.testing.assert_allclose(
+        mapping.d_extinction,
+        low_level[3][:, spectral_indices],
+        rtol=2e-14,
+        atol=1e-18,
+    )
+    np.testing.assert_allclose(
+        mapping.interpolator,
+        np.tile(np.eye(altitudes.size), (repeats, 1)),
+    )

--- a/tests/continuum/test_mt_ckd.py
+++ b/tests/continuum/test_mt_ckd.py
@@ -1,0 +1,338 @@
+from __future__ import annotations
+
+import hashlib
+
+import numpy as np
+
+import sasktran2 as sk
+from sasktran2.constituent.base import Constituent
+
+
+class _VMRProfile(Constituent):
+    def __init__(self, altitudes_m: np.ndarray, vmr: np.ndarray):
+        self.altitudes_m = altitudes_m
+        self.vmr = vmr
+
+    def add_to_atmosphere(self, atmo: sk.Atmosphere):  # noqa: ARG002
+        pass
+
+    def register_derivative(self, atmo: sk.Atmosphere, name: str):  # noqa: ARG002
+        pass
+
+
+def _inputs():
+    return (
+        np.array([101325.0]),
+        np.array([288.15]),
+        np.array([0.01]),
+        np.array([400.0e-6]),
+        np.array([2.0e-6]),
+    )
+
+
+def test_first_data_download_prints_and_caches_aer_license(
+    tmp_path, monkeypatch, capsys
+):
+    coefficient_data = b"coefficient data"
+    license_data = b"AER license"
+    files = {
+        sk.continuum._MT_CKD_DATA_KEY: coefficient_data,
+        sk.continuum._MT_CKD_LICENSE_KEY: license_data,
+    }
+
+    class _TestDatabase:
+        def path(self, key):
+            path = tmp_path.joinpath(key)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            if not path.exists():
+                path.write_bytes(files[key])
+            return path
+
+    monkeypatch.setattr(sk.appconfig, "database_root", lambda: tmp_path)
+    monkeypatch.setattr(sk.database, "StandardDatabase", _TestDatabase)
+    monkeypatch.setattr(
+        sk.continuum,
+        "_MT_CKD_DATA_SHA256",
+        hashlib.sha256(coefficient_data).hexdigest(),
+    )
+    monkeypatch.setattr(
+        sk.continuum,
+        "_MT_CKD_LICENSE_SHA256",
+        hashlib.sha256(license_data).hexdigest(),
+    )
+
+    sk.continuum._mt_ckd_data_file.cache_clear()
+    try:
+        assert sk.continuum._mt_ckd_data_file().read_bytes() == coefficient_data
+        output = capsys.readouterr().out
+        assert "licensed separately from SASKTRAN2" in output
+        assert sk.continuum.MT_CKD_AER_LICENSE in output
+        assert tmp_path.joinpath(sk.continuum._MT_CKD_LICENSE_KEY).exists()
+
+        sk.continuum._mt_ckd_data_file()
+        assert capsys.readouterr().out == ""
+    finally:
+        sk.continuum._mt_ckd_data_file.cache_clear()
+
+
+def test_mt_ckd_fixed_grid_interface():
+    result = sk.mt_ckd(*_inputs())
+
+    assert result.shape == (1, 1991)
+    np.testing.assert_array_equal(
+        sk.MT_CKD_WAVENUMBERS_CM_INV,
+        np.arange(0.0, 19_901.0, 10.0),
+    )
+    np.testing.assert_allclose(
+        result[0, [1, 100, 240, 800, 1300, 1990]],
+        [
+            7.904694654058591e-4,
+            4.542272170306234e-5,
+            2.2776831103477272e-4,
+            4.661442799889581e-6,
+            4.317920214252337e-6,
+            2.3854890426228372e-5,
+        ],
+        rtol=5e-14,
+        atol=1e-16,
+    )
+
+
+def test_mt_ckd_analytic_jacobians():
+    inputs = _inputs()
+    result = sk.mt_ckd_linearized(*inputs)
+    perturbations = (1.0, 1.0e-3, 1.0e-7, 1.0e-8, 1.0e-8)
+
+    assert len(result) == 6
+    for input_index, (analytic, delta) in enumerate(
+        zip(result[1:], perturbations, strict=True)
+    ):
+        above = [value.copy() for value in inputs]
+        below = [value.copy() for value in inputs]
+        above[input_index] += delta
+        below[input_index] -= delta
+        numeric = (sk.mt_ckd(*above) - sk.mt_ckd(*below)) / (2.0 * delta)
+        np.testing.assert_allclose(
+            analytic[:, 1:],
+            numeric[:, 1:],
+            rtol=3e-5,
+            atol=1e-12,
+        )
+
+
+def test_full_spectra_match_mt_ckd_4_3_double_precision_reference():
+    reference_path = sk.database.StandardDatabase().path(
+        "continuum/mt_ckd_4_3_reference.bin"
+    )
+    assert hashlib.sha256(reference_path.read_bytes()).hexdigest() == (
+        "0fdc39229ae020f2979511acfc81600ddfaa0b9bc0bbb03bb86a5ce3d01a9760"
+    )
+    expected = np.fromfile(reference_path, dtype="<f8").reshape(4, 1991)
+    scenarios = (
+        (101_325.0, 288.15, 0.01, 400.0e-6, 2.0e-6, 100.0),
+        (50_000.0, 250.0, 0.002, 420.0e-6, 1.0e-6, 100.0),
+        (8_000.0, 220.0, 5.0e-5, 380.0e-6, 5.0e-6, 37.5),
+        (90_000.0, 310.0, 0.2, 1.0e-3, 1.0e-5, 250.0),
+    )
+
+    for index, scenario in enumerate(scenarios):
+        pressure, temperature, h2o, co2, o3, reference_path_length_cm = scenario
+        actual = sk.mt_ckd(
+            np.array([pressure]),
+            np.array([temperature]),
+            np.array([h2o]),
+            np.array([co2]),
+            np.array([o3]),
+        )[0]
+        expected_extinction = expected[index] * (100.0 / reference_path_length_cm)
+        relative_error = np.abs(actual - expected_extinction) / np.maximum(
+            np.abs(expected_extinction), 2.0e-15
+        )
+        assert np.max(relative_error) <= 5.0e-14
+
+
+def test_compatibility_constructor_options_are_accepted():
+    continuum = sk.continuum.MTCKDContinuum(
+        h2o_name="water",
+        co2_name="carbon_dioxide",
+        o3_name="ozone",
+        numeric_wf_fractional_change=0.2,
+        numeric_wf_central_difference=False,
+    )
+
+    assert continuum._h2o_name == "water"
+
+
+def test_constituent_adds_extinction_and_analytic_mappings():
+    altitudes = np.array([0.0, 10_000.0, 30_000.0])
+    wavenumbers = np.array([1000.0, 2400.0, 10_000.0])
+    geometry = sk.Geometry1D(
+        cos_sza=0.6,
+        solar_azimuth=0.0,
+        earth_radius_m=6_372_000.0,
+        altitude_grid_m=altitudes,
+        interpolation_method=sk.InterpolationMethod.LinearInterpolation,
+        geometry_type=sk.GeometryType.Spherical,
+    )
+    atmosphere = sk.Atmosphere(
+        geometry,
+        sk.Config(),
+        wavenumber_cminv=wavenumbers,
+        calculate_derivatives=True,
+    )
+    atmosphere.pressure_pa = np.array([101_325.0, 50_000.0, 8_000.0])
+    atmosphere.temperature_k = np.array([288.15, 250.0, 220.0])
+    atmosphere["H2O"] = _VMRProfile(altitudes, np.array([0.01, 0.002, 5e-5]))
+    atmosphere["CO2"] = _VMRProfile(
+        altitudes, np.array([400e-6, 420e-6, 380e-6])
+    )
+    atmosphere["O3"] = _VMRProfile(altitudes, np.array([2e-6, 1e-6, 5e-6]))
+    atmosphere["continuum"] = sk.continuum.MTCKDContinuum()
+
+    atmosphere.internal_object()
+
+    low_level = sk.mt_ckd_linearized(
+        atmosphere.pressure_pa,
+        atmosphere.temperature_k,
+        atmosphere["H2O"].vmr,
+        atmosphere["CO2"].vmr,
+        atmosphere["O3"].vmr,
+    )
+    indices = (wavenumbers / 10.0).astype(int)
+    np.testing.assert_allclose(
+        atmosphere.storage.total_extinction,
+        low_level[0][:, indices],
+        rtol=2e-14,
+    )
+
+    mapping_specs = (
+        ("wf_continuum_pressure_pa", "wf_pressure_pa"),
+        ("wf_continuum_temperature_k", "wf_temperature_k"),
+        ("wf_continuum_H2O_vmr", "wf_H2O_vmr"),
+        ("wf_continuum_CO2_vmr", "wf_CO2_vmr"),
+        ("wf_continuum_O3_vmr", "wf_O3_vmr"),
+    )
+    for (mapping_name, assign_name), expected in zip(
+        mapping_specs, low_level[1:], strict=True
+    ):
+        mapping = atmosphere.storage.get_derivative_mapping(mapping_name)
+        np.testing.assert_allclose(
+            mapping.d_extinction,
+            expected[:, indices],
+            rtol=2e-14,
+            atol=1e-18,
+        )
+        assert mapping.assign_name == assign_name
+
+
+def test_constituent_without_derivatives_uses_value_only_path(monkeypatch):
+    altitudes = np.array([0.0, 10_000.0])
+    geometry = sk.Geometry1D(
+        cos_sza=0.6,
+        solar_azimuth=0.0,
+        earth_radius_m=6_372_000.0,
+        altitude_grid_m=altitudes,
+        interpolation_method=sk.InterpolationMethod.LinearInterpolation,
+        geometry_type=sk.GeometryType.Spherical,
+    )
+    atmosphere = sk.Atmosphere(
+        geometry,
+        sk.Config(),
+        wavenumber_cminv=np.array([1000.0]),
+        calculate_derivatives=False,
+    )
+    atmosphere.pressure_pa = np.array([101_325.0, 50_000.0])
+    atmosphere.temperature_k = np.array([288.15, 250.0])
+    atmosphere["H2O"] = _VMRProfile(altitudes, np.array([0.01, 0.002]))
+    atmosphere["CO2"] = _VMRProfile(altitudes, np.full(2, 400e-6))
+    atmosphere["O3"] = _VMRProfile(altitudes, np.full(2, 2e-6))
+
+    value_calls = 0
+    value_function = sk.continuum.mt_ckd
+
+    def tracked_value(*args):
+        nonlocal value_calls
+        value_calls += 1
+        return value_function(*args)
+
+    def unexpected_linearized(*args):  # noqa: ARG001
+        msg = "the linearized MT_CKD path should not be evaluated"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(sk.continuum, "mt_ckd", tracked_value)
+    monkeypatch.setattr(sk.continuum, "mt_ckd_linearized", unexpected_linearized)
+    atmosphere["continuum"] = sk.continuum.MTCKDContinuum()
+
+    atmosphere.internal_object()
+
+    assert value_calls == 1
+    assert np.all(atmosphere.storage.total_extinction > 0.0)
+
+
+def test_species_derivative_mapping_chains_to_profile_grid():
+    altitudes = np.array([0.0, 10_000.0, 30_000.0])
+    h2o_altitudes = np.array([0.0, 30_000.0])
+    h2o_vmr = np.array([0.01, 5e-5])
+    wavenumbers = np.array([1000.0, 2400.0])
+    geometry = sk.Geometry1D(
+        cos_sza=0.6,
+        solar_azimuth=0.0,
+        earth_radius_m=6_372_000.0,
+        altitude_grid_m=altitudes,
+        interpolation_method=sk.InterpolationMethod.LinearInterpolation,
+        geometry_type=sk.GeometryType.Spherical,
+    )
+    atmosphere = sk.Atmosphere(
+        geometry,
+        sk.Config(),
+        wavenumber_cminv=wavenumbers,
+        calculate_derivatives=True,
+    )
+    atmosphere.pressure_pa = np.array([101_325.0, 50_000.0, 8_000.0])
+    atmosphere.temperature_k = np.array([288.15, 250.0, 220.0])
+    atmosphere["H2O"] = _VMRProfile(h2o_altitudes, h2o_vmr)
+    atmosphere["CO2"] = _VMRProfile(altitudes, np.full(3, 400e-6))
+    atmosphere["O3"] = _VMRProfile(altitudes, np.full(3, 2e-6))
+    atmosphere["continuum"] = sk.continuum.MTCKDContinuum()
+    atmosphere.internal_object()
+
+    expected_interpolator = np.array(
+        [
+            [1.0, 0.0],
+            [2.0 / 3.0, 1.0 / 3.0],
+            [0.0, 1.0],
+        ]
+    )
+    mapping = atmosphere.storage.get_derivative_mapping("wf_continuum_H2O_vmr")
+    np.testing.assert_allclose(mapping.interpolator, expected_interpolator)
+    assert mapping.interp_dim == "H2O_altitude"
+    assert mapping.assign_name == "wf_H2O_vmr"
+
+    delta = 1e-7
+    spectral_indices = (wavenumbers / 10.0).astype(int)
+    for parameter_index in range(h2o_vmr.size):
+        above = h2o_vmr.copy()
+        below = h2o_vmr.copy()
+        above[parameter_index] += delta
+        below[parameter_index] -= delta
+        numeric = (
+            sk.mt_ckd(
+                atmosphere.pressure_pa,
+                atmosphere.temperature_k,
+                expected_interpolator @ above,
+                atmosphere["CO2"].vmr,
+                atmosphere["O3"].vmr,
+            )[:, spectral_indices]
+            - sk.mt_ckd(
+                atmosphere.pressure_pa,
+                atmosphere.temperature_k,
+                expected_interpolator @ below,
+                atmosphere["CO2"].vmr,
+                atmosphere["O3"].vmr,
+            )[:, spectral_indices]
+        ) / (2.0 * delta)
+        analytic = (
+            mapping.d_extinction
+            * expected_interpolator[:, parameter_index, np.newaxis]
+        )
+        np.testing.assert_allclose(analytic, numeric, rtol=3e-5, atol=1e-12)

--- a/tools/databases/mt-ckd/README.md
+++ b/tools/databases/mt-ckd/README.md
@@ -1,0 +1,59 @@
+# MT_CKD 4.3 data generation
+
+This directory records the extraction and validation recipe used to generate
+SASKTRAN2's separately distributed MT_CKD 4.3 coefficient and reference files.
+It contains no AER coefficient data, wrapper source, or generated artifacts.
+
+The input MT_CKD checkout, its data, and the generated files are governed by
+AER's license rather than SASKTRAN2's MIT license. Obtain MT_CKD directly from
+AER-RC and review its terms before running this tool.
+
+## Pinned inputs
+
+- AER-RC/MT_CKD tag `4.3`, commit
+  `1dad6e29363a2dc75d0eb642b7321b5db51079cc`
+- Its LBLRTM submodule at
+  `f66bb596e1686e5ff162a6fadc014e91d3ce01d4`
+- An externally built shared library exposing the probe ABI described below.
+  Its source is deliberately not redistributed in this MIT-licensed
+  repository.
+
+The published hashes were reproduced with GNU Fortran 14.2.0, NetCDF 4.9.2,
+and NetCDF-Fortran 4.6.1 on macOS arm64. Other compatible toolchains may be
+numerically identical without being byte-identical; the script treats a hash
+mismatch as a failure so that such differences are explicit.
+
+Obtain the pinned source with its submodules and separately prepare a compatible
+probe library under the applicable upstream terms. Then run:
+
+```shell
+python tools/databases/mt-ckd/generate_mt_ckd_4_3.py \
+    --mt-ckd-checkout /path/to/MT_CKD \
+    --probe-library /path/to/libmtckd_probe.dylib \
+    --output-directory /Volumes/SasktranFiles/sasktran2_db/v_latest/continuum
+```
+
+The script verifies the source revisions and refuses modified MT_CKD source,
+MT_CKD data, or LBLRTM source. Through the external probe, it enables each
+continuum component separately and reconstructs the 22 fields in the exact
+order consumed by `rust/sasktran2-rs/src/continuum/mt_ckd.rs`. It then runs all
+components, including the standalone model's historical Rayleigh term, for the
+four validation atmospheres.
+
+The probe library must export the C symbols `set_inputs`, `set_flags`,
+`run_mtckd`, `get_absrb`, and `get_n2_data` with the signatures configured in
+`generate_mt_ckd_4_3.py`. Supplying and building that adapter remains outside
+this repository's licensing scope. The final hashes are the authoritative
+compatibility check for both the adapter and compiler toolchain.
+
+Successful output must have these hashes:
+
+- `mt_ckd_4_3.bin`:
+  `06b5600ecb0f5a3417c46d226555bc516f5a55ae93b19b6e7b5431e50f8f0459`
+- `mt_ckd_4_3_reference.bin`:
+  `0fdc39229ae020f2979511acfc81600ddfaa0b9bc0bbb03bb86a5ce3d01a9760`
+
+The coefficient file begins with `MTCKD43\0`, followed by little-endian `u32`
+values for the 1,991-point spectral length and 22-field count, then the fields
+as field-major little-endian `f64` values. The reference file is four
+consecutive 1,991-element little-endian `f64` spectra.

--- a/tools/databases/mt-ckd/generate_mt_ckd_4_3.py
+++ b/tools/databases/mt-ckd/generate_mt_ckd_4_3.py
@@ -1,0 +1,455 @@
+"""Generate SASKTRAN2's MT_CKD 4.3 server-side data artifacts.
+
+This script contains no AER coefficient data or wrapper source. It requires a
+separately obtained MT_CKD checkout and an externally built probe library,
+both governed by their respective license terms.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import hashlib
+import math
+import os
+import struct
+import subprocess
+from collections.abc import Iterable, Iterator
+from itertools import zip_longest
+from pathlib import Path
+
+MT_CKD_COMMIT = "1dad6e29363a2dc75d0eb642b7321b5db51079cc"
+LBLRTM_COMMIT = "f66bb596e1686e5ff162a6fadc014e91d3ce01d4"
+COEFFICIENT_SHA256 = "06b5600ecb0f5a3417c46d226555bc516f5a55ae93b19b6e7b5431e50f8f0459"
+REFERENCE_SHA256 = "0fdc39229ae020f2979511acfc81600ddfaa0b9bc0bbb03bb86a5ce3d01a9760"
+
+SPECTRAL_POINTS = 1991
+FIELD_COUNT = 22
+WAVENUMBERS = tuple(10.0 * index for index in range(SPECTRAL_POINTS))
+RADCN2 = 1.438_775_2
+ALOSMT = 2.686_777_5e19
+XLOSMT = 2.686_75e19
+
+
+def zip_equal(*iterables: Iterable[float]) -> Iterator[tuple[float, ...]]:
+    """Python 3.9-compatible equivalent of zip(..., strict=True)."""
+    sentinel = object()
+    for values in zip_longest(*iterables, fillvalue=sentinel):
+        if sentinel in values:
+            message = "iterables have different lengths"
+            raise ValueError(message)
+        yield values
+
+
+def command_output(command: list[str], cwd: Path | None = None) -> str:
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def verify_checkout(checkout: Path) -> None:
+    expected_paths = (
+        checkout / "build" / "make_cntnm",
+        checkout / "data" / "absco-ref_wv-mt-ckd.nc",
+        checkout / "LBLRTM" / "src" / "contnm.f90",
+    )
+    missing = [str(path) for path in expected_paths if not path.exists()]
+    if missing:
+        message = f"MT_CKD checkout is incomplete; missing: {', '.join(missing)}"
+        raise RuntimeError(message)
+
+    revisions = (
+        (checkout, MT_CKD_COMMIT, "MT_CKD"),
+        (checkout / "LBLRTM", LBLRTM_COMMIT, "LBLRTM submodule"),
+    )
+    for repository, expected, label in revisions:
+        actual = command_output(["git", "rev-parse", "HEAD"], repository)
+        if actual != expected:
+            message = f"expected {label} revision {expected}, found {actual}"
+            raise RuntimeError(message)
+
+    checkout_source_diff = subprocess.run(
+        ["git", "diff", "--quiet", "--", "src", "data"],
+        cwd=checkout,
+        check=False,
+    )
+    if checkout_source_diff.returncode != 0:
+        message = "the pinned MT_CKD source or data directory has local modifications"
+        raise RuntimeError(message)
+    source_diff = subprocess.run(
+        ["git", "diff", "--quiet", "--", "src"],
+        cwd=checkout / "LBLRTM",
+        check=False,
+    )
+    if source_diff.returncode != 0:
+        message = "the pinned LBLRTM source directory has local modifications"
+        raise RuntimeError(message)
+
+
+class Probe:
+    def __init__(self, library: Path, data_directory: Path) -> None:
+        library = library.resolve()
+        os.chdir(data_directory)
+        self._library = ctypes.CDLL(str(library))
+        self._library.set_inputs.argtypes = [ctypes.c_double] * 6
+        self._library.set_flags.argtypes = [ctypes.c_double] * 7
+        self._library.run_mtckd.argtypes = []
+        self._library.get_absrb.argtypes = [ctypes.c_int]
+        self._library.get_absrb.restype = ctypes.c_double
+        self._library.get_n2_data.argtypes = [ctypes.c_int, ctypes.c_int]
+        self._library.get_n2_data.restype = ctypes.c_double
+
+    def set_inputs(self, state: tuple[float, ...]) -> None:
+        self._library.set_inputs(*state)
+
+    def set_flags(self, flags: list[float]) -> None:
+        self._library.set_flags(*flags)
+
+    def run(self) -> None:
+        self._library.run_mtckd()
+
+    def absorption(self, index: int) -> float:
+        return self._library.get_absrb(index)
+
+    def n2_data(self, field: int, index: int) -> float:
+        return self._library.get_n2_data(field, index)
+
+
+def radiation(wavenumber: float, temperature: float) -> float:
+    ratio = wavenumber / (temperature / RADCN2)
+    if ratio <= 0.01:
+        return 0.5 * ratio * wavenumber
+    if ratio <= 10.0:
+        exponential = math.exp(-ratio)
+        return wavenumber * (1.0 - exponential) / (1.0 + exponential)
+    return wavenumber
+
+
+def atmospheric_state(
+    pressure_mb: float,
+    temperature: float,
+    h2o_vmr: float,
+    co2_vmr: float,
+    o3_vmr: float,
+    path_length_cm: float,
+) -> dict[str, float]:
+    initial_total = (
+        ALOSMT * (pressure_mb / 1013.0) * (273.0 / temperature) * path_length_cm
+    )
+    dry = initial_total * (1.0 - h2o_vmr)
+    h2o = initial_total if abs(h2o_vmr - 1.0) < 1.0e-5 else h2o_vmr * dry
+    co2 = co2_vmr * dry
+    o3 = o3_vmr * dry
+    o2 = 0.21 * dry
+    broadening = (0.78 + 0.009) * dry
+    total = broadening + h2o + co2 + o3 + o2
+    x_h2o = h2o / total
+    x_o2 = o2 / total
+    x_n2 = 1.0 - x_h2o - x_o2
+    return {
+        "h2o": h2o,
+        "co2": co2,
+        "o3": o3,
+        "o2": o2,
+        "n2": x_n2 * total,
+        "total": total,
+        "xh": x_h2o,
+        "xo2": x_o2,
+        "xn2": x_n2,
+        "rho": (pressure_mb / 1013.0) * (296.0 / temperature),
+        "amagat": (pressure_mb / 1013.0) * (273.0 / temperature),
+    }
+
+
+def isolated_component(
+    probe: Probe,
+    flag_index: int,
+    pressure_mb: float = 1013.0,
+    temperature: float = 296.0,
+    h2o_vmr: float = 0.01,
+    co2_vmr: float = 400.0e-6,
+    o3_vmr: float = 2.0e-6,
+    path_length_cm: float = 100.0,
+) -> tuple[list[float], dict[str, float]]:
+    state = (
+        pressure_mb,
+        temperature,
+        h2o_vmr,
+        co2_vmr,
+        o3_vmr,
+        path_length_cm,
+    )
+    flags = [0.0] * 7
+    flags[flag_index] = 1.0
+    probe.set_inputs(state)
+    probe.set_flags(flags)
+    probe.run()
+    values = []
+    for index, wavenumber in enumerate(WAVENUMBERS, 1):
+        radiation_value = radiation(wavenumber, temperature)
+        value = probe.absorption(index)
+        values.append(0.0 if radiation_value == 0.0 else value / radiation_value)
+    return values, atmospheric_state(*state)
+
+
+def divide(values: list[float], factor: float) -> list[float]:
+    return [value / factor for value in values]
+
+
+def exponent(base: list[float], other: list[float], denominator: float) -> list[float]:
+    return [
+        math.log(second / first) / denominator if first > 0.0 and second > 0.0 else 0.0
+        for first, second in zip_equal(base, other)
+    ]
+
+
+def solve_two(
+    first_values: list[float],
+    first_a: float,
+    first_b: float,
+    second_values: list[float],
+    second_a: float,
+    second_b: float,
+) -> tuple[list[float], list[float]]:
+    determinant = first_a * second_b - second_a * first_b
+    a = [
+        (first * second_b - second * first_b) / determinant
+        for first, second in zip_equal(first_values, second_values)
+    ]
+    b = [
+        (first_a * second - second_a * first) / determinant
+        for first, second in zip_equal(first_values, second_values)
+    ]
+    return a, b
+
+
+def coefficient_fields(probe: Probe) -> list[list[float]]:
+    fields: list[list[float]] = []
+
+    self_296, state = isolated_component(probe, 0, temperature=296.0)
+    self_base = divide(self_296, state["h2o"] * state["xh"] * state["rho"])
+    self_250, state = isolated_component(probe, 0, temperature=250.0)
+    self_250 = divide(self_250, state["h2o"] * state["xh"] * state["rho"])
+    self_exponent = exponent(self_base, self_250, math.log(296.0 / 250.0))
+    foreign, state = isolated_component(probe, 1)
+    foreign_base = divide(
+        foreign,
+        state["h2o"] * (1.0 - state["xh"]) * state["rho"],
+    )
+    fields.extend((self_base, self_exponent, foreign_base))
+
+    co2_246, state = isolated_component(probe, 2, temperature=246.0)
+    co2_base = divide(co2_246, state["co2"] * state["rho"] * 1.0e-20)
+    co2_296, state = isolated_component(probe, 2, temperature=296.0)
+    co2_296 = divide(co2_296, state["co2"] * state["rho"] * 1.0e-20)
+    co2_exponent = exponent(co2_base, co2_296, math.log(296.0 / 246.0))
+    fields.extend((co2_base, co2_exponent))
+
+    o3_values = []
+    for temperature in (273.15, 293.15, 253.15):
+        values, state = isolated_component(probe, 3, temperature=temperature)
+        o3_values.append(divide(values, state["o3"] * 1.0e-20))
+    o3_constant, o3_plus, o3_minus = o3_values
+    o3_linear = [(plus - minus) / 40.0 for plus, minus in zip_equal(o3_plus, o3_minus)]
+    o3_quadratic = [
+        (plus + minus - 2.0 * constant) / 800.0
+        for plus, minus, constant in zip_equal(
+            o3_plus,
+            o3_minus,
+            o3_constant,
+        )
+    ]
+    fields.extend((o3_constant, o3_linear, o3_quadratic))
+
+    o2_296, state = isolated_component(probe, 4, temperature=296.0)
+    o2_fundamental = divide(o2_296, state["o2"] * 1.0e-20 * state["amagat"])
+    o2_250, state = isolated_component(probe, 4, temperature=250.0)
+    o2_250 = divide(o2_250, state["o2"] * 1.0e-20 * state["amagat"])
+    o2_energy = exponent(
+        o2_fundamental,
+        o2_250,
+        (1.0 / 296.0) - (1.0 / 250.0),
+    )
+    o2_fundamental = [
+        value if wavenumber < 3000.0 else 0.0
+        for wavenumber, value in zip_equal(WAVENUMBERS, o2_fundamental)
+    ]
+    o2_energy = [
+        value if wavenumber < 3000.0 else 0.0
+        for wavenumber, value in zip_equal(WAVENUMBERS, o2_energy)
+    ]
+    fields.extend((o2_fundamental, o2_energy))
+
+    o2_all, state = isolated_component(probe, 4, temperature=296.0)
+    infrared1_factor = (
+        (state["o2"] / XLOSMT)
+        * state["amagat"]
+        * (state["xo2"] / 0.446 + 0.3 * state["xn2"] / 0.446 + state["xh"])
+    )
+    infrared1 = divide(o2_all, infrared1_factor)
+    infrared1 = [
+        value if 7000.0 <= wavenumber < 9000.0 else 0.0
+        for wavenumber, value in zip_equal(WAVENUMBERS, infrared1)
+    ]
+    infrared2_factor = (
+        (state["o2"] / state["total"])
+        * (1.0 / 0.209)
+        * (state["o2"] * 1.0e-20)
+        * state["rho"]
+    )
+    infrared2 = divide(o2_all, infrared2_factor)
+    infrared2 = [
+        value if 9000.0 <= wavenumber < 12000.0 else 0.0
+        for wavenumber, value in zip_equal(WAVENUMBERS, infrared2)
+    ]
+    infrared3_factor = (state["o2"] / XLOSMT) * state["amagat"]
+    infrared3 = divide(o2_all, infrared3_factor)
+    infrared3 = [
+        value if 12000.0 <= wavenumber < 14000.0 else 0.0
+        for wavenumber, value in zip_equal(WAVENUMBERS, infrared3)
+    ]
+    visible_factor = (
+        (state["o2"] / state["total"]) * (state["o2"] * 1.0e-20) * state["amagat"]
+    )
+    visible = divide(o2_all, visible_factor)
+    visible = [
+        value if wavenumber >= 14000.0 else 0.0
+        for wavenumber, value in zip_equal(WAVENUMBERS, visible)
+    ]
+    fields.extend((infrared1, infrared2, infrared3, visible))
+
+    for temperature in (296.0, 220.0):
+        equations = []
+        for h2o_vmr in (0.01, 0.2):
+            values, state = isolated_component(
+                probe,
+                5,
+                temperature=temperature,
+                h2o_vmr=h2o_vmr,
+            )
+            tau = (state["n2"] / XLOSMT) * state["amagat"]
+            equations.append((divide(values, tau), 1.0 - state["xo2"], state["xo2"]))
+        rotation, rotation_o2 = solve_two(*equations[0], *equations[1])
+        rotation_scale = [
+            1.0 + (o2_value / value) * 0.21 / 0.79 if value != 0.0 else 1.0
+            for value, o2_value in zip_equal(rotation, rotation_o2)
+        ]
+        rotation = [
+            value if wavenumber < 1000.0 else 0.0
+            for wavenumber, value in zip_equal(WAVENUMBERS, rotation)
+        ]
+        rotation_scale = [
+            value if wavenumber < 1000.0 else 1.0
+            for wavenumber, value in zip_equal(WAVENUMBERS, rotation_scale)
+        ]
+        fields.extend((rotation, rotation_scale))
+
+    for field in range(3):
+        raw = [probe.n2_data(field, index) for index in range(1, 229)]
+        fields.append(raw + [0.0] * (SPECTRAL_POINTS - len(raw)))
+
+    n2_all, state = isolated_component(probe, 5, temperature=296.0)
+    overtone_factor = (
+        (state["n2"] / XLOSMT)
+        * state["amagat"]
+        * (state["xn2"] + state["xo2"] + state["xh"])
+    )
+    overtone = divide(n2_all, overtone_factor)
+    overtone = [
+        value if 4000.0 <= wavenumber < 6000.0 else 0.0
+        for wavenumber, value in zip_equal(WAVENUMBERS, overtone)
+    ]
+    fields.append(overtone)
+
+    if len(fields) != FIELD_COUNT:
+        message = f"expected {FIELD_COUNT} fields, generated {len(fields)}"
+        raise RuntimeError(message)
+    return fields
+
+
+def write_coefficients(path: Path, fields: list[list[float]]) -> None:
+    payload = bytearray(b"MTCKD43\0")
+    payload.extend(struct.pack("<II", SPECTRAL_POINTS, len(fields)))
+    for field in fields:
+        if len(field) != SPECTRAL_POINTS:
+            message = "coefficient field has the wrong spectral length"
+            raise RuntimeError(message)
+        payload.extend(struct.pack(f"<{SPECTRAL_POINTS}d", *field))
+    path.write_bytes(payload)
+
+
+def write_reference(path: Path, probe: Probe) -> None:
+    scenarios = (
+        (1013.25, 288.15, 0.01, 400.0e-6, 2.0e-6, 100.0),
+        (500.0, 250.0, 0.002, 420.0e-6, 1.0e-6, 100.0),
+        (80.0, 220.0, 5.0e-5, 380.0e-6, 5.0e-6, 37.5),
+        (900.0, 310.0, 0.2, 1.0e-3, 1.0e-5, 250.0),
+    )
+    payload = bytearray()
+    for scenario in scenarios:
+        probe.set_inputs(scenario)
+        probe.set_flags([1.0] * 7)
+        probe.run()
+        values = [probe.absorption(index) for index in range(1, SPECTRAL_POINTS + 1)]
+        values[0] = 0.0
+        payload.extend(struct.pack(f"<{SPECTRAL_POINTS}d", *values))
+    path.write_bytes(payload)
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def require_hash(path: Path, expected: str) -> None:
+    actual = sha256(path)
+    print(f"{actual}  {path}")  # noqa: T201
+    if actual != expected:
+        message = f"{path} does not reproduce the expected SHA-256 {expected}"
+        raise RuntimeError(message)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--mt-ckd-checkout",
+        type=Path,
+        required=True,
+        help="separately obtained AER-RC/MT_CKD 4.3 checkout",
+    )
+    parser.add_argument(
+        "--output-directory",
+        type=Path,
+        required=True,
+        help="directory in which to write the two server artifacts",
+    )
+    parser.add_argument(
+        "--probe-library",
+        type=Path,
+        required=True,
+        help="externally built, ABI-compatible MT_CKD probe library",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    checkout = args.mt_ckd_checkout.resolve()
+    output_directory = args.output_directory.resolve()
+    output_directory.mkdir(parents=True, exist_ok=True)
+    verify_checkout(checkout)
+
+    probe = Probe(args.probe_library, checkout / "data")
+    coefficient_path = output_directory / "mt_ckd_4_3.bin"
+    reference_path = output_directory / "mt_ckd_4_3_reference.bin"
+    write_coefficients(coefficient_path, coefficient_fields(probe))
+    write_reference(reference_path, probe)
+    require_hash(coefficient_path, COEFFICIENT_SHA256)
+    require_hash(reference_path, REFERENCE_SHA256)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add an isolated pure-Rust MT_CKD 4.3 evaluator on the native 1,991-point grid
- expose value-only and fully analytic pressure, temperature, H2O, CO2, and O3 Jacobian paths through Python
- add an MTCKDContinuum constituent compatible with the sasktran2-ext interface and correct 1D/2D derivative mappings
- download the separately licensed coefficient table through StandardDatabase with first-use AER notice and SHA-256 validation
- add a reproducible extraction and validation tool that requires an externally built probe and contains no upstream wrapper source or AER coefficient data

## Numerical and API conventions

- the public low-level interface uses the fixed 0 to 19,900 cm-1 grid at 10 cm-1 spacing
- a fixed one-metre reference column is used internally, so path length is not an API input
- low-level calls include the standalone wrapper's historical Rayleigh term by default for compatibility
- MTCKDContinuum requests absorption only, avoiding double counting with SASKTRAN2's Rayleigh constituent
- the upstream pure-water branch is preserved and analytically differentiated
- the no-derivative constituent path uses the value-only Rust evaluator

## Data and licensing

The Rust and Python source remains MIT licensed. AER coefficient and validation data are not committed to this repository. They are downloaded separately from SasktranFiles under AER's scientific/research terms; those terms are printed before the first coefficient download and cached beside the data.

The generation workflow records pinned MT_CKD/LBLRTM revisions and exact artifact hashes. Its compatible probe library must be prepared externally under the applicable upstream terms, so no AER wrapper source is redistributed by this repository.

## Validation

- full Python suite: 671 passed, 15 skipped
- cargo test -p sasktran2-rs continuum::mt_ckd
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt -p sasktran2-rs -p core_rust -- --check
- pixi run pre-commit
- pixi run docs
- full spectra agree with four double-precision MT_CKD 4.3 reference atmospheres to a maximum relative tolerance of 5e-14
- clean pinned-input regeneration reproduces the exact coefficient and reference SHA-256 hashes
- coefficient, reference, and license URLs on SasktranFiles return successfully and match their recorded hashes
